### PR TITLE
Force the hiding of the label

### DIFF
--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -45,6 +45,7 @@ function getContent({type, label, required, children, displayLabel}) {
 
 function Wrapper(props) {
   const {type, classNames} = props;
+
   return (
     <div className={`field field-${type} ${classNames}`}>
       {getContent(props)}
@@ -66,7 +67,7 @@ if (process.env.NODE_ENV !== "production") {
 Wrapper.defaultProps = {
   classNames: ""
 };
-
+ 
 function SchemaField(props) {
   const {schema, uiSchema, name, required} = props;
   const FieldComponent = COMPONENT_TYPES[schema.type] || UnsupportedField;
@@ -77,6 +78,8 @@ function SchemaField(props) {
   if (schema.type === "object") {
     displayLabel = false;
   }
+
+  if (props.uiSchema["ui:hideLabel"] ===  true) displayLabel=false;
 
   return (
     <Wrapper

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -78,8 +78,9 @@ function SchemaField(props) {
   if (schema.type === "object") {
     displayLabel = false;
   }
-
-  if (props.uiSchema["ui:hideLabel"] ===  true) displayLabel=false;
+  if (props.uiSchema["ui:hideLabel"] ===  true) {
+    displayLabel=false;
+  }
 
   return (
     <Wrapper


### PR DESCRIPTION
Allows to hide the creation of the label by adding `ui:hideLabel: true` to the corresponding uiSchema.

E.g. (from the simple example):
```json
{
  "age": {
    "ui:widget": "updown",
    "ui:hideLabel": true
  },
  "bio": {
    "ui:widget": "textarea"
  },
  "password": {
    "ui:widget": "password"
  }
}
```

This is useful if you want to create a custom widget to be styled by an external CSS framework.