### PR TITLE
Fixes #114: Added a widget for datetime string format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ Here's a list of supported alternative widgets for different JSONSchema data typ
 
 The built-in string field also supports the JSONSchema `format` property, and will render an appropriate widget by default for the following formats:
 
-- `date-time`: An `input[type=datetime]` will be rendered.
+- `date-time`: An `input[type=datetime-local]` will be rendered.
+- More formats will be supported in a near future, feel free to help us going faster!
 
 #### For `number` and `integer` fields
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ Here's a list of supported alternative widgets for different JSONSchema data typ
   * `password`: an `input[type=password]` element;
   * by default, a regular `input[type=text]` element is used.
 
+The built-in string field also supports the JSONSchema `format` property, and will render an appropriate widget by default for the following formats:
+
+- `date-time`: An `input[type=datetime]` will be rendered.
+
 #### For `number` and `integer` fields
 
   * `updown`: an `input[type=number]` updown selector;
@@ -209,7 +213,7 @@ const uiSchema = {
 
 > Notes
 >
-> - Hiding widgets is only supported for `boolean`, `string`, `number`, `integer` and `date-time` schema types;
+> - Hiding widgets is only supported for `boolean`, `string`, `number` and `integer` schema types;
 > - An hidden widget takes its value from the `formData` prop.
 
 ### Object fields ordering
@@ -330,7 +334,6 @@ You can provide your own custom widgets to a uiSchema for the following json dat
 - `number`
 - `integer`
 - `boolean`
-- `date-time`
 
 ```jsx
 const schema = {

--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -35,6 +35,10 @@ module.exports = {
           }
         }
       },
+      datetime: {
+        type: "string",
+        format: "date-time"
+      },
       secret: {
         type: "string",
         default: "I'm a hidden string."
@@ -69,6 +73,7 @@ module.exports = {
       default: "Hello...",
       textarea: "... World"
     },
+    datetime: new Date().toJSON(),
     secret: "I'm a hidden string."
   }
 };

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -35,7 +35,7 @@ function BooleanField(props) {
     required,
   };
   if (widget) {
-    const Widget = getAlternativeWidget(schema.type, widget, widgets);
+    const Widget = getAlternativeWidget(schema, widget, widgets);
     return <Widget options={buildOptions(schema)} {... commonProps} />;
   }
   return <CheckboxWidget {...commonProps} />;

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -13,7 +13,6 @@ const REQUIRED_FIELD_SYMBOL = "*";
 const COMPONENT_TYPES = {
   "array":     ArrayField,
   "boolean":   BooleanField,
-  "date-time": StringField,
   "integer":   NumberField,
   "number":    NumberField,
   "object":    ObjectField,

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -17,7 +17,7 @@ function StringField(props) {
     onChange
   } = props;
   const {title, description} = schema;
-  const widget = uiSchema["ui:widget"];
+  const widget = uiSchema["ui:widget"] || schema.format;
   const commonProps = {
     schema,
     id: idSchema && idSchema.id,
@@ -30,13 +30,13 @@ function StringField(props) {
   };
   if (Array.isArray(schema.enum)) {
     if (widget) {
-      const Widget = getAlternativeWidget(schema.type, widget, widgets);
+      const Widget = getAlternativeWidget(schema, widget, widgets);
       return <Widget options={optionsList(schema)} {...commonProps} />;
     }
     return <SelectWidget options={optionsList(schema)} {...commonProps} />;
   }
   if (widget) {
-    const Widget = getAlternativeWidget(schema.type, widget, widgets);
+    const Widget = getAlternativeWidget(schema, widget, widgets);
     return <Widget {...commonProps} />;
   }
   return <TextWidget {...commonProps} />;

--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -11,7 +11,7 @@ function DateTimeWidget({
   onChange
 }) {
   return (
-    <input type="datetime"
+    <input type="datetime-local"
       id={id}
       className="form-control"
       value={value}

--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -1,0 +1,37 @@
+import React, { PropTypes } from "react";
+
+
+function DateTimeWidget({
+  schema,
+  id,
+  placeholder,
+  value,
+  defaultValue,
+  required,
+  onChange
+}) {
+  return (
+    <input type="datetime"
+      id={id}
+      className="form-control"
+      value={value}
+      defaultValue={defaultValue}
+      placeholder={placeholder}
+      required={required}
+      onChange={(event) => onChange(event.target.value)} />
+  );
+}
+
+if (process.env.NODE_ENV !== "production") {
+  DateTimeWidget.propTypes = {
+    schema: PropTypes.object.isRequired,
+    id: PropTypes.string.isRequired,
+    placeholder: PropTypes.string,
+    value: React.PropTypes.string,
+    defaultValue: React.PropTypes.string,
+    required: PropTypes.bool,
+    onChange: PropTypes.func,
+  };
+}
+
+export default DateTimeWidget;

--- a/src/components/widgets/HiddenWidget.js
+++ b/src/components/widgets/HiddenWidget.js
@@ -20,10 +20,12 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number,
+      React.PropTypes.bool,
     ]),
     defaultValue: PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number,
+      React.PropTypes.bool,
     ])
   };
 }

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -171,7 +171,7 @@ describe("StringField", () => {
         format: "date-time",
       }});
 
-      expect(node.querySelectorAll(".field [type=datetime]"))
+      expect(node.querySelectorAll(".field [type=datetime-local]"))
         .to.have.length.of(1);
     });
 
@@ -193,7 +193,7 @@ describe("StringField", () => {
         description: "baz",
       }});
 
-      expect(node.querySelector(".field [type=datetime]").getAttribute("placeholder"))
+      expect(node.querySelector(".field [type=datetime-local]").getAttribute("placeholder"))
         .eql("baz");
     });
 
@@ -215,11 +215,11 @@ describe("StringField", () => {
       }});
 
       const newDatetime = new Date().toJSON();
-      Simulate.change(node.querySelector("[type=datetime]"), {
+      Simulate.change(node.querySelector("[type=datetime-local]"), {
         target: {value: newDatetime}
       });
 
-      expect(node.querySelector("[type=datetime]").value).eql(newDatetime);
+      expect(node.querySelector("[type=datetime-local]").value).eql(newDatetime);
     });
 
     it("should fill field with data", () => {
@@ -238,7 +238,7 @@ describe("StringField", () => {
         format: "date-time",
       }});
 
-      expect(node.querySelector("[type=datetime]").id)
+      expect(node.querySelector("[type=datetime-local]").id)
         .eql("root");
     });
   });

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -163,4 +163,83 @@ describe("StringField", () => {
         .eql("root");
     });
   });
+
+  describe("DateTimeWidget", () => {
+    it("should render a datetime field", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "date-time",
+      }});
+
+      expect(node.querySelectorAll(".field [type=datetime]"))
+        .to.have.length.of(1);
+    });
+
+    it("should render a string field with a label", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "date-time",
+        title: "foo",
+      }});
+
+      expect(node.querySelector(".field label").textContent)
+        .eql("foo");
+    });
+
+    it("should render a select field with a placeholder", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "date-time",
+        description: "baz",
+      }});
+
+      expect(node.querySelector(".field [type=datetime]").getAttribute("placeholder"))
+        .eql("baz");
+    });
+
+    it("should assign a default value", () => {
+      const datetime = new Date().toJSON();
+      const {comp} = createFormComponent({schema: {
+        type: "string",
+        format: "date-time",
+        default: datetime,
+      }});
+
+      expect(comp.state.formData).eql(datetime);
+    });
+
+    it("should reflect the change into the dom", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "date-time",
+      }});
+
+      const newDatetime = new Date().toJSON();
+      Simulate.change(node.querySelector("[type=datetime]"), {
+        target: {value: newDatetime}
+      });
+
+      expect(node.querySelector("[type=datetime]").value).eql(newDatetime);
+    });
+
+    it("should fill field with data", () => {
+      const datetime = new Date().toJSON();
+      const {comp} = createFormComponent({schema: {
+        type: "string",
+        format: "date-time",
+      }, formData: datetime});
+
+      expect(comp.state.formData).eql(datetime);
+    });
+
+    it("should render the widget with the expected id", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "date-time",
+      }});
+
+      expect(node.querySelector("[type=datetime]").id)
+        .eql("root");
+    });
+  });
 });

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -54,50 +54,6 @@ describe("uiSchema", () => {
     });
   });
 
-  describe("date-time", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        foo: {
-          type: "date-time",
-        }
-      }
-    };
-
-    describe("hidden", () => {
-      const uiSchema = {
-        foo: {
-          "ui:widget": "hidden"
-        }
-      };
-      const datetime = new Date().toJSON();
-
-      it("should accept a uiSchema object", () => {
-        const {node} = createFormComponent({schema, uiSchema});
-
-        expect(node.querySelectorAll("[type=hidden]"))
-          .to.have.length.of(1);
-      });
-
-      it("should support formData", () => {
-        const {node} = createFormComponent({schema, uiSchema, formData: {
-          foo: datetime
-        }});
-
-        expect(node.querySelector("[type=hidden]").value)
-          .eql(datetime);
-      });
-
-      it("should map widget value to a typed state one", () => {
-        const {comp} = createFormComponent({schema, uiSchema, formData: {
-          foo: datetime
-        }});
-
-        expect(comp.state.formData.foo).eql(datetime);
-      });
-    });
-  });
-
   describe("string", () => {
     const schema = {
       type: "object",


### PR DESCRIPTION
WiP. Refs #114 and #113. I've realized that the `string` JSONSchema type allows specifying a `format` property, which can be `date-time`. Previously, we were erroneously considering this value as a *type*, so this patch removes support for it as a type and moves its support as a `format`.

It also introduces a very basic [`input[type=datetime]`](https://www.w3.org/TR/html-markup/input.datetime.html) widget which offers a specific UI on some platforms; by default, browsers not supporting it will render a simple text input. The good thing being the validator works in every situation when validating the value, which must follow the [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt), section 5.6 format. 

- [x] Implement
- [x] Test
- [x] Document
- [x] Add sample to the playground

Note: next steps will be to add support for more string formats (email, url, etc.) through #113.