### PR TITLE
Fixes #119: Do not render two equivalent labels for checkboxes.

### DIFF
--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -124,6 +124,9 @@ function SchemaField(props) {
   if (schema.type === "object") {
     displayLabel = false;
   }
+  if (schema.type === "boolean" && !uiSchema["ui:widget"]) {
+    displayLabel = false;
+  }
 
   return (
     <Wrapper

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -21,7 +21,7 @@ function CheckboxWidget({
           defaultChecked={defaultValue}
           required={required}
           onChange={(event) => onChange(event.target.checked)} />
-        {label}
+        <strong>{label}</strong>
       </label>
     </div>
   );

--- a/test/BooleanField_test.js
+++ b/test/BooleanField_test.js
@@ -19,8 +19,18 @@ describe("BooleanField", () => {
       title: "foo"
     }});
 
-    expect(node.querySelector(".field label").textContent)
+    expect(node.querySelector(".field label strong").textContent)
       .eql("foo");
+  });
+
+  it("should render a single label", () => {
+    const {node} = createFormComponent({schema: {
+      type: "boolean",
+      title: "foo"
+    }});
+
+    expect(node.querySelectorAll(".field label"))
+      .to.have.length.of(1);
   });
 
   it("should assign a default value", () => {


### PR DESCRIPTION
Refs #119.

Before:

![](http://i.imgur.com/6XFW8vb.png)

After:

![](http://i.imgur.com/AlZvOSz.png)

r=? @leplatrem @magopian 