### PR TITLE
Fixes #11: Added support for referenced schema definitions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,35 @@ render(
 
 **Warning:** there should be a button or an input with `type="submit"` to trigger the form submission (and then the form validation).
 
+## Schema definitions & references
+
+This library partially supports [inline schema definition dereferencing]( http://json-schema.org/latest/json-schema-core.html#rfc.section.7.2.3), which is Barbarian for *avoiding to copy and paste commonly used field schemas*:
+
+```json
+{
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street_address": { "type": "string" },
+        "city":           { "type": "string" },
+        "state":          { "type": "string" }
+      },
+      "required": ["street_address", "city", "state"]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "billing_address": { "$ref": "#/definitions/address" },
+    "shipping_address": { "$ref": "#/definitions/address" }
+  }
+}
+```
+
+*(Sample schema courtesy of the [Space Telescope Science Institute](http://spacetelescope.github.io/understanding-json-schema/structuring.html))*
+
+Note that it only supports local definition referencing, we do not plan on fetching foreign schemas over HTTP anytime soon. Basically, you can only reference a definition from the very schema object defining it.
+
 ## Development server
 
 ```

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -4,6 +4,7 @@ import numbers from "./numbers";
 import simple from "./simple";
 import widgets from "./widgets";
 import ordering from "./ordering";
+import references from "./references";
 
 export const samples = {
   Simple: simple,
@@ -12,4 +13,5 @@ export const samples = {
   Numbers: numbers,
   Widgets: widgets,
   Ordering: ordering,
+  References: references,
 };

--- a/playground/samples/references.js
+++ b/playground/samples/references.js
@@ -1,0 +1,35 @@
+module.exports = {
+  schema: {
+    definitions: {
+      address: {
+        type: "object",
+        properties: {
+          street_address: { type: "string" },
+          city:           { type: "string" },
+          state:          { type: "string" }
+        },
+        required: ["street_address", "city", "state"]
+      }
+    },
+    type: "object",
+    properties: {
+      billing_address: { $ref: "#/definitions/address" },
+      shipping_address: { $ref: "#/definitions/address" }
+    }
+  },
+  uiSchema: {
+    "ui:order": ["shipping_address", "billing_address"]
+  },
+  formData: {
+    billing_address: {
+      street_address: "21, Jump Street",
+      city: "Babel",
+      state: "Neverland"
+    },
+    shipping_address: {
+      street_address: "221B, Baker Street",
+      city: "London",
+      state: "N/A"
+    }
+  }
+};

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -22,7 +22,8 @@ export default class Form extends Component {
   getStateFromProps(props) {
     const schema = "schema" in props ? props.schema : this.props.schema;
     const edit = !!props.formData;
-    const formData = getDefaultFormState(schema, props.formData) || null;
+    const {definitions} = schema;
+    const formData = getDefaultFormState(schema, props.formData, definitions) || null;
     return {
       status: "initial",
       formData,
@@ -80,6 +81,7 @@ export default class Form extends Component {
       SchemaField: this.props.SchemaField || SchemaField,
       TitleField: this.props.TitleField || TitleField,
       widgets: this.props.widgets || {},
+      definitions: this.props.schema.definitions || {},
     };
   }
 

--- a/src/components/fields/NumberField.js
+++ b/src/components/fields/NumberField.js
@@ -14,7 +14,7 @@ if (process.env.NODE_ENV !== "production") {
   NumberField.propTypes = {
     schema: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    formData: PropTypes.number,
+    formData: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     required: PropTypes.bool,
   };
 }

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -1,6 +1,10 @@
 import React, { Component, PropTypes } from "react";
 
-import { getDefaultFormState, orderProperties } from "../../utils";
+import {
+  getDefaultFormState,
+  orderProperties,
+  retrieveSchema
+} from "../../utils";
 
 
 class ObjectField extends Component {
@@ -18,7 +22,8 @@ class ObjectField extends Component {
   }
 
   getStateFromProps(props) {
-    return getDefaultFormState(props.schema, props.formData) || {};
+    const {schema, formData, registry} = props;
+    return getDefaultFormState(schema, formData, registry.definitions) || {};
   }
 
   isRequired(name) {
@@ -37,18 +42,23 @@ class ObjectField extends Component {
   }
 
   render() {
-    const {schema, uiSchema, name} = this.props;
+    const {uiSchema, name} = this.props;
+    const {SchemaField, TitleField, definitions} = this.props.registry;
+    const schema = retrieveSchema(this.props.schema, definitions);
     const title = schema.title || name;
-    const {SchemaField, TitleField} = this.props.registry;
+    let orderedProperties;
     try {
-      var orderedProperties = orderProperties(
-        Object.keys(schema.properties), uiSchema["ui:order"]);
+      const properties = Object.keys(schema.properties);
+      orderedProperties = orderProperties(properties, uiSchema["ui:order"]);
     } catch(err) {
       return (
-        <p className="config-error" style={{color: "red"}}>
-          Invalid {name || "root"} object field configuration:
-          <em>{err.message}</em>.
-        </p>
+        <div>
+          <p className="config-error" style={{color: "red"}}>
+            Invalid {name || "root"} object field configuration:
+            <em>{err.message}</em>.
+          </p>
+          <pre>{JSON.stringify(schema)}</pre>
+        </div>
       );
     }
     return (

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from "react";
 
-import { isMultiSelect } from "../../utils";
+import { isMultiSelect, retrieveSchema } from "../../utils";
 import ArrayField from "./ArrayField";
 import BooleanField from "./BooleanField";
 import NumberField from "./NumberField";
@@ -68,8 +68,15 @@ Wrapper.defaultProps = {
 };
 
 function SchemaField(props) {
-  const {schema, uiSchema, name, required} = props;
+  const {uiSchema, name, required, registry} = props;
+  const {definitions} = registry;
+  const schema = retrieveSchema(props.schema, definitions);
   const FieldComponent = COMPONENT_TYPES[schema.type] || UnsupportedField;
+
+  if (Object.keys(schema).length === 0) {
+    return <div />;
+  }
+
   let displayLabel = true;
   if (schema.type === "array") {
     displayLabel = isMultiSelect(schema);

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -66,6 +66,146 @@ describe("Form", () => {
     });
   });
 
+  describe("Schema definitions", () => {
+    it("should use a single schema definition reference", () => {
+      const schema = {
+        definitions: {
+          testdef: {type: "string"}
+        },
+        $ref: "#/definitions/testdef"
+      };
+
+      const {node} = createComponent({schema});
+
+      expect(node.querySelectorAll("input[type=text]"))
+        .to.have.length.of(1);
+    });
+
+    it("should handle multiple schema definition references", () => {
+      const schema = {
+        definitions: {
+          testdef: {type: "string"}
+        },
+        type: "object",
+        properties: {
+          foo: {$ref: "#/definitions/testdef"},
+          bar: {$ref: "#/definitions/testdef"},
+        }
+      };
+
+      const {node} = createComponent({schema});
+
+      expect(node.querySelectorAll("input[type=text]"))
+        .to.have.length.of(2);
+    });
+
+    it("should handle deeply referenced schema definitions", () => {
+      const schema = {
+        definitions: {
+          testdef: {type: "string"}
+        },
+        type: "object",
+        properties: {
+          foo: {
+            type: "object",
+            properties: {
+              bar: {$ref: "#/definitions/testdef"},
+            }
+          }
+        }
+      };
+
+      const {node} = createComponent({schema});
+
+      expect(node.querySelectorAll("input[type=text]"))
+        .to.have.length.of(1);
+    });
+
+    it("should handle referenced definitions for array items", () => {
+      const schema = {
+        definitions: {
+          testdef: {type: "string"}
+        },
+        type: "object",
+        properties: {
+          foo: {
+            type: "array",
+            items: {$ref: "#/definitions/testdef"}
+          }
+        }
+      };
+
+      const {node} = createComponent({schema, formData: {
+        foo: ["blah"]
+      }});
+
+      expect(node.querySelectorAll("input[type=text]"))
+        .to.have.length.of(1);
+    });
+
+    it("should raise for non-existent definitions referenced", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {$ref: "#/definitions/nonexistent"},
+        }
+      };
+
+      expect(() => createComponent({schema}))
+        .to.Throw(Error, /#\/definitions\/nonexistent/);
+    });
+
+    it("should propagate referenced definition defaults", () => {
+      const schema = {
+        definitions: {
+          testdef: {type: "string", default: "hello"}
+        },
+        $ref: "#/definitions/testdef"
+      };
+
+      const {node} = createComponent({schema});
+
+      expect(node.querySelector("input[type=text]").value)
+        .eql("hello");
+    });
+
+    it("should propagate nested referenced definition defaults", () => {
+      const schema = {
+        definitions: {
+          testdef: {type: "string", default: "hello"}
+        },
+        type: "object",
+        properties: {
+          foo: {$ref: "#/definitions/testdef"}
+        }
+      };
+
+      const {node} = createComponent({schema});
+
+      expect(node.querySelector("input[type=text]").value)
+        .eql("hello");
+    });
+
+    it("should propagate referenced definition defaults for array items", () => {
+      const schema = {
+        definitions: {
+          testdef: {type: "string", default: "hello"}
+        },
+        type: "array",
+        items: {
+          $ref: "#/definitions/testdef"
+        }
+      };
+
+      const {node} = createComponent({schema});
+
+      Simulate.click(node.querySelector(".array-item-add button"));
+
+      expect(node.querySelector("input[type=text]").value)
+        .eql("hello");
+    });
+  });
+
   describe("Defaults array items default propagation", () => {
     const schema = {
       type: "object",

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -146,5 +146,54 @@ describe("ObjectField", () => {
       expect(node.querySelector(".config-error").textContent)
         .to.match(/does not match object properties list/);
     });
+
+    it("should order referenced schema definitions", () => {
+      const refSchema = {
+        definitions: {
+          testdef: {type: "string"}
+        },
+        type: "object",
+        properties: {
+          foo: {$ref: "#/definitions/testdef"},
+          bar: {$ref: "#/definitions/testdef"}
+        }
+      };
+
+      const {node} = createComponent({schema: refSchema, uiSchema: {
+        "ui:order": ["bar", "foo"]
+      }});
+      const labels = [].map.call(
+        node.querySelectorAll(".field > label"), l => l.textContent);
+
+      expect(labels).eql(["bar", "foo"]);
+    });
+
+    it("should order referenced object schema definition properties", () => {
+      const refSchema = {
+        definitions: {
+          testdef: {
+            type: "object",
+            properties: {
+              foo: {type: "string"},
+              bar: {type: "string"},
+            }
+          }
+        },
+        type: "object",
+        properties: {
+          root: {$ref: "#/definitions/testdef"},
+        }
+      };
+
+      const {node} = createComponent({schema: refSchema, uiSchema: {
+        root: {
+          "ui:order": ["bar", "foo"]
+        }
+      }});
+      const labels = [].map.call(
+        node.querySelectorAll(".field > label"), l => l.textContent);
+
+      expect(labels).eql(["bar", "foo"]);
+    });
   });
 });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -4,7 +4,8 @@ import {
   asNumber,
   getDefaultFormState,
   isMultiSelect,
-  mergeObjects
+  mergeObjects,
+  retrieveSchema
 } from "../src/utils";
 
 
@@ -249,6 +250,23 @@ describe("utils", () => {
         c: 3
       };
       expect(mergeObjects(obj1, obj2)).eql(expected);
+    });
+  });
+
+  describe("retrieveSchema()", () => {
+    it("should 'resolve' a schema which contains definitions", () => {
+      const schema = { $ref: "#/definitions/address" };
+      const address_definition = {
+        type: "object",
+        properties: {
+          street_address: { type: "string" },
+          city: { type: "string" },
+          state: { type: "string" }
+        },
+        required: [ "street_address", "city", "state" ]
+      };
+      const definitions = { address: address_definition };
+      expect(retrieveSchema(schema, definitions)).eql(address_definition);
     });
   });
 });


### PR DESCRIPTION
Refs #11.

## Schema definitions & references

This library partially supports [inline schema definition dereferencing]( http://json-schema.org/latest/json-schema-core.html#rfc.section.7.2.3), which is Barbarian for *avoiding to copy and paste commonly used field schemas*:

```json
{
  "definitions": {
    "address": {
      "type": "object",
      "properties": {
        "street_address": { "type": "string" },
        "city":           { "type": "string" },
        "state":          { "type": "string" }
      },
      "required": ["street_address", "city", "state"]
    }
  },
  "type": "object",
  "properties": {
    "billing_address": { "$ref": "#/definitions/address" },
    "shipping_address": { "$ref": "#/definitions/address" }
  }
}
```

*(Sample schema courtesy of the [Space Telescope Science Institute](http://spacetelescope.github.io/understanding-json-schema/structuring.html))*

Note that it only supports local definition referencing, we do not plan on fetching foreign schemas over HTTP anytime soon. Basically, you can only reference a definition from the very schema object defining it.

Feedback=? @magopian @leplatrem 