### PR TITLE
Exclude Buffer from dist bundles.

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -17,6 +17,9 @@ module.exports = {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],
+  node: {
+    Buffer: "mock",
+  },
   module: {
     loaders: [
       {

--- a/webpack.config.dist.js
+++ b/webpack.config.dist.js
@@ -19,6 +19,9 @@ module.exports = {
       }
     })
   ],
+  node: {
+    Buffer: "mock",
+  },
   devtool: "source-map",
   externals: {
     react: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -21,6 +21,9 @@ module.exports = {
   resolve: {
     extensions: ["", ".js", ".jsx", ".css"]
   },
+  node: {
+    Buffer: "mock",
+  },
   module: {
     loaders: [
       {


### PR DESCRIPTION
This patch excludes -- or more precisely *mocks* -- the node `Buffer` object, so it doesn't bloat the generated dist files. `Buffer` is not used at all by the code (except in a check by the `deeper` dependency, hence the mock) so this operation should be safe.