### PR TITLE
Refs #113: Added support for email and uri string formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The built-in string field also supports the JSONSchema `format` property, and wi
 
 - `date-time`: An `input[type=datetime-local]` element is used;
 - `email`: An `input[type=email]` element is used;
+- `uri`: An `input[type=url]` element is used;
 - More formats could be supported in a near future, feel free to help us going faster!
 
 #### For `number` and `integer` fields

--- a/README.md
+++ b/README.md
@@ -178,14 +178,15 @@ Here's a list of supported alternative widgets for different JSONSchema data typ
 
 #### For `string` fields
 
-  * `textarea`: a `textarea` element;
-  * `password`: an `input[type=password]` element;
+  * `textarea`: a `textarea` element is used;
+  * `password`: an `input[type=password]` element is used;
   * by default, a regular `input[type=text]` element is used.
 
 The built-in string field also supports the JSONSchema `format` property, and will render an appropriate widget by default for the following formats:
 
-- `date-time`: An `input[type=datetime-local]` will be rendered.
-- More formats will be supported in a near future, feel free to help us going faster!
+- `date-time`: An `input[type=datetime-local]` element is used;
+- `email`: An `input[type=email]` element is used;
+- More formats could be supported in a near future, feel free to help us going faster!
 
 #### For `number` and `integer` fields
 

--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -43,6 +43,10 @@ module.exports = {
             type: "string",
             format: "email"
           },
+          uri: {
+            type: "string",
+            format: "uri"
+          },
           datetime: {
             type: "string",
             format: "date-time"
@@ -85,6 +89,7 @@ module.exports = {
     },
     stringFormats: {
       email: "chuck@norris.net",
+      uri: "http://chucknorris.com/",
       datetime: new Date().toJSON(),
     },
     secret: "I'm a hidden string."

--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -35,9 +35,19 @@ module.exports = {
           }
         }
       },
-      datetime: {
-        type: "string",
-        format: "date-time"
+      stringFormats: {
+        type: "object",
+        title: "String formats",
+        properties: {
+          email: {
+            type: "string",
+            format: "email"
+          },
+          datetime: {
+            type: "string",
+            format: "date-time"
+          }
+        }
       },
       secret: {
         type: "string",
@@ -73,7 +83,10 @@ module.exports = {
       default: "Hello...",
       textarea: "... World"
     },
-    datetime: new Date().toJSON(),
+    stringFormats: {
+      email: "chuck@norris.net",
+      datetime: new Date().toJSON(),
+    },
     secret: "I'm a hidden string."
   }
 };

--- a/src/components/widgets/EmailWidget.js
+++ b/src/components/widgets/EmailWidget.js
@@ -1,0 +1,37 @@
+import React, { PropTypes } from "react";
+
+
+function EmailWidget({
+  schema,
+  id,
+  placeholder,
+  value,
+  defaultValue,
+  required,
+  onChange
+}) {
+  return (
+    <input type="email"
+      id={id}
+      className="form-control"
+      value={value}
+      defaultValue={defaultValue}
+      placeholder={placeholder}
+      required={required}
+      onChange={(event) => onChange(event.target.value)} />
+  );
+}
+
+if (process.env.NODE_ENV !== "production") {
+  EmailWidget.propTypes = {
+    schema: PropTypes.object.isRequired,
+    id: PropTypes.string.isRequired,
+    placeholder: PropTypes.string,
+    value: React.PropTypes.string,
+    defaultValue: React.PropTypes.string,
+    required: PropTypes.bool,
+    onChange: PropTypes.func,
+  };
+}
+
+export default EmailWidget;

--- a/src/components/widgets/URLWidget.js
+++ b/src/components/widgets/URLWidget.js
@@ -1,0 +1,37 @@
+import React, { PropTypes } from "react";
+
+
+function URLWidget({
+  schema,
+  id,
+  placeholder,
+  value,
+  defaultValue,
+  required,
+  onChange
+}) {
+  return (
+    <input type="url"
+      id={id}
+      className="form-control"
+      value={value}
+      defaultValue={defaultValue}
+      placeholder={placeholder}
+      required={required}
+      onChange={(event) => onChange(event.target.value)} />
+  );
+}
+
+if (process.env.NODE_ENV !== "production") {
+  URLWidget.propTypes = {
+    schema: PropTypes.object.isRequired,
+    id: PropTypes.string.isRequired,
+    placeholder: PropTypes.string,
+    value: React.PropTypes.string,
+    defaultValue: React.PropTypes.string,
+    required: PropTypes.bool,
+    onChange: PropTypes.func,
+  };
+}
+
+export default URLWidget;

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,7 @@ import SelectWidget from "./components/widgets/SelectWidget";
 import TextWidget from "./components/widgets/TextWidget";
 import DateTimeWidget from "./components/widgets/DateTimeWidget";
 import EmailWidget from "./components/widgets/EmailWidget";
+import URLWidget from "./components/widgets/URLWidget";
 import TextareaWidget from "./components/widgets/TextareaWidget";
 import HiddenWidget from "./components/widgets/HiddenWidget";
 
@@ -45,7 +46,7 @@ const stringFormatWidgets = {
   "hostname": TextWidget,
   "ipv4": TextWidget,
   "ipv6": TextWidget,
-  "uri": TextWidget, // XXX: to customize appropriately
+  "uri": URLWidget,
 };
 
 export function defaultTypeValue(type) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,7 @@ import RangeWidget from "./components/widgets/RangeWidget";
 import SelectWidget from "./components/widgets/SelectWidget";
 import TextWidget from "./components/widgets/TextWidget";
 import DateTimeWidget from "./components/widgets/DateTimeWidget";
+import EmailWidget from "./components/widgets/EmailWidget";
 import TextareaWidget from "./components/widgets/TextareaWidget";
 import HiddenWidget from "./components/widgets/HiddenWidget";
 
@@ -40,7 +41,7 @@ const altWidgetMap = {
 
 const stringFormatWidgets = {
   "date-time": DateTimeWidget,
-  "email": TextWidget, // XXX: to customize appropriately
+  "email": EmailWidget,
   "hostname": TextWidget,
   "ipv4": TextWidget,
   "ipv6": TextWidget,

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -241,5 +241,110 @@ describe("StringField", () => {
       expect(node.querySelector("[type=datetime-local]").id)
         .eql("root");
     });
+
+    it("should reject an invalid entered datetime", () => {
+      const {comp, node} = createFormComponent({schema: {
+        type: "string",
+        format: "date-time",
+      }, liveValidate: true});
+
+      Simulate.change(node.querySelector("[type=datetime-local]"), {
+        target: {value: "invalid"}
+      });
+
+      expect(comp.state.errors).to.have.length.of(1);
+    });
+  });
+
+  describe("EmailWidget", () => {
+    it("should render an email field", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "email",
+      }});
+
+      expect(node.querySelectorAll(".field [type=email]"))
+        .to.have.length.of(1);
+    });
+
+    it("should render a string field with a label", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "email",
+        title: "foo",
+      }});
+
+      expect(node.querySelector(".field label").textContent)
+        .eql("foo");
+    });
+
+    it("should render a select field with a placeholder", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "email",
+        description: "baz",
+      }});
+
+      expect(node.querySelector(".field [type=email]").getAttribute("placeholder"))
+        .eql("baz");
+    });
+
+    it("should assign a default value", () => {
+      const email = "foo@bar.baz";
+      const {comp} = createFormComponent({schema: {
+        type: "string",
+        format: "email",
+        default: email,
+      }});
+
+      expect(comp.state.formData).eql(email);
+    });
+
+    it("should reflect the change into the dom", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "email",
+      }});
+
+      const newDatetime = new Date().toJSON();
+      Simulate.change(node.querySelector("[type=email]"), {
+        target: {value: newDatetime}
+      });
+
+      expect(node.querySelector("[type=email]").value).eql(newDatetime);
+    });
+
+    it("should fill field with data", () => {
+      const email = "foo@bar.baz";
+      const {comp} = createFormComponent({schema: {
+        type: "string",
+        format: "email",
+      }, formData: email});
+
+      expect(comp.state.formData).eql(email);
+    });
+
+    it("should render the widget with the expected id", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "email",
+      }});
+
+      expect(node.querySelector("[type=email]").id)
+        .eql("root");
+    });
+
+    it("should reject an invalid entered email", () => {
+      const {comp, node} = createFormComponent({schema: {
+        type: "string",
+        format: "email",
+      }, liveValidate: true});
+
+      Simulate.change(node.querySelector("[type=email]"), {
+        target: {value: "invalid"}
+      });
+
+      expect(comp.state.errors).to.have.length.of(1);
+    });
   });
 });

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -347,4 +347,96 @@ describe("StringField", () => {
       expect(comp.state.errors).to.have.length.of(1);
     });
   });
+
+  describe("URLWidget", () => {
+    it("should render an url field", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "uri",
+      }});
+
+      expect(node.querySelectorAll(".field [type=url]"))
+        .to.have.length.of(1);
+    });
+
+    it("should render a string field with a label", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "uri",
+        title: "foo",
+      }});
+
+      expect(node.querySelector(".field label").textContent)
+        .eql("foo");
+    });
+
+    it("should render a select field with a placeholder", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "uri",
+        description: "baz",
+      }});
+
+      expect(node.querySelector(".field [type=url]").getAttribute("placeholder"))
+        .eql("baz");
+    });
+
+    it("should assign a default value", () => {
+      const url = "http://foo.bar/baz";
+      const {comp} = createFormComponent({schema: {
+        type: "string",
+        format: "uri",
+        default: url,
+      }});
+
+      expect(comp.state.formData).eql(url);
+    });
+
+    it("should reflect the change into the dom", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "uri",
+      }});
+
+      const newDatetime = new Date().toJSON();
+      Simulate.change(node.querySelector("[type=url]"), {
+        target: {value: newDatetime}
+      });
+
+      expect(node.querySelector("[type=url]").value).eql(newDatetime);
+    });
+
+    it("should fill field with data", () => {
+      const url = "http://foo.bar/baz";
+      const {comp} = createFormComponent({schema: {
+        type: "string",
+        format: "uri",
+      }, formData: url});
+
+      expect(comp.state.formData).eql(url);
+    });
+
+    it("should render the widget with the expected id", () => {
+      const {node} = createFormComponent({schema: {
+        type: "string",
+        format: "uri",
+      }});
+
+      expect(node.querySelector("[type=url]").id)
+        .eql("root");
+    });
+
+    it("should reject an invalid entered email", () => {
+      const {comp, node} = createFormComponent({schema: {
+        type: "string",
+        format: "uri",
+      }, liveValidate: true});
+
+      Simulate.change(node.querySelector("[type=url]"), {
+        target: {value: "invalid"}
+      });
+
+      expect(comp.state.errors).to.have.length.of(1);
+    });
+  });
 });


### PR DESCRIPTION
Refs #113. This patch introduces support for JSONSchema `email` and `uri` string formats through dedicated widgets.

Note that  `hostname`, `ipv4` and `ipv6` formats are already handled by regular `TextWidget` widgets, and that their validation is already provided by our *jsonschema* dependency.

r=? @magopian @leplatrem 