### PR TITLE
Custom schema fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A default, very basic CSS stylesheet is provided, though you're encouraged to bu
 
 ## Usage
 
-```js
+```jsx
 import React, { Component } from "react";
 import { render } from "react-dom";
 
@@ -79,7 +79,7 @@ JSONSchema is limited for describing how a given data type should be rendered as
 
 Example:
 
-```js
+```jsx
 const uiSchema =  {
   done: {
     widget: "radio" // could also be "select"
@@ -119,7 +119,7 @@ Here's a list of supported alternative widgets for different JSONSchema data typ
 
 The UISchema object accepts a `classNames` property for each field of the schema:
 
-```js
+```jsx
 const uiSchema = {
   title: {
     classNames: "task-title foo-bar"
@@ -148,7 +148,7 @@ You can provide your own custom widgets to a uiSchema for the following json dat
 - `boolean`
 - `date-time`
 
-```js
+```jsx
 const schema = {
   type: "string"
 };
@@ -178,6 +178,36 @@ The following props are passed to the widget component:
 - `onChange`: The value change event handler; call it with the new value everytime it changes;
 - `placeholder`: The placeholder value, if any;
 - `options`: The list of options for `enum` fields;
+
+## Custom SchemaField
+
+**Warning:** This is a powerful feature as you can override the whole form behavior and easily mess it up. Handle with care.
+
+You can provide your own implementation of the `SchemaField` base React component for rendering any JSONSchema field type, including objects and arrays. This is useful when you want to augment a given field type with supplementary powers.
+
+To proceed so, you can pass a `SchemaField` prop to the `Form` component instance; here's a rather silly example wrapping the standard `SchemaField` lib component:
+
+```jsx
+import SchemaField from "react-jsonschema-form/lib/components/fields/SchemaField";
+
+const CustomSchemaField = function(props) {
+  return (
+    <div id="custom">
+      <p>Yeah, I'm pretty dumb.</p>
+      <SchemaField {...props} />
+    </div>
+  );
+};
+
+render((
+  <Form schema={schema}
+        uiSchema={uiSchema}
+        formData={formData}
+        SchemaField={CustomSchemaField} />
+), document.getElementById("app"));
+```
+
+If you're curious how this could ever be useful, have a look at the [Kinto formbuilder](https://github.com/Kinto/formbuilder) repository to see how it's used to provide editing capabilities to any form field.
 
 ## Development server
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,9 +1,8 @@
 import React, { Component, PropTypes } from "react";
 import { Validator } from "jsonschema";
-
-import { getDefaultFormState, getSchemaField } from "../utils";
+import SchemaField from "./fields/SchemaField";
+import { getDefaultFormState } from "../utils";
 import ErrorList from "./ErrorList";
-
 
 export default class Form extends Component {
   static defaultProps = {
@@ -27,13 +26,6 @@ export default class Form extends Component {
       formData,
       edit,
       errors: edit ? this.validate(formData) : []
-    };
-  }
-
-  getChildContext() {
-    const SchemaField = getSchemaField(this.props);
-    return {
-      schemaField: SchemaField
     };
   }
 
@@ -84,16 +76,16 @@ export default class Form extends Component {
   render() {
     const {schema, uiSchema} = this.props;
     const {formData} = this.state;
-    const SchemaField = getSchemaField(this.props, this.context);
-    console.log("THIS IS FORM", SchemaField);
+    const _SchemaField = this.props.SchemaField || SchemaField;
     return (
       <form className="rjsf" onSubmit={this.onSubmit.bind(this)}>
         {this.renderErrors()}
-        <SchemaField
+        <_SchemaField
           schema={schema}
           uiSchema={uiSchema}
           formData={formData}
-          onChange={this.onChange.bind(this)} />
+          onChange={this.onChange.bind(this)}
+          SchemaField={_SchemaField}/>
         <p><button type="submit">Submit</button></p>
       </form>
     );
@@ -108,11 +100,8 @@ if (process.env.NODE_ENV !== "production") {
     onChange: PropTypes.func,
     onError: PropTypes.func,
     onSubmit: PropTypes.func,
+    SchemaField: PropTypes.oneOfType([Component, PropTypes.func])
   };
 }
-
-Form.childContextTypes = {
-  schemaField: PropTypes.oneOfType([Component, Function])
-};
 
 export default Form;

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,8 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import { Validator } from "jsonschema";
 
-import { getDefaultFormState } from "../utils";
-import SchemaField from "./fields/SchemaField";
+import { getDefaultFormState, getSchemaField } from "../utils";
 import ErrorList from "./ErrorList";
 
 
@@ -28,6 +27,13 @@ export default class Form extends Component {
       formData,
       edit,
       errors: edit ? this.validate(formData) : []
+    };
+  }
+
+  getChildContext() {
+    const SchemaField = getSchemaField(this.props);
+    return {
+      schemaField: SchemaField
     };
   }
 
@@ -78,6 +84,8 @@ export default class Form extends Component {
   render() {
     const {schema, uiSchema} = this.props;
     const {formData} = this.state;
+    const SchemaField = getSchemaField(this.props, this.context);
+    console.log("THIS IS FORM", SchemaField);
     return (
       <form className="rjsf" onSubmit={this.onSubmit.bind(this)}>
         {this.renderErrors()}
@@ -102,5 +110,9 @@ if (process.env.NODE_ENV !== "production") {
     onSubmit: PropTypes.func,
   };
 }
+
+Form.childContextTypes = {
+  schemaField: PropTypes.oneOfType([Component, Function])
+};
 
 export default Form;

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -100,7 +100,7 @@ if (process.env.NODE_ENV !== "production") {
     onChange: PropTypes.func,
     onError: PropTypes.func,
     onSubmit: PropTypes.func,
-    SchemaField: PropTypes.oneOfType([Component, PropTypes.func])
+    SchemaField: PropTypes.func,
   };
 }
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from "react";
 
 import { getDefaultFormState } from "../../utils";
-import SchemaField from "./SchemaField";
 
 
 class ArrayField extends Component {
@@ -65,6 +64,8 @@ class ArrayField extends Component {
     const {schema, uiSchema, name} = this.props;
     const title = schema.title || name;
     const {items} = this.state;
+    const SchemaField = this.context.schemaField;
+    console.log("In ArrayField, got", SchemaField);
     return (
       <fieldset
         className={`field field-array field-array-of-${schema.items.type}`}>
@@ -80,7 +81,8 @@ class ArrayField extends Component {
                   uiSchema={uiSchema.items}
                   formData={items[index]}
                   required={this.isItemRequired(schema.items)}
-                  onChange={this.onChange.bind(this, index)} />
+                  onChange={this.onChange.bind(this, index)}
+                  schemaField={SchemaField}/>
                 <p className="array-item-remove">
                   <button type="button"
                     onClick={this.onDropClick.bind(this, index)}>-</button></p>
@@ -104,5 +106,9 @@ if (process.env.NODE_ENV !== "production") {
     formData: PropTypes.array,
   };
 }
+
+ArrayField.childContextTypes = {
+  schemaField: PropTypes.oneOfType([Component, Function])
+};
 
 export default ArrayField;

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -64,8 +64,7 @@ class ArrayField extends Component {
     const {schema, uiSchema, name} = this.props;
     const title = schema.title || name;
     const {items} = this.state;
-    const SchemaField = this.context.schemaField;
-    console.log("In ArrayField, got", SchemaField);
+    const SchemaField = this.props.SchemaField;
     return (
       <fieldset
         className={`field field-array field-array-of-${schema.items.type}`}>
@@ -82,7 +81,7 @@ class ArrayField extends Component {
                   formData={items[index]}
                   required={this.isItemRequired(schema.items)}
                   onChange={this.onChange.bind(this, index)}
-                  schemaField={SchemaField}/>
+                  SchemaField={SchemaField}/>
                 <p className="array-item-remove">
                   <button type="button"
                     onClick={this.onDropClick.bind(this, index)}>-</button></p>
@@ -104,11 +103,8 @@ if (process.env.NODE_ENV !== "production") {
     uiSchema: PropTypes.object,
     onChange: PropTypes.func.isRequired,
     formData: PropTypes.array,
+    SchemaField: PropTypes.oneOfType([Component, PropTypes.func]).isRequired
   };
 }
-
-ArrayField.childContextTypes = {
-  schemaField: PropTypes.oneOfType([Component, Function])
-};
 
 export default ArrayField;

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -103,7 +103,7 @@ if (process.env.NODE_ENV !== "production") {
     uiSchema: PropTypes.object,
     onChange: PropTypes.func.isRequired,
     formData: PropTypes.array,
-    SchemaField: PropTypes.oneOfType([Component, PropTypes.func]).isRequired
+    SchemaField: PropTypes.func.isRequired,
   };
 }
 

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from "react";
 
 import { defaultFieldValue, getAlternativeWidget } from "../../utils";
-import CheckboxField from "./../widgets/CheckboxWidget";
+import CheckboxWidget from "./../widgets/CheckboxWidget";
 
 function BooleanField({schema, name, uiSchema, formData, required, onChange}) {
   const {title, description} = schema;
@@ -19,7 +19,7 @@ function BooleanField({schema, name, uiSchema, formData, required, onChange}) {
     const Widget = getAlternativeWidget(schema.type, widget);
     return <Widget options={[true, false]} {... commonProps} />;
   }
-  return <CheckboxField {...commonProps} />;
+  return <CheckboxWidget {...commonProps} />;
 }
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from "react";
 
 import { getDefaultFormState } from "../../utils";
-import SchemaField from "./SchemaField";
 
 
 class ObjectField extends Component {
@@ -40,6 +39,7 @@ class ObjectField extends Component {
   render() {
     const {schema, uiSchema, name} = this.props;
     const title = name || schema.title;
+    const SchemaField = this.context.schemaField;
     return (
       <fieldset>
         {title ? <legend>{title}</legend> : null}
@@ -71,5 +71,9 @@ if (process.env.NODE_ENV !== "production") {
     required: PropTypes.bool,
   };
 }
+
+ObjectField.childContextTypes = {
+  schemaField: PropTypes.oneOfType([Component, Function])
+};
 
 export default ObjectField;

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -70,7 +70,7 @@ if (process.env.NODE_ENV !== "production") {
     onChange: PropTypes.func.isRequired,
     formData: PropTypes.object,
     required: PropTypes.bool,
-    SchemaField: PropTypes.oneOfType([Component, PropTypes.func]).isRequired
+    SchemaField: PropTypes.func.isRequired,
   };
 }
 

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -39,7 +39,7 @@ class ObjectField extends Component {
   render() {
     const {schema, uiSchema, name} = this.props;
     const title = name || schema.title;
-    const SchemaField = this.context.schemaField;
+    const SchemaField = this.props.SchemaField;
     return (
       <fieldset>
         {title ? <legend>{title}</legend> : null}
@@ -54,7 +54,8 @@ class ObjectField extends Component {
               schema={schema.properties[name]}
               uiSchema={uiSchema[name]}
               formData={this.state[name]}
-              onChange={this.onChange.bind(this, name)} />
+              onChange={this.onChange.bind(this, name)}
+              SchemaField={SchemaField}/>
             );
         })
       }</fieldset>
@@ -69,11 +70,8 @@ if (process.env.NODE_ENV !== "production") {
     onChange: PropTypes.func.isRequired,
     formData: PropTypes.object,
     required: PropTypes.bool,
+    SchemaField: PropTypes.oneOfType([Component, PropTypes.func]).isRequired
   };
 }
-
-ObjectField.childContextTypes = {
-  schemaField: PropTypes.oneOfType([Component, Function])
-};
 
 export default ObjectField;

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ import UpDownWidget from "./components/widgets/UpDownWidget";
 import RangeWidget from "./components/widgets/RangeWidget";
 import SelectWidget from "./components/widgets/SelectWidget";
 import TextareaWidget from "./components/widgets/TextareaWidget";
+import SchemaField from "./components/fields/SchemaField";
 
 
 const altWidgetMap = {
@@ -79,4 +80,11 @@ export function asNumber(value) {
   const n = Number(value);
   const valid = typeof n === "number" && !Number.isNaN(n);
   return valid ? n : value;
+}
+
+export function getSchemaField(props, context) {
+  if (props == undefined) {
+    return SchemaField;
+  }
+  return props.hasOwnProperty("schemaField") ? props.schemaField : SchemaField;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,6 @@ import UpDownWidget from "./components/widgets/UpDownWidget";
 import RangeWidget from "./components/widgets/RangeWidget";
 import SelectWidget from "./components/widgets/SelectWidget";
 import TextareaWidget from "./components/widgets/TextareaWidget";
-import SchemaField from "./components/fields/SchemaField";
 
 
 const altWidgetMap = {
@@ -80,11 +79,4 @@ export function asNumber(value) {
   const n = Number(value);
   const valid = typeof n === "number" && !Number.isNaN(n);
   return valid ? n : value;
-}
-
-export function getSchemaField(props, context) {
-  if (props == undefined) {
-    return SchemaField;
-  }
-  return props.hasOwnProperty("schemaField") ? props.schemaField : SchemaField;
 }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -5,6 +5,7 @@ import sinon from "sinon";
 import React from "react";
 import { Simulate, renderIntoDocument } from "react-addons-test-utils";
 import { findDOMNode } from "react-dom";
+import SchemaField from "../src/components/fields/SchemaField";
 
 import Form from "../src";
 
@@ -42,6 +43,24 @@ describe("Form", () => {
       expect(node.querySelectorAll("button[type=submit]"))
         .to.have.length.of(1);
     });
+  });
+
+  describe("Custom SchemaField", () => {
+    const CustomSchemaField = function(props) {
+      return (<div id="custom"><SchemaField {...props} /></div>);
+    };
+
+    it("should use the specified custom SchemaType property", () => {
+      const {node} = createComponent({
+        schema: {type: "string"},
+        SchemaField: CustomSchemaField
+      });
+
+      expect(node.querySelectorAll("#custom>.field input[type=text]"))
+        .to.have.length.of(1);
+
+    });
+
   });
 
   describe("StringField", () => {
@@ -1252,7 +1271,7 @@ describe("Form", () => {
     });
 
     describe("array level", () => {
-      it.only("should update form state from new formData prop value", () => {
+      it("should update form state from new formData prop value", () => {
         const schema = {
           type: "array",
           items: {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1252,7 +1252,7 @@ describe("Form", () => {
     });
 
     describe("array level", () => {
-      it("should update form state from new formData prop value", () => {
+      it.only("should update form state from new formData prop value", () => {
         const schema = {
           type: "array",
           items: {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -56,11 +56,9 @@ describe("Form", () => {
         SchemaField: CustomSchemaField
       });
 
-      expect(node.querySelectorAll("#custom>.field input[type=text]"))
+      expect(node.querySelectorAll("#custom > .field input[type=text]"))
         .to.have.length.of(1);
-
     });
-
   });
 
   describe("StringField", () => {


### PR DESCRIPTION
## Custom SchemaField

**Warning:** This is a powerful feature as you can override the whole form behavior and easily mess it up. Handle with care.

You can provide your own implementation of the `SchemaField` base React component for rendering any JSONSchema field type, including objects and arrays. This is useful when you want to augment a given field type with supplementary powers.

To proceed so, you can pass a `SchemaField` prop to the `Form` component instance; here's a rather silly example wrapping the standard `SchemaField` lib component:

```jsx
import SchemaField from "react-jsonschema-form/lib/components/fields/SchemaField";

const CustomSchemaField = function(props) {
  return (
    <div id="custom">
      <p>Yeah, I'm pretty dumb.</p>
      <SchemaField {...props} />
    </div>
  );
};

render((
  <Form schema={schema}
        uiSchema={uiSchema}
        formData={formData}
        SchemaField={CustomSchemaField} />
), document.getElementById("app"));
```

If you're curious how this could ever be useful, have a look at the [Kinto formbuilder](https://github.com/Kinto/formbuilder) repository to see how it's used to provide editing capabilities to any form field.