### PR TITLE
Handle fixed items arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,13 @@ This library partially supports [inline schema definition dereferencing]( http:/
 
 Note that it only supports local definition referencing, we do not plan on fetching foreign schemas over HTTP anytime soon. Basically, you can only reference a definition from the very schema object defining it.
 
+## JSON Schema supporting status
+
+This component follows [JSON Schema](http://json-schema.org/documentation.html) specs. Due to the limitation of form widgets, there are some exceptions as follows:
+
+* `additionalItems` keyword for arrays
+    This keyword works when `items` is an array. `additionalItems: true` is not supported because there's no widget to represent a item of any type. In this case it will be treated as no additional items allowed. `additionalItems` being a valid schema is supported.
+
 ## Troubleshooting
 
 ### Build error wrt missing "buffertools" module

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
   - [Live form data validation](#live-form-data-validation)
   - [Styling your forms](#styling-your-forms)
   - [Schema definitions and references](#schema-definitions-and-references)
+  - [JSON Schema supporting status](#json-schema-supporting-status)
   - [Troubleshooting](#troubleshooting)
      - [Build error wrt missing &quot;buffertools&quot; module](#build-error-wrt-missing-buffertools-module)
   - [Contributing](#contributing)
@@ -641,7 +642,7 @@ Note that it only supports local definition referencing, we do not plan on fetch
 This component follows [JSON Schema](http://json-schema.org/documentation.html) specs. Due to the limitation of form widgets, there are some exceptions as follows:
 
 * `additionalItems` keyword for arrays
-    This keyword works when `items` is an array. `additionalItems: true` is not supported because there's no widget to represent a item of any type. In this case it will be treated as no additional items allowed. `additionalItems` being a valid schema is supported.
+    This keyword works when `items` is an array. `additionalItems: true` is not supported because there's no widget to represent an item of any type. In this case it will be treated as no additional items allowed. `additionalItems` being a valid schema is supported.
 
 ## Troubleshooting
 

--- a/playground/samples/arrays.js
+++ b/playground/samples/arrays.js
@@ -24,15 +24,19 @@ module.exports = {
         title: "A list of fixed items",
         items: [
           {
-            title: "Item 1",
+            title: "A string value",
             type: "string",
             default: "lorem ipsum"
           },
           {
-            title: "Item 2",
-            type: "integer"
+            title: "a boolean value",
+            type: "boolean"
           }
-        ]
+        ],
+        additionalItems: {
+          title: "Additional item",
+          type: "number"
+        }
       },
       nestedList: {
         type: "array",
@@ -52,7 +56,7 @@ module.exports = {
   formData: {
     listOfStrings: ["foo", "bar"],
     multipleChoicesList: ["foo", "bar"],
-    fixedItemsList: ["Some text", 123],
+    fixedItemsList: ["Some text", true, 123],
     nestedList: [["lorem", "ipsum"], ["dolor"]]
   }
 };

--- a/playground/samples/arrays.js
+++ b/playground/samples/arrays.js
@@ -18,12 +18,41 @@ module.exports = {
           enum: ["foo", "bar", "fuzz"],
         },
         uniqueItems: true
+      },
+      fixedItemsList: {
+        type: "array",
+        title: "A list of fixed items",
+        items: [
+          {
+            title: "Item 1",
+            type: "string",
+            default: "lorem ipsum"
+          },
+          {
+            title: "Item 2",
+            type: "integer"
+          }
+        ]
+      },
+      nestedList: {
+        type: "array",
+        title: "Nested list",
+        items: {
+          type: "array",
+          title: "Inner list",
+          items: {
+            type: "string",
+            default: "lorem ipsum"
+          }
+        }
       }
     }
   },
   uiSchema: {},
   formData: {
     listOfStrings: ["foo", "bar"],
-    multipleChoicesList: ["foo", "bar"]
+    multipleChoicesList: ["foo", "bar"],
+    fixedItemsList: ["Some text", 123],
+    nestedList: [["lorem", "ipsum"], ["dolor"]]
   }
 };

--- a/playground/samples/arrays.js
+++ b/playground/samples/arrays.js
@@ -52,7 +52,17 @@ module.exports = {
       }
     }
   },
-  uiSchema: {},
+  uiSchema: {
+    fixedItemsList: {
+      items: [
+        {"ui:widget": "textarea"},
+        {"ui:widget": "select"}
+      ],
+      additionalItems: {
+        "ui:widget": "updown"
+      }
+    }
+  },
   formData: {
     listOfStrings: ["foo", "bar"],
     multipleChoicesList: ["foo", "bar"],

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -3,6 +3,7 @@ import React, { Component, PropTypes } from "react";
 import {
   getDefaultFormState,
   isMultiSelect,
+  isFixedItems,
   optionsList,
   retrieveSchema,
   toIdSchema,
@@ -93,6 +94,39 @@ class ArrayField extends Component {
     const {items} = this.state;
     const {fields, definitions} = this.props.registry;
     const {SchemaField} = fields;
+    if (isFixedItems(schema)) {
+      const itemSchemas = schema.items.map(item => retrieveSchema(item, definitions));
+      return (
+          <fieldset
+              className={`field field-array field-array-fixed-items`}>
+            {title ? <legend>{title}</legend> : null}
+            {schema.description ?
+                <div className="field-description">{schema.description}</div> : null}
+            <div className="row array-item-list">{
+              itemSchemas.map((itemSchema, index) => {
+                const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
+                const itemIdPrefix = idSchema.id + "_" + index;
+                const itemIdSchema = toIdSchema(itemSchema, itemIdPrefix, definitions);
+                return (
+                    <div key={index}>
+                      <div className="col-xs-12">
+                        <SchemaField
+                            schema={itemSchema}
+                            uiSchema={uiSchema.items}
+                            formData={items[index]}
+                            errorSchema={itemErrorSchema}
+                            idSchema={itemIdSchema}
+                            required={this.isItemRequired(itemSchema)}
+                            onChange={this.onChangeForIndex(index)}
+                            registry={this.props.registry}/>
+                      </div>
+                    </div>
+                );
+              })
+            }</div>
+          </fieldset>
+      );
+    }
     const itemsSchema = retrieveSchema(schema.items, definitions);
     if (isMultiSelect(schema)) {
       return (

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -163,7 +163,7 @@ class ArrayField extends Component {
     const additionalItems = additionalSchema && items && (items.length > itemSchemas.length) && items.slice(itemSchemas.length);
     return (
       <fieldset
-          className={`field field-array field-array-fixed-items`}>
+          className="field field-array field-array-fixed-items">
         {title ? <legend>{title}</legend> : null}
         {schema.description ?
             <div className="field-description">{schema.description}</div> : null}
@@ -232,7 +232,7 @@ class ArrayField extends Component {
           : null
         }
       </div>
-    )
+    );
   }
 }
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -113,10 +113,10 @@ class ArrayField extends Component {
 
     return (
       <fieldset
-          className={`field field-array field-array-of-${itemsSchema.type}`}>
+        className={`field field-array field-array-of-${itemsSchema.type}`}>
         {title ? <legend>{title}</legend> : null}
         {schema.description ?
-            <div className="field-description">{schema.description}</div> : null}
+          <div className="field-description">{schema.description}</div> : null}
         <div className="row array-item-list">{
           items.map((item, index) => {
             const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -65,7 +65,6 @@ class ArrayField extends Component {
     if (isFixedItems(schema) && allowAdditionalItems(schema)) {
       itemSchema = schema.additionalItems;
     }
-    console.log(itemSchema, getDefaultFormState(itemSchema, undefined, definitions));
     this.asyncSetState({
       items: items.concat([getDefaultFormState(itemSchema, undefined, definitions)])
     }, {validate: false});

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -167,6 +167,7 @@ class ArrayField extends Component {
       retrieveSchema(schema.additionalItems, definitions) : null;
 
     if (!items || items.length < itemSchemas.length) {
+      // to make sure at least all fixed items are generated
       items = items || [];
       items = items.concat(new Array(itemSchemas.length - items.length));
     }

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -172,11 +172,12 @@ class ArrayField extends Component {
             const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
             const itemIdPrefix = idSchema.id + "_" + index;
             const itemIdSchema = toIdSchema(itemSchema, itemIdPrefix, definitions);
+            const itemUiSchema = (uiSchema.items instanceof Array) ? uiSchema.items[index] : uiSchema.items || {};
             return this.renderArrayFieldItem({
               index, itemSchema, itemIdSchema, itemErrorSchema,
               removable: false,
               itemData: items[index],
-              itemUiSchema: uiSchema.items
+              itemUiSchema
             });
           })
         }{
@@ -190,7 +191,7 @@ class ArrayField extends Component {
                 index, itemIdSchema, itemErrorSchema,
                 itemData: items[index],
                 itemSchema: additionalSchema,
-                itemUiSchema: uiSchema.items
+                itemUiSchema: uiSchema.additionalItems
               });
             }) : null
         }</div>

--- a/src/utils.js
+++ b/src/utils.js
@@ -111,6 +111,8 @@ function computeDefaults(schema, parentDefaults, definitions={}) {
     // Use referenced schema defaults for this node.
     const refSchema = findSchemaDefinition(schema.$ref, definitions);
     defaults = computeDefaults(refSchema, defaults, definitions);
+  } else if (isFixedItems(schema)) {
+    defaults = schema.items.map(itemSchema => computeDefaults(itemSchema, undefined, definitions));
   }
   // Not defaults defined for this node, fallback to generic typed ones.
   if (typeof(defaults) === "undefined") {
@@ -191,6 +193,10 @@ export function orderProperties(properties, order) {
 
 export function isMultiSelect(schema) {
   return Array.isArray(schema.items.enum) && schema.uniqueItems;
+}
+
+export function isFixedItems(schema) {
+  return Array.isArray(schema.items) && schema.items.length > 0 && schema.items.every(item => isObject(item));
 }
 
 export function optionsList(schema) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -199,6 +199,10 @@ export function isFixedItems(schema) {
   return Array.isArray(schema.items) && schema.items.length > 0 && schema.items.every(item => isObject(item));
 }
 
+export function allowAdditionalItems(schema) {
+  return isObject(schema.additionalItems);
+}
+
 export function optionsList(schema) {
   return schema.enum.map((value, i) => {
     const label = schema.enumNames && schema.enumNames[i] || String(value);

--- a/src/utils.js
+++ b/src/utils.js
@@ -196,7 +196,9 @@ export function isMultiSelect(schema) {
 }
 
 export function isFixedItems(schema) {
-  return Array.isArray(schema.items) && schema.items.length > 0 && schema.items.every(item => isObject(item));
+  return Array.isArray(schema.items) &&
+         schema.items.length > 0 &&
+         schema.items.every(item => isObject(item));
 }
 
 export function allowAdditionalItems(schema) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,7 +13,7 @@ import URLWidget from "./components/widgets/URLWidget";
 import TextareaWidget from "./components/widgets/TextareaWidget";
 import HiddenWidget from "./components/widgets/HiddenWidget";
 
-const RE_ERROR_ARRAY_PATH = /(.*)\[(\d+)\]$/;
+const RE_ERROR_ARRAY_PATH = /\[\d+]/g;
 
 const altWidgetMap = {
   boolean: {
@@ -242,9 +242,11 @@ function errorPropertyToPath(property) {
   // Parse array indices, eg. "instance.level1.level2[2].level3"
   // => ["instance", "level1", "level2", 2, "level3"]
   return property.split(".").reduce((path, node) => {
-    const match = RE_ERROR_ARRAY_PATH.exec(node);
+    const match = node.match(RE_ERROR_ARRAY_PATH);
     if (match) {
-      path = path.concat([match[1], parseInt(match[2], 10)]);
+      const nodeName = node.slice(0, node.indexOf('['));
+      const indices = match.map(str => parseInt(str.slice(1, -1), 10));
+      path = path.concat(nodeName, indices);
     } else {
       path.push(node);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -200,6 +200,9 @@ export function isFixedItems(schema) {
 }
 
 export function allowAdditionalItems(schema) {
+  if (schema.additionalItems === true) {
+    console.warn("additionalItems=true is currently not supported");
+  }
   return isObject(schema.additionalItems);
 }
 

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -214,4 +214,67 @@ describe("ArrayField", () => {
       expect(node.querySelectorAll("fieldset fieldset")).to.have.length.of(1);
     });
   });
+
+  describe("Fixed items lists", () => {
+    const schema = {
+      type: "array",
+      title: "List of fixed items",
+      items: [
+        {
+          type: "string",
+          title: "Some text"
+        },
+        {
+          type: "number",
+          title: "A number"
+        }
+      ]
+    };
+
+    it("should render a fieldset", () => {
+      const {node} = createFormComponent({schema});
+
+      expect(node.querySelectorAll("fieldset"))
+          .to.have.length.of(1);
+    });
+
+    it("should render a fieldset legend", () => {
+      const {node} = createFormComponent({schema});
+
+      expect(node.querySelector("fieldset > legend").textContent)
+          .eql("List of fixed items");
+    });
+
+    it("should render field widgets", () => {
+      const {node} = createFormComponent({schema});
+      const strInput = node.querySelector("fieldset .field-string input[type=text]");
+      const numInput = node.querySelector("fieldset .field-number input[type=text]");
+      expect(strInput.id).eql("root_0");
+      expect(numInput.id).eql("root_1");
+    });
+
+    it("should fill fields with data", () => {
+      const {node} = createFormComponent({schema, formData: ["foo", 42]});
+      const strInput = node.querySelector("fieldset .field-string input[type=text]");
+      const numInput = node.querySelector("fieldset .field-number input[type=text]");
+      expect(strInput.value).eql("foo");
+      expect(numInput.value).eql("42");
+    });
+
+    it("should handle change events", () => {
+      const {comp, node} = createFormComponent({schema});
+      const strInput = node.querySelector("fieldset .field-string input[type=text]");
+      const numInput = node.querySelector("fieldset .field-number input[type=text]");
+
+      Simulate.change(strInput, {
+        target: { value: "bar" }
+      });
+      Simulate.change(numInput, {
+        target: { value: "101" }
+      });
+
+      expect(comp.state.formData).eql(["bar", 101]);
+    });
+
+  });
 });

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -230,7 +230,24 @@ describe("ArrayField", () => {
         }
       ]
     };
-
+    const schemaAdditional = {
+      type: "array",
+      title: "List of fixed items",
+      items: [
+        {
+          type: "number",
+          title: "A number"
+        },
+        {
+          type: "number",
+          title: "Another number"
+        }
+      ],
+      additionalItems: {
+        type: "string",
+        title: "Additional item"
+      }
+    };
     it("should render a fieldset", () => {
       const {node} = createFormComponent({schema});
 
@@ -274,6 +291,38 @@ describe("ArrayField", () => {
       });
 
       expect(comp.state.formData).eql(["bar", 101]);
+    });
+
+    it("should generate additional fields and fill data", () => {
+      const {node} = createFormComponent({schema: schemaAdditional, formData: [1, 2, "bar"]});
+      const addInput = node.querySelector("fieldset .field-string input[type=text]");
+      expect(addInput.id).eql("root_2");
+      expect(addInput.value).eql("bar");
+    });
+
+    it("add, remove, change for additional items", () => {
+      const {comp, node} = createFormComponent({schema: schemaAdditional, formData: [1, 2, "foo"]});
+
+      const addBtn = node.querySelector(".array-item-add button");
+
+      Simulate.click(addBtn);
+      expect(node.querySelectorAll('.field-string')).to.have.length.of(2);
+      expect(comp.state.formData).eql([1, 2, "foo", ""]);
+
+      const inputs = node.querySelectorAll(".field-string input[type=text]");
+      Simulate.change(inputs[0], {target: {value: "bar"}});
+      Simulate.change(inputs[1], {target: {value: "baz"}});
+      expect(comp.state.formData).eql([1, 2, "bar", "baz"]);
+
+      let dropBtns = node.querySelectorAll(".array-item-remove button");
+      Simulate.click(dropBtns[0]);
+      expect(node.querySelectorAll('.field-string')).to.have.length.of(1);
+      expect(comp.state.formData).eql([1, 2, "baz"]);
+
+      dropBtns = node.querySelectorAll(".array-item-remove button");
+      Simulate.click(dropBtns[0]);
+      expect(node.querySelectorAll('.field-string')).to.be.empty;
+      expect(comp.state.formData).eql([1, 2]);
     });
 
   });

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -324,7 +324,7 @@ describe("ArrayField", () => {
         Simulate.click(addBtn);
         
         expect(node.querySelectorAll(".field-string")).to.have.length.of(2);
-        expect(comp.state.formData).eql([1, 2, "foo", ""]);
+        expect(comp.state.formData).eql([1, 2, "foo", undefined]);
       });
       
       it("should change the state when changing input value", () => {

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -230,6 +230,7 @@ describe("ArrayField", () => {
         }
       ]
     };
+    
     const schemaAdditional = {
       type: "array",
       title: "List of fixed items",
@@ -248,6 +249,7 @@ describe("ArrayField", () => {
         title: "Additional item"
       }
     };
+    
     it("should render a fieldset", () => {
       const {node} = createFormComponent({schema});
 
@@ -264,24 +266,30 @@ describe("ArrayField", () => {
 
     it("should render field widgets", () => {
       const {node} = createFormComponent({schema});
-      const strInput = node.querySelector("fieldset .field-string input[type=text]");
-      const numInput = node.querySelector("fieldset .field-number input[type=text]");
+      const strInput =
+          node.querySelector("fieldset .field-string input[type=text]");
+      const numInput =
+          node.querySelector("fieldset .field-number input[type=text]");
       expect(strInput.id).eql("root_0");
       expect(numInput.id).eql("root_1");
     });
 
     it("should fill fields with data", () => {
       const {node} = createFormComponent({schema, formData: ["foo", 42]});
-      const strInput = node.querySelector("fieldset .field-string input[type=text]");
-      const numInput = node.querySelector("fieldset .field-number input[type=text]");
+      const strInput =
+          node.querySelector("fieldset .field-string input[type=text]");
+      const numInput =
+          node.querySelector("fieldset .field-number input[type=text]");
       expect(strInput.value).eql("foo");
       expect(numInput.value).eql("42");
     });
 
     it("should handle change events", () => {
       const {comp, node} = createFormComponent({schema});
-      const strInput = node.querySelector("fieldset .field-string input[type=text]");
-      const numInput = node.querySelector("fieldset .field-number input[type=text]");
+      const strInput =
+          node.querySelector("fieldset .field-string input[type=text]");
+      const numInput =
+          node.querySelector("fieldset .field-number input[type=text]");
 
       Simulate.change(strInput, {
         target: { value: "bar" }
@@ -294,36 +302,55 @@ describe("ArrayField", () => {
     });
 
     it("should generate additional fields and fill data", () => {
-      const {node} = createFormComponent({schema: schemaAdditional, formData: [1, 2, "bar"]});
-      const addInput = node.querySelector("fieldset .field-string input[type=text]");
+      const {node} = createFormComponent({
+        schema: schemaAdditional,
+        formData: [1, 2, "bar"]
+      });
+      const addInput =
+          node.querySelector("fieldset .field-string input[type=text]");
       expect(addInput.id).eql("root_2");
       expect(addInput.value).eql("bar");
     });
 
-    it("add, remove, change for additional items", () => {
-      const {comp, node} = createFormComponent({schema: schemaAdditional, formData: [1, 2, "foo"]});
+    describe("operations for additional items", () => {
+      const {comp, node} = createFormComponent({
+        schema: schemaAdditional,
+        formData: [1, 2, "foo"]
+      });
 
-      const addBtn = node.querySelector(".array-item-add button");
-
-      Simulate.click(addBtn);
-      expect(node.querySelectorAll('.field-string')).to.have.length.of(2);
-      expect(comp.state.formData).eql([1, 2, "foo", ""]);
-
-      const inputs = node.querySelectorAll(".field-string input[type=text]");
-      Simulate.change(inputs[0], {target: {value: "bar"}});
-      Simulate.change(inputs[1], {target: {value: "baz"}});
-      expect(comp.state.formData).eql([1, 2, "bar", "baz"]);
-
-      let dropBtns = node.querySelectorAll(".array-item-remove button");
-      Simulate.click(dropBtns[0]);
-      expect(node.querySelectorAll('.field-string')).to.have.length.of(1);
-      expect(comp.state.formData).eql([1, 2, "baz"]);
-
-      dropBtns = node.querySelectorAll(".array-item-remove button");
-      Simulate.click(dropBtns[0]);
-      expect(node.querySelectorAll('.field-string')).to.be.empty;
-      expect(comp.state.formData).eql([1, 2]);
+      it("should add a field when clicking add button", () => {
+        const addBtn = node.querySelector(".array-item-add button");
+        
+        Simulate.click(addBtn);
+        
+        expect(node.querySelectorAll('.field-string')).to.have.length.of(2);
+        expect(comp.state.formData).eql([1, 2, "foo", ""]);
+      });
+      
+      it("should change the state when changing input value", () => {
+        const inputs = node.querySelectorAll(".field-string input[type=text]");
+        
+        Simulate.change(inputs[0], {target: {value: "bar"}});
+        Simulate.change(inputs[1], {target: {value: "baz"}});
+        
+        expect(comp.state.formData).eql([1, 2, "bar", "baz"]);
+      });
+      
+      it("should remove array items when clicking remove buttons", () => {
+        let dropBtns = node.querySelectorAll(".array-item-remove button");
+        
+        Simulate.click(dropBtns[0]);
+        
+        expect(node.querySelectorAll('.field-string')).to.have.length.of(1);
+        expect(comp.state.formData).eql([1, 2, "baz"]);
+        
+        dropBtns = node.querySelectorAll(".array-item-remove button");
+        
+        Simulate.click(dropBtns[0]);
+        
+        expect(node.querySelectorAll('.field-string')).to.be.empty;
+        expect(comp.state.formData).eql([1, 2]);
+      });
     });
-
   });
 });

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -323,7 +323,7 @@ describe("ArrayField", () => {
         
         Simulate.click(addBtn);
         
-        expect(node.querySelectorAll('.field-string')).to.have.length.of(2);
+        expect(node.querySelectorAll(".field-string")).to.have.length.of(2);
         expect(comp.state.formData).eql([1, 2, "foo", ""]);
       });
       
@@ -341,14 +341,14 @@ describe("ArrayField", () => {
         
         Simulate.click(dropBtns[0]);
         
-        expect(node.querySelectorAll('.field-string')).to.have.length.of(1);
+        expect(node.querySelectorAll(".field-string")).to.have.length.of(1);
         expect(comp.state.formData).eql([1, 2, "baz"]);
         
         dropBtns = node.querySelectorAll(".array-item-remove button");
         
         Simulate.click(dropBtns[0]);
         
-        expect(node.querySelectorAll('.field-string')).to.be.empty;
+        expect(node.querySelectorAll(".field-string")).to.be.empty;
         expect(comp.state.formData).eql([1, 2]);
       });
     });

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -792,6 +792,65 @@ describe("Form", () => {
       });
     });
 
+    describe("nested arrays", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          outer: {
+            type: "array",
+            items: {
+              type: "array",
+              items: {
+                type: "string",
+                minLength: 4
+              }
+            }
+          }
+        }
+      };
+
+      const formData = {
+        outer: [
+          ["good", "bad"],
+          ["bad", "good"]
+        ]
+      };
+
+      const formProps = {schema, formData, liveValidate: true};
+
+      it("should contextualize the error for nested array indices", () => {
+        const {comp} = createFormComponent(formProps);
+
+        expect(comp.state.errorSchema).eql({
+          outer: {
+            0: {
+              1: {errors: ["does not meet minimum length of 4"]}
+            },
+            1: {
+              0: {errors: ["does not meet minimum length of 4"]}
+            }
+          }
+        });
+      });
+
+      it("should denote the error in the nested item field in error", () => {
+        const {node} = createFormComponent(formProps);
+        const fields = node.querySelectorAll(".field-string");
+        const errors = [].map.call(fields, field => {
+          const li = field.querySelector(".error-detail li");
+          return li && li.textContent;
+        });
+
+        expect(errors)
+          .eql([
+            null,
+            "does not meet minimum length of 4",
+            "does not meet minimum length of 4",
+            null
+          ]);
+      });
+    });
+
     describe("array nested items", () => {
       const schema = {
         type: "array",

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -209,7 +209,7 @@ describe("utils", () => {
           }
         };
         expect(getDefaultFormState(schema, {}))
-          .eql({array: ["foo", 0]});
+          .eql({array: ["foo", undefined]});
       });
     });
   });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -189,6 +189,28 @@ describe("utils", () => {
         expect(getDefaultFormState(schema, {}))
           .eql({foo: "a"});
       });
+
+      it("should map item defaults to fixed array default", () => {
+        const schema = {
+          type: "object",
+          properties: {
+            array: {
+              type: "array",
+              items: [
+                {
+                  type: "string",
+                  default: "foo"
+                },
+                {
+                  type: "number"
+                }
+              ]
+            }
+          }
+        };
+        expect(getDefaultFormState(schema, {}))
+          .eql({array: ["foo", 0]});
+      })
     });
   });
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -210,7 +210,7 @@ describe("utils", () => {
         };
         expect(getDefaultFormState(schema, {}))
           .eql({array: ["foo", 0]});
-      })
+      });
     });
   });
 


### PR DESCRIPTION
fixed #76 
handle fixed items arrays:
```json
{
  "type": "array",
  "title": "List of fixed items",
  "items": [
    {
      "type": "string",
      "title": "Some text"
    },
    {
      "type": "number",
      "title": "A number"
    }
  ]
}
```
NOTE: According to the [spec](http://json-schema.org/latest/json-schema-validation.html#anchor131), it should be **valid** that form data has less items in fixed array than the schema defined, but it seems hard to find an appropriate UI for this. I'm glad to implement it if there's any reasonable suggestion. 

