### PR TITLE
fixed bug of nested array: "add" button doesn't work for outer array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 build
 dist
 lib
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ node_modules
 build
 dist
 lib
-.idea

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -58,7 +58,7 @@ class ArrayField extends Component {
     const {schema, registry} = this.props;
     const {definitions} = registry;
     this.asyncSetState({
-      items: items.concat(getDefaultFormState(schema.items, undefined, definitions))
+      items: items.concat([getDefaultFormState(schema.items, undefined, definitions)])
     }, {validate: false});
   };
 

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -179,4 +179,30 @@ describe("ArrayField", () => {
       expect(node.querySelector("select").id).eql("root");
     });
   });
+  
+  describe("Nested lists", () => {
+    const schema = {
+      "type": "array",
+      "title": "A list of arrays",
+      "items": {
+        "type": "array",
+        "title": "A list of numbers",
+        "items": {
+          "type": "number"
+        }
+      }
+    };
+
+    it("should render two lists of inputs inside of a list", () => {
+      const {node} = createFormComponent({schema, formData: [[1, 2], [3, 4]]});
+      expect(node.querySelectorAll("fieldset fieldset")).to.have.length.of(2);
+    });
+
+    it("should add an inner list when clicking the add button", () => {
+      const {node} = createFormComponent({schema});
+      expect(node.querySelectorAll("fieldset fieldset")).to.be.empty;
+      Simulate.click(node.querySelector(".array-item-add button"));
+      expect(node.querySelectorAll("fieldset fieldset")).to.have.length.of(1);
+    });
+  });
 });


### PR DESCRIPTION
example schema:

```javascript
{
  "type": "object",
  "properties": {
    "listOfArrays": {
      "type": "array",
      "title": "A list of arrays",
      "items": {
        "type": "array",
        "title": "A list of numbers",
        "items": {
          "type": "number"
}}}}}
```

When clicking **Add** button of **listOfArrays**, nothing happens. That's because _default state_ of `type: "array"` is `[]` and `items.concat([])` has no effect. adding a pair of extra `[]` fixed this.

Also add `.idea` to `.gitignore` for convenience for WebStorm.