### PR TITLE
Fixes #61: Allow users to enter float in number field.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -76,6 +76,11 @@ export function getDefaultFormState(schema) {
 }
 
 export function asNumber(value) {
+  if (/\.$/.test(value)) {
+    // "3." can't really be considered a number even if it parses in js. The
+    // user is most likely entering a float.
+    return value;
+  }
   const n = Number(value);
   const valid = typeof n === "number" && !Number.isNaN(n);
   return valid ? n : value;

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -333,6 +333,18 @@ describe("Form", () => {
         expect(node.querySelector(".field input").getAttribute("value"))
           .eql("2");
       });
+
+      it("should not cast the input as a number if it ends with a dot", () => {
+        const {comp, node} = createComponent({schema: {
+          type: "number",
+        }});
+
+        Simulate.change(node.querySelector("input"), {
+          target: {value: "2."}
+        });
+
+        expect(comp.state.formData).eql("2.");
+      });
     });
 
     describe("SelectWidget", () => {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import { getDefaultFormState, isMultiSelect } from "../src/utils";
+import { asNumber, getDefaultFormState, isMultiSelect } from "../src/utils";
 
 
 describe("utils", () => {
@@ -78,6 +78,20 @@ describe("utils", () => {
           }
         })).to.eql({object: {array: ["foo", "bar"]}});
       });
+    });
+  });
+
+  describe("asNumber()", () => {
+    it("should return a number out of a string representing a number", () => {
+      expect(asNumber("3")).eql(3);
+    });
+
+    it("should return a float out of a string representing a float", () => {
+      expect(asNumber("3.14")).eql(3.14);
+    });
+
+    it("should return the raw value if the input ends with a dot", () => {
+      expect(asNumber("3.")).eql("3.");
     });
   });
 


### PR DESCRIPTION
This patch allows users to enter a float in a `NumberField`.

r=? @magopian /cc @aduth