### PR TITLE
Adds explicit spans for labels

### DIFF
--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -37,7 +37,7 @@ function getLabel(label, required) {
   if (required) {
     return <span>{label + REQUIRED_FIELD_SYMBOL}</span>;
   }
-  return <span>label</span>;
+  return <span>{label}</span>;
 }
 
 function getContent({type, label, required, children, displayLabel}) {


### PR DESCRIPTION
React 15.0 doesn't add spans automatically which makes the current solution for labels a bit inconvenient