### PR TITLE
Leverage registry for widgets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
   - [Advanced customization](#advanced-customization)
      - [Custom widget components](#custom-widget-components)
      - [Custom field components](#custom-field-components)
+        - [Field props](#field-props)
+        - [The registry object](#the-registry-object)
      - [Custom SchemaField](#custom-schemafield)
      - [Custom titles](#custom-titles)
   - [Live form data validation](#live-form-data-validation)
@@ -428,7 +430,7 @@ const uiSchema = {
 render(<Form
   schema={schema}
   uiSchema={uiSchema}
-  widgets={widgets}/>);
+  widgets={widgets} />);
 ```
 
 This is useful if you expose the `uiSchema` as pure JSON, which can't carry functions.
@@ -497,10 +499,31 @@ const fields = {geo: GeoPosition};
 render(<Form
   schema={schema}
   uiSchema={uiSchema}
-  fields={fields}/>);
+  fields={fields} />);
 ```
 
 Note: Registered fields can be reused accross the entire schema.
+
+#### Field props
+
+A field component will always be passed the following props:
+
+ - `schema`: The JSON schema for this field;
+ - `uiSchema`: The [uiSchema](#the-uischema-object) for this field;
+ - `idSchema`: The tree of unique ids for every child field;
+ - `formData`: The data for this field;
+ - `errorSchema`: The tree of errors for this field and its children;
+ - `registry`: A [registry](#the-registry-object) object (read next).
+
+#### The `registry` object
+
+The `registry` is an object containing the registered custom fields and widgets as well as root schema definitions.
+
+ - `fields`: The [custom registered fields](#custom-field-components). By default this object contains the standard `SchemaField` and `TitleField` components;
+ - `widgets`: The [custom registered widgets](#custom-widget-components), if any;
+ - `definitions`: The root schema [definitions](#schema-definitions-and-references), if any.
+
+The registry is passed down the component tree, so you can access it from your custom field and `SchemaField` components.
 
 ### Custom SchemaField
 
@@ -508,7 +531,7 @@ Note: Registered fields can be reused accross the entire schema.
 
 You can provide your own implementation of the `SchemaField` base React component for rendering any JSONSchema field type, including objects and arrays. This is useful when you want to augment a given field type with supplementary powers.
 
-To proceed so, you can pass a `SchemaField` prop to the `Form` component instance; here's a rather silly example wrapping the standard `SchemaField` lib component:
+To proceed so, pass a `fields` object having a `SchemaField` property to your `Form` component; here's a rather silly example wrapping the standard `SchemaField` lib component:
 
 ```jsx
 import SchemaField from "react-jsonschema-form/lib/components/fields/SchemaField";
@@ -522,32 +545,42 @@ const CustomSchemaField = function(props) {
   );
 };
 
+const fields = {
+  SchemaField: CustomSchemaField
+};
+
 render((
   <Form schema={schema}
         uiSchema={uiSchema}
         formData={formData}
-        SchemaField={CustomSchemaField} />
+        fields={fields} />
 ), document.getElementById("app"));
 ```
 
 If you're curious how this could ever be useful, have a look at the [Kinto formbuilder](https://github.com/Kinto/formbuilder) repository to see how it's used to provide editing capabilities to any form field.
+
+Props passed to a custom SchemaField are the same as [the ones passed to a custom field](#field-props).
 
 ### Custom titles
 
 You can provide your own implementation of the `TitleField` base React component for rendering any title. This is useful when you want to augment how titles are handled.
 
 
-To proceed so, you can pass a `TitleField` prop to the `Form` component instance:
+Simply pass a `fields` object having a `TitleField` property to your `Form` component:
 
 ```jsx
 
 const CustomTitleField = ({title}) => <div id="custom">{title}</div>;
 
+const fields = {
+  TitleField: CustomTitleField
+};
+
 render((
   <Form schema={schema}
         uiSchema={uiSchema}
         formData={formData}
-        TitleField={CustomTitleField} />
+        fields={fields} />
 ), document.getElementById("app"));
 ```
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -6,7 +6,8 @@ import {
   optionsList,
   retrieveSchema,
   toIdSchema,
-  shouldRender
+  shouldRender,
+  getDefaultRegistry
 } from "../../utils";
 import SelectWidget from "./../widgets/SelectWidget";
 
@@ -15,6 +16,7 @@ class ArrayField extends Component {
   static defaultProps = {
     uiSchema: {},
     idSchema: {},
+    registry: getDefaultRegistry(),
   };
 
   constructor(props) {
@@ -162,6 +164,7 @@ if (process.env.NODE_ENV !== "production") {
     registry: PropTypes.shape({
       widgets: PropTypes.objectOf(PropTypes.func).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
+      definitions: PropTypes.object.isRequired,
     })
   };
 }

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -1,6 +1,11 @@
 import React, { PropTypes } from "react";
 
-import { defaultFieldValue, getAlternativeWidget, optionsList } from "../../utils";
+import {
+  defaultFieldValue,
+  getAlternativeWidget,
+  optionsList,
+  getDefaultRegistry
+} from "../../utils";
 import CheckboxWidget from "./../widgets/CheckboxWidget";
 
 
@@ -18,11 +23,12 @@ function BooleanField(props) {
     uiSchema,
     idSchema,
     formData,
-    widgets,
+    registry,
     required,
     onChange
   } = props;
   const {title, description} = schema;
+  const {widgets} = registry;
   const widget = uiSchema["ui:widget"];
   const commonProps = {
     schema,
@@ -49,11 +55,17 @@ if (process.env.NODE_ENV !== "production") {
     onChange: PropTypes.func.isRequired,
     formData: PropTypes.bool,
     required: PropTypes.bool,
+    registry: PropTypes.shape({
+      widgets: PropTypes.objectOf(PropTypes.func).isRequired,
+      fields: PropTypes.objectOf(PropTypes.func).isRequired,
+      definitions: PropTypes.object.isRequired,
+    })
   };
 }
 
 BooleanField.defaultProps = {
-  uiSchema: {}
+  uiSchema: {},
+  registry: getDefaultRegistry(),
 };
 
 export default BooleanField;

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -4,7 +4,8 @@ import {
   getDefaultFormState,
   orderProperties,
   retrieveSchema,
-  shouldRender
+  shouldRender,
+  getDefaultRegistry
 } from "../../utils";
 
 
@@ -13,6 +14,7 @@ class ObjectField extends Component {
     uiSchema: {},
     errorSchema: {},
     idSchema: {},
+    registry: getDefaultRegistry(),
   }
 
   constructor(props) {
@@ -108,6 +110,7 @@ if (process.env.NODE_ENV !== "production") {
     registry: PropTypes.shape({
       widgets: PropTypes.objectOf(PropTypes.func).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
+      definitions: PropTypes.object.isRequired,
     })
   };
 }

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -1,12 +1,11 @@
 import React, { PropTypes } from "react";
 
-import { isMultiSelect, retrieveSchema } from "../../utils";
+import { isMultiSelect, retrieveSchema, getDefaultRegistry } from "../../utils";
 import ArrayField from "./ArrayField";
 import BooleanField from "./BooleanField";
 import NumberField from "./NumberField";
 import ObjectField from "./ObjectField";
 import StringField from "./StringField";
-import TitleField from "./TitleField";
 import UnsupportedField from "./UnsupportedField";
 
 const REQUIRED_FIELD_SYMBOL = "*";
@@ -151,11 +150,7 @@ SchemaField.defaultProps = {
   uiSchema: {},
   errorSchema: {},
   idSchema: {},
-  registry: {
-    fields: {SchemaField, TitleField},
-    widgets: {},
-    definitions: {},
-  }
+  registry: getDefaultRegistry(),
 };
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -1,8 +1,13 @@
 import React, { PropTypes } from "react";
 
-import { defaultFieldValue, getAlternativeWidget, optionsList } from "../../utils";
-import TextWidget from "./../widgets/TextWidget";
-import SelectWidget from "./../widgets/SelectWidget";
+import {
+  defaultFieldValue,
+  getAlternativeWidget,
+  optionsList,
+  getDefaultRegistry
+} from "../../utils";
+import TextWidget from "../widgets/TextWidget";
+import SelectWidget from "../widgets/SelectWidget";
 
 
 function StringField(props) {
@@ -12,11 +17,12 @@ function StringField(props) {
     uiSchema,
     idSchema,
     formData,
-    widgets,
+    registry,
     required,
     onChange
   } = props;
   const {title, description} = schema;
+  const {widgets} = registry;
   const widget = uiSchema["ui:widget"] || schema.format;
   const commonProps = {
     schema,
@@ -51,12 +57,18 @@ if (process.env.NODE_ENV !== "production") {
       React.PropTypes.string,
       React.PropTypes.number,
     ]),
+    registry: PropTypes.shape({
+      widgets: PropTypes.objectOf(PropTypes.func).isRequired,
+      fields: PropTypes.objectOf(PropTypes.func).isRequired,
+      definitions: PropTypes.object.isRequired,
+    }),
     required: PropTypes.bool,
   };
 }
 
 StringField.defaultProps = {
-  uiSchema: {}
+  uiSchema: {},
+  registry: getDefaultRegistry(),
 };
 
 export default StringField;

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,9 @@ import EmailWidget from "./components/widgets/EmailWidget";
 import URLWidget from "./components/widgets/URLWidget";
 import TextareaWidget from "./components/widgets/TextareaWidget";
 import HiddenWidget from "./components/widgets/HiddenWidget";
+import SchemaField from "./components/fields/SchemaField";
+import TitleField from "./components/fields/TitleField";
+
 
 
 const RE_ERROR_ARRAY_PATH = /(.*)\[(\d+)\]$/;
@@ -48,6 +51,14 @@ const stringFormatWidgets = {
   "ipv6": TextWidget,
   "uri": URLWidget,
 };
+
+export function getDefaultRegistry() {
+  return {
+    fields: {SchemaField, TitleField},
+    widgets: {},
+    definitions: {},
+  };
+}
 
 export function defaultTypeValue(schema) {
   const {type} = schema;

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -12,9 +12,10 @@ describe("SchemaField", () => {
     };
 
     it("should use the specified custom SchemaType property", () => {
+      const fields = {SchemaField: CustomSchemaField};
       const {node} = createFormComponent({
         schema: {type: "string"},
-        SchemaField: CustomSchemaField
+        fields
       });
 
       expect(node.querySelectorAll("#custom > .field input[type=text]"))

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -1,8 +1,7 @@
 import sinon from "sinon";
 import React from "react";
 
-import SchemaField from "../src/components/fields/SchemaField";
-import TitleField from "../src/components/fields/TitleField";
+import { getDefaultRegistry } from "../src/utils";
 import ArrayField from "../src/components/fields/ArrayField";
 import ObjectField from "../src/components/fields/ObjectField";
 import { createComponent, createFormComponent } from "./test_utils";
@@ -49,11 +48,7 @@ describe("Rendering performance optimizations", () => {
     const onChange = () => {};
     const schema = {type: "array", items: {type: "string"}};
     const uiSchema = {};
-    const registry = {
-      fields: {TitleField, SchemaField},
-      widgets: {},
-      definitions: {}
-    };
+    const registry = getDefaultRegistry();
 
     it("should not render if next props are equivalent", () => {
       const {comp} = createComponent(ArrayField, {
@@ -88,11 +83,7 @@ describe("Rendering performance optimizations", () => {
 
   describe("ObjectField", () => {
     const onChange = () => {};
-    const registry = {
-      fields: {TitleField, SchemaField},
-      widgets: {},
-      definitions: {}
-    };
+    const registry = getDefaultRegistry();
     const uiSchema = {};
     const schema = {
       type: "object",

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -30,12 +30,48 @@ describe("uiSchema", () => {
   });
 
   describe("custom widget", () => {
-    const schema = {
-      type: "string"
-    };
+    describe("root widget", () => {
+      const schema = {
+        type: "string"
+      };
 
-    const uiSchema = {
-      "ui:widget": (props) => {
+      const uiSchema = {
+        "ui:widget": (props) => {
+          return (
+            <input type="text"
+              className="custom"
+              value={props.value}
+              defaultValue={props.defaultValue}
+              required={props.required}
+              onChange={(event) => props.onChange(event.target.value)} />
+          );
+        }
+      };
+
+      it("should render a root custom widget", () => {
+        const {node} = createFormComponent({schema, uiSchema});
+
+        expect(node.querySelectorAll(".custom")).to.have.length.of(1);
+      });
+    });
+
+    describe("nested widget", () => {
+      const schema = {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          }
+        }
+      };
+
+      const uiSchema = {
+        "field": {
+          "ui:widget": "custom"
+        }
+      };
+
+      const CustomWidget = (props) => {
         return (
           <input type="text"
             className="custom"
@@ -44,13 +80,17 @@ describe("uiSchema", () => {
             required={props.required}
             onChange={(event) => props.onChange(event.target.value)} />
         );
-      }
-    };
+      };
 
-    it("should render a custom widget", () => {
-      const {node} = createFormComponent({schema, uiSchema});
+      const widgets = {
+        custom: CustomWidget
+      };
 
-      expect(node.querySelectorAll(".custom")).to.have.length.of(1);
+      it("should render a nested custom widget", () => {
+        const {node} = createFormComponent({schema, uiSchema, widgets});
+
+        expect(node.querySelectorAll(".custom")).to.have.length.of(1);
+      });
     });
   });
 


### PR DESCRIPTION
Refs https://github.com/mozilla-services/react-jsonschema-form/pull/127#issuecomment-206434248

Note: While this was previously poorly documented, it's possible this breaks existing usage of the `widgets` props in custom field components. As we're in a 0.x version and we didn't see much adoption yet, this is probably not that much of a big deal if we properly document the change in the release notes.   

Feedback=? @minettiandrea
r=? @almet @magopian @leplatrem 