### PR TITLE
adds example for cdn users

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Source maps are available at [this url](https://npmcdn.com/react-jsonschema-form
 
 > Note: The CDN version **does not** embed *react* nor *react-dom*.
 
+> You'll also need to alias the default export property to use the Form component:
+
+```jsx
+const Form = JSONSchemaForm.default;
+```
+
 ## Usage
 
 ```jsx


### PR DESCRIPTION
Found a [confused Stack Overflow user](http://stackoverflow.com/questions/36302120/using-react-component-from-js-source-maps/36303960#36303960) trying to access `Form` on the global namespace, figured this should clear up future ambiguities.