### PR TITLE
Migrated code to use React 15.0.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,6 @@ const uiSchema = {
       <input type="text"
         className="custom"
         value={props.value}
-        defaultValue={props.defaultValue}
         required={props.required}
         onChange={(event) => props.onChange(event.target.value)} />
     );
@@ -415,7 +414,6 @@ const MyCustomWidget = (props) => {
     <input type="text"
       className="custom"
       value={props.value}
-      defaultValue={props.defaultValue}
       required={props.required}
       onChange={(event) => props.onChange(event.target.value)} />
   );
@@ -441,7 +439,6 @@ The following props are passed to the widget component:
 
 - `schema`: The JSONSchema subschema object for this field;
 - `value`: The current value for this field;
-- `defaultValue`: The default value for this field;
 - `required`: The required status of this field;
 - `onChange`: The value change event handler; call it with the new value everytime it changes;
 - `placeholder`: The placeholder value, if any;

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "node": ">=4"
   },
   "peerDependencies": {
-    "react": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
     "deeper": "^2.1.0",
@@ -56,11 +55,13 @@
     "html": "0.0.10",
     "jsdom": "^8.3.0",
     "mocha": "^2.3.0",
-    "react-addons-test-utils": "^0.14.3",
+    "react": "^15.0.0",
+    "react-addons-test-utils": "^15.0.1",
     "react-codemirror": "^0.2.3",
+    "react-dom": "^15.0.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
-    "redbox-react": "^1.2.0",
+    "redbox-react": "^1.2.3",
     "rimraf": "^2.4.4",
     "sinon": "^1.17.2",
     "style-loader": "^0.13.1",

--- a/playground/app.js
+++ b/playground/app.js
@@ -241,11 +241,13 @@ function ThemeSelector({theme, select}) {
 class App extends Component {
   constructor(props) {
     super(props);
+    // initialize state with Simple data sample
+    const {schema, uiSchema, formData} = samples.Simple;
     this.state = {
       form: false,
-      schema: {},
-      uiSchema: {},
-      formData: {},
+      schema,
+      uiSchema,
+      formData,
       editor: "default",
       theme: "default",
     };

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -103,7 +103,6 @@ class ArrayField extends Component {
           options={optionsList(itemsSchema)}
           schema={schema}
           title={title}
-          defaultValue={schema.default}
           value={items}
         />
       );

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -36,7 +36,6 @@ function BooleanField(props) {
     onChange,
     label: title || name,
     placeholder: description,
-    defaultValue: schema.default,
     value: defaultFieldValue(formData, schema),
     required,
   };

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -32,7 +32,6 @@ function StringField(props) {
     onChange,
     value: defaultFieldValue(formData, schema),
     required: required,
-    defaultValue: schema.default,
   };
   if (Array.isArray(schema.enum)) {
     if (widget) {

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -4,7 +4,6 @@ import React, { PropTypes } from "react";
 function CheckboxWidget({
   schema,
   id,
-  defaultValue,
   value,
   required,
   placeholder,
@@ -18,7 +17,6 @@ function CheckboxWidget({
           id={id}
           title={placeholder}
           checked={value}
-          defaultChecked={defaultValue}
           required={required}
           onChange={(event) => onChange(event.target.checked)} />
         <strong>{label}</strong>
@@ -31,7 +29,6 @@ if (process.env.NODE_ENV !== "production") {
     schema: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
     onChange: PropTypes.func,
-    defaultValue: PropTypes.bool,
     value: PropTypes.bool,
     required: PropTypes.bool,
     placeholder: PropTypes.string,

--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -33,11 +33,11 @@ function DateElement({type, range, value, select, rootId}) {
 class DateTimeWidget extends Component {
   constructor(props) {
     super(props);
-    this.state = parseDateString(props.value || props.defaultValue);
+    this.state = parseDateString(props.value);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState(parseDateString(nextProps.value || nextProps.defaultValue));
+    this.setState(parseDateString(nextProps.value));
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -85,7 +85,6 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     value: React.PropTypes.string,
-    defaultValue: React.PropTypes.string,
     required: PropTypes.bool,
     onChange: PropTypes.func,
   };

--- a/src/components/widgets/EmailWidget.js
+++ b/src/components/widgets/EmailWidget.js
@@ -6,7 +6,6 @@ function EmailWidget({
   id,
   placeholder,
   value,
-  defaultValue,
   required,
   onChange
 }) {
@@ -15,7 +14,6 @@ function EmailWidget({
       id={id}
       className="form-control"
       value={value}
-      defaultValue={defaultValue}
       placeholder={placeholder}
       required={required}
       onChange={(event) => onChange(event.target.value)} />
@@ -28,7 +26,6 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     value: React.PropTypes.string,
-    defaultValue: React.PropTypes.string,
     required: PropTypes.bool,
     onChange: PropTypes.func,
   };

--- a/src/components/widgets/HiddenWidget.js
+++ b/src/components/widgets/HiddenWidget.js
@@ -1,16 +1,9 @@
 import React, { PropTypes } from "react";
 
 
-function HiddenWidget({
-  id,
-  value,
-  defaultValue
-}) {
+function HiddenWidget({id, value}) {
   return (
-    <input type="hidden"
-      id={id}
-      value={value}
-      defaultValue={defaultValue} />
+    <input type="hidden" id={id} value={value} />
   );
 }
 
@@ -22,11 +15,6 @@ if (process.env.NODE_ENV !== "production") {
       React.PropTypes.number,
       React.PropTypes.bool,
     ]),
-    defaultValue: PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-      React.PropTypes.bool,
-    ])
   };
 }
 

--- a/src/components/widgets/PasswordWidget.js
+++ b/src/components/widgets/PasswordWidget.js
@@ -6,7 +6,6 @@ function PasswordWidget({
   id,
   placeholder,
   value,
-  defaultValue,
   required,
   onChange
 }) {
@@ -15,7 +14,6 @@ function PasswordWidget({
       id={id}
       className="form-control"
       value={value}
-      defaultValue={defaultValue}
       placeholder={placeholder}
       required={required}
       onChange={(event) => onChange(event.target.value)} />
@@ -28,10 +26,6 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     value: PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-    ]),
-    defaultValue: PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number,
     ]),

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -6,7 +6,6 @@ function RadioWidget({
   options,
   placeholder,
   value,
-  defaultValue,
   required,
   onChange
 }) {
@@ -15,8 +14,7 @@ function RadioWidget({
   return (
     <div className="field-radio-group">{
       options.map((option, i) => {
-        const checked = value !== undefined ? option.value === value :
-                                              option.value === defaultValue;
+        const checked = option.value === value;
         return (
           <div key={i} className="radio">
             <label>
@@ -42,7 +40,6 @@ if (process.env.NODE_ENV !== "production") {
     options: PropTypes.array.isRequired,
     placeholder: PropTypes.string,
     value: PropTypes.any,
-    defaultValue: PropTypes.any,
     required: PropTypes.bool,
     onChange: PropTypes.func,
   };

--- a/src/components/widgets/RangeWidget.js
+++ b/src/components/widgets/RangeWidget.js
@@ -20,7 +20,6 @@ function RangeWidget({
   id,
   placeholder,
   value,
-  defaultValue,
   required,
   onChange
 }) {
@@ -29,7 +28,6 @@ function RangeWidget({
       <input type="range"
         id={id}
         value={value}
-        defaultValue={defaultValue}
         placeholder={placeholder}
         required={required}
         onChange={(event) => onChange(event.target.value)}
@@ -45,10 +43,6 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     value: PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-    ]),
-    defaultValue: PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number,
     ]),

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -22,7 +22,6 @@ function SelectWidget({
   options,
   placeholder,
   value,
-  defaultValue,
   required,
   multiple,
   onChange
@@ -34,7 +33,6 @@ function SelectWidget({
       className="form-control"
       title={placeholder}
       value={value}
-      defaultValue={defaultValue}
       onChange={(event) => {
         let newValue;
         if (multiple) {
@@ -60,7 +58,6 @@ if (process.env.NODE_ENV !== "production") {
     options: PropTypes.array.isRequired,
     placeholder: PropTypes.string,
     value: PropTypes.any,
-    defaultValue: PropTypes.any,
     required: PropTypes.bool,
     multiple: PropTypes.bool,
     onChange: PropTypes.func,

--- a/src/components/widgets/TextWidget.js
+++ b/src/components/widgets/TextWidget.js
@@ -6,7 +6,6 @@ function TextWidget({
   id,
   placeholder,
   value,
-  defaultValue,
   required,
   onChange
 }) {
@@ -15,7 +14,6 @@ function TextWidget({
       id={id}
       className="form-control"
       value={value}
-      defaultValue={defaultValue}
       placeholder={placeholder}
       required={required}
       onChange={(event) => onChange(event.target.value)} />
@@ -28,10 +26,6 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     value: PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-    ]),
-    defaultValue: PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number,
     ]),

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -6,7 +6,6 @@ function TextWidget({
   id,
   placeholder,
   value,
-  defaultValue,
   required,
   onChange
 }) {
@@ -15,7 +14,6 @@ function TextWidget({
       id={id}
       className="form-control"
       value={value}
-      defaultValue={defaultValue}
       placeholder={placeholder}
       required={required}
       onChange={(event) => onChange(event.target.value)} />
@@ -28,7 +26,6 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     value: PropTypes.string,
-    defaultValue: PropTypes.string,
     required: PropTypes.bool,
     onChange: PropTypes.func,
   };

--- a/src/components/widgets/URLWidget.js
+++ b/src/components/widgets/URLWidget.js
@@ -6,7 +6,6 @@ function URLWidget({
   id,
   placeholder,
   value,
-  defaultValue,
   required,
   onChange
 }) {
@@ -15,7 +14,6 @@ function URLWidget({
       id={id}
       className="form-control"
       value={value}
-      defaultValue={defaultValue}
       placeholder={placeholder}
       required={required}
       onChange={(event) => onChange(event.target.value)} />
@@ -28,7 +26,6 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     value: React.PropTypes.string,
-    defaultValue: React.PropTypes.string,
     required: PropTypes.bool,
     onChange: PropTypes.func,
   };

--- a/src/components/widgets/UpDownWidget.js
+++ b/src/components/widgets/UpDownWidget.js
@@ -20,7 +20,6 @@ function UpDownWidget({
   id,
   placeholder,
   value,
-  defaultValue,
   required,
   onChange
 }) {
@@ -29,7 +28,6 @@ function UpDownWidget({
       id={id}
       className="form-control"
       value={value}
-      defaultValue={defaultValue}
       placeholder={placeholder}
       required={required}
       onChange={(event) => onChange(event.target.value)}
@@ -43,10 +41,6 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     value: PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-    ]),
-    defaultValue: PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number,
     ]),

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -166,9 +166,9 @@ describe("ArrayField", () => {
 
       const options = node.querySelectorAll(".field select option");
       expect(options).to.have.length.of(3);
-      expect(options[0].getAttribute("selected")).not.to.be.null;  // foo
-      expect(options[1].getAttribute("selected")).not.to.be.null;  // bar
-      expect(options[2].getAttribute("selected")).to.be.null;  // fuzz
+      expect(options[0].selected).eql(true);   // foo
+      expect(options[1].selected).eql(true);   // bar
+      expect(options[2].selected).eql(false);  // fuzz
     });
 
     it("should render the select widget with the expected id", () => {

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -40,7 +40,7 @@ describe("NumberField", () => {
         default: 2,
       }});
 
-      expect(node.querySelector(".field input").getAttribute("value"))
+      expect(node.querySelector(".field input").value)
         .eql("2");
     });
 
@@ -61,7 +61,7 @@ describe("NumberField", () => {
         type: "number",
       }, formData: 2});
 
-      expect(node.querySelector(".field input").getAttribute("value"))
+      expect(node.querySelector(".field input").value)
         .eql("2");
     });
 

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -40,7 +40,7 @@ describe("StringField", () => {
         default: "plop",
       }});
 
-      expect(node.querySelector(".field input").getAttribute("value"))
+      expect(node.querySelector(".field input").value)
         .eql("plop");
     });
 
@@ -61,7 +61,7 @@ describe("StringField", () => {
         type: "string",
       }, formData: "plip"});
 
-      expect(node.querySelector(".field input").getAttribute("value"))
+      expect(node.querySelector(".field input").value)
         .eql("plip");
     });
 

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -250,7 +250,7 @@ describe("uiSchema", () => {
           foo: "b"
         }});
 
-        expect(node.querySelector("[type=radio][value=b]").checked)
+        expect(node.querySelectorAll("[type=radio]")[1].checked)
           .eql(true);
       });
 
@@ -259,7 +259,7 @@ describe("uiSchema", () => {
           foo: "a"
         }});
 
-        Simulate.change(node.querySelector("[type=radio][value=b]"), {
+        Simulate.change(node.querySelectorAll("[type=radio]")[1], {
           target: {checked: true}
         });
 
@@ -520,16 +520,16 @@ describe("uiSchema", () => {
 
         expect(node.querySelectorAll("[type=radio]"))
           .to.have.length.of(2);
-        expect(node.querySelector("[type=radio][value=true]"))
+        expect(node.querySelectorAll("[type=radio]")[0])
           .not.eql(null);
-        expect(node.querySelector("[type=radio][value=false]"))
+        expect(node.querySelectorAll("[type=radio]")[1])
           .not.eql(null);
       });
 
       it("should render boolean option labels", () => {
         const {node} = createFormComponent({schema, uiSchema});
         const labels = [].map.call(
-          node.querySelectorAll(".field-radio-group label > span"),
+          node.querySelectorAll(".field-radio-group label"),
           node => node.textContent);
 
         expect(labels)
@@ -541,7 +541,7 @@ describe("uiSchema", () => {
           foo: false
         }});
 
-        expect(node.querySelector("[type=radio][value=false]").checked)
+        expect(node.querySelectorAll("[type=radio]")[1].checked)
           .eql(true);
       });
 
@@ -550,7 +550,7 @@ describe("uiSchema", () => {
           foo: true
         }});
 
-        Simulate.change(node.querySelector("[type=radio][value=false]"), {
+        Simulate.change(node.querySelectorAll("[type=radio]")[1], {
           target: {checked: true}
         });
 
@@ -562,7 +562,7 @@ describe("uiSchema", () => {
           foo: false
         }});
 
-        Simulate.change(node.querySelector("[type=radio][value=true]"), {
+        Simulate.change(node.querySelectorAll("[type=radio]")[0], {
           target: {checked: true}
         });
 


### PR DESCRIPTION
#### Changes:

- All references to `defaultValue` have been removed from widgets, as React 15.0.1 requires to choose between controlled and uncontrolled input components.
- Related, tests relying on selecting input tags from their value attribute have been updated accordingly.

#### Todo

- [x] Update docs to reflect removal of passed `defaultValue` widget prop.