### PR TITLE
Do not render current date by default.

### DIFF
--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -3,6 +3,28 @@ module.exports = {
     title: "Widgets",
     type: "object",
     properties: {
+      stringFormats: {
+        type: "object",
+        title: "String formats",
+        properties: {
+          email: {
+            type: "string",
+            format: "email"
+          },
+          uri: {
+            type: "string",
+            format: "uri"
+          },
+          datetime: {
+            type: "string",
+            format: "date-time"
+          },
+          date: {
+            type: "string",
+            format: "date-time"
+          }
+        }
+      },
       boolean: {
         type: "object",
         title: "Boolean field",
@@ -32,28 +54,6 @@ module.exports = {
           textarea: {
             type: "string",
             title: "textarea"
-          }
-        }
-      },
-      stringFormats: {
-        type: "object",
-        title: "String formats",
-        properties: {
-          email: {
-            type: "string",
-            format: "email"
-          },
-          uri: {
-            type: "string",
-            format: "uri"
-          },
-          datetime: {
-            type: "string",
-            format: "date-time"
-          },
-          date: {
-            type: "string",
-            format: "date-time"
           }
         }
       },
@@ -87,6 +87,10 @@ module.exports = {
     }
   },
   formData: {
+    stringFormats: {
+      email: "chuck@norris.net",
+      uri: "http://chucknorris.com/",
+    },
     boolean: {
       default: true,
       radio: true,
@@ -95,10 +99,6 @@ module.exports = {
     string: {
       default: "Hello...",
       textarea: "... World"
-    },
-    stringFormats: {
-      email: "chuck@norris.net",
-      uri: "http://chucknorris.com/",
     },
     secret: "I'm a hidden string."
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -316,7 +316,14 @@ export function toIdSchema(schema, id, definitions) {
 
 export function parseDateString(dateString, includeTime = true) {
   if (!dateString) {
-    dateString = new Date().toJSON();
+    return {
+      year: -1,
+      month: -1,
+      day: -1,
+      hour: includeTime ? -1 : 0,
+      minute: includeTime ? -1 : 0,
+      second: includeTime ? -1 : 0,
+    };
   }
   const date = new Date(dateString);
   if (Number.isNaN(date.getTime())) {
@@ -332,8 +339,7 @@ export function parseDateString(dateString, includeTime = true) {
   };
 }
 
-export function toDateString(dateObj) {
-  const {year, month, day, hour, minute, second} = dateObj;
+export function toDateString({year, month, day, hour=0, minute=0, second=0}) {
   const utcTime = Date.UTC(year, month - 1, day, hour, minute, second);
   return new Date(utcTime).toJSON();
 }

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 
+import { parseDateString, toDateString } from "../src/utils";
 import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
 
 
@@ -214,12 +215,12 @@ describe("StringField", () => {
       }});
 
       return Promise.all([
-        SimulateAsync().change(node.querySelector("#root_year"), {target: {value: "2012"}}),
-        SimulateAsync().change(node.querySelector("#root_month"), {target: {value: "10"}}),
-        SimulateAsync().change(node.querySelector("#root_day"), {target: {value: "2"}}),
-        SimulateAsync().change(node.querySelector("#root_hour"), {target: {value: "1"}}),
-        SimulateAsync().change(node.querySelector("#root_minute"), {target: {value: "2"}}),
-        SimulateAsync().change(node.querySelector("#root_second"), {target: {value: "3"}}),
+        SimulateAsync().change(node.querySelector("#root_year"), {target: {value: 2012}}),
+        SimulateAsync().change(node.querySelector("#root_month"), {target: {value: 10}}),
+        SimulateAsync().change(node.querySelector("#root_day"), {target: {value: 2}}),
+        SimulateAsync().change(node.querySelector("#root_hour"), {target: {value: 1}}),
+        SimulateAsync().change(node.querySelector("#root_minute"), {target: {value: 2}}),
+        SimulateAsync().change(node.querySelector("#root_second"), {target: {value: 3}}),
       ])
         .then(() => {
           expect(comp.state.formData).eql("2012-10-02T01:02:03.000Z");
@@ -263,17 +264,17 @@ describe("StringField", () => {
       const lengths = [].map.call(node.querySelectorAll("select"), node => node.length);
 
       expect(lengths).eql([
-        121, // from 1900 to 2020
-        12,
-        31,
-        24,
-        60,
-        60
+        121 + 1, // from 1900 to 2020 + undefined
+        12 + 1,
+        31 + 1,
+        24 + 1,
+        60 + 1,
+        60 + 1
       ]);
       const monthOptions = node.querySelectorAll("select#root_month option");
       const monthOptionsValues = [].map.call(monthOptions, option => option.value);
       expect(monthOptionsValues).eql([
-        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]);
+        "-1", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]);
     });
 
     it("should render the widgets with the expected options' labels", () => {
@@ -285,7 +286,44 @@ describe("StringField", () => {
       const monthOptions = node.querySelectorAll("select#root_month option");
       const monthOptionsLabels = [].map.call(monthOptions, option => option.text);
       expect(monthOptionsLabels).eql([
-        "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]);
+        "month", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]);
+    });
+
+    describe("Action buttons", () => {
+      it("should render a action buttons", () => {
+        const {node} = createFormComponent({schema: {
+          type: "string",
+          format: "date-time",
+        }});
+
+        const buttonLabels = [].map.call(node.querySelectorAll("a.btn"),
+                                         x => x.textContent);
+        expect(buttonLabels).eql(["Now", "Clear"]);
+      });
+
+      it("should set current date when pressing the Now button", () => {
+        const {comp, node} = createFormComponent({schema: {
+          type: "string",
+          format: "date-time",
+        }});
+
+        return SimulateAsync().click(node.querySelector("a.btn-now"))
+          .then(() => {
+            const expected = toDateString(parseDateString(new Date().toJSON(), true));
+            expect(comp.state.formData).eql(expected);
+          });
+      });
+
+      it("should clear current date when pressing the Clear button", () => {
+        const {comp, node} = createFormComponent({schema: {
+          type: "string",
+          format: "date-time",
+        }});
+
+        return SimulateAsync().click(node.querySelector("a.btn-now"))
+          .then(() => SimulateAsync().click(node.querySelector("a.btn-clear")))
+          .then(() => expect(comp.state.formData).eql(undefined));
+      });
     });
   });
 
@@ -331,9 +369,9 @@ describe("StringField", () => {
       }, uiSchema});
 
       return Promise.all([
-        SimulateAsync().change(node.querySelector("#root_year"), {target: {value: "2012"}}),
-        SimulateAsync().change(node.querySelector("#root_month"), {target: {value: "10"}}),
-        SimulateAsync().change(node.querySelector("#root_day"), {target: {value: "2"}}),
+        SimulateAsync().change(node.querySelector("#root_year"), {target: {value: 2012}}),
+        SimulateAsync().change(node.querySelector("#root_month"), {target: {value: 10}}),
+        SimulateAsync().change(node.querySelector("#root_day"), {target: {value: 2}}),
       ])
         .then(() => {
           expect(comp.state.formData).eql("2012-10-02T00:00:00.000Z");
@@ -374,14 +412,14 @@ describe("StringField", () => {
       const lengths = [].map.call(node.querySelectorAll("select"), node => node.length);
 
       expect(lengths).eql([
-        121, // from 1900 to 2020
-        12,
-        31,
+        121 + 1, // from 1900 to 2020 + undefined
+        12 + 1,
+        31 + 1,
       ]);
       const monthOptions = node.querySelectorAll("select#root_month option");
       const monthOptionsValues = [].map.call(monthOptions, option => option.value);
       expect(monthOptionsValues).eql([
-        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]);
+        "-1", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"]);
     });
 
     it("should render the widgets with the expected options' labels", () => {
@@ -393,7 +431,44 @@ describe("StringField", () => {
       const monthOptions = node.querySelectorAll("select#root_month option");
       const monthOptionsLabels = [].map.call(monthOptions, option => option.text);
       expect(monthOptionsLabels).eql([
-        "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]);
+        "month", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]);
+    });
+
+    describe("Action buttons", () => {
+      it("should render a action buttons", () => {
+        const {node} = createFormComponent({schema: {
+          type: "string",
+          format: "date-time",
+        }, uiSchema});
+
+        const buttonLabels = [].map.call(node.querySelectorAll("a.btn"),
+                                         x => x.textContent);
+        expect(buttonLabels).eql(["Now", "Clear"]);
+      });
+
+      it("should set current date when pressing the Now button", () => {
+        const {comp, node} = createFormComponent({schema: {
+          type: "string",
+          format: "date-time",
+        }, uiSchema});
+
+        return SimulateAsync().click(node.querySelector("a.btn-now"))
+          .then(() => {
+            const expected = toDateString(parseDateString(new Date().toJSON(), false));
+            expect(comp.state.formData).eql(expected);
+          });
+      });
+
+      it("should clear current date when pressing the Clear button", () => {
+        const {comp, node} = createFormComponent({schema: {
+          type: "string",
+          format: "date-time",
+        }, uiSchema});
+
+        return SimulateAsync().click(node.querySelector("a.btn-now"))
+          .then(() => SimulateAsync().click(node.querySelector("a.btn-clear")))
+          .then(() => expect(comp.state.formData).eql(undefined));
+      });
     });
   });
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -520,6 +520,28 @@ describe("utils", () => {
         .to.Throw(Error, "Unable to parse");
     });
 
+    it("should return a default object when no datetime is passed", () => {
+      expect(parseDateString()).eql({
+        "year": -1,
+        "month": -1,
+        "day": -1,
+        "hour": -1,
+        "minute": -1,
+        "second": -1,
+      });
+    });
+
+    it("should return a default object when time should not be included", () => {
+      expect(parseDateString(undefined, false)).eql({
+        "year": -1,
+        "month": -1,
+        "day": -1,
+        "hour": 0,
+        "minute": 0,
+        "second": 0,
+      });
+    });
+
     it("should parse a valid JSON datetime string", () => {
       expect(parseDateString("2016-04-05T14:01:30.182Z"))
         .eql({


### PR DESCRIPTION
Atm we render date widgets with current date by default, but this rendered value isn't populated to state; so it needs user interaction for the current date to be taken into account. We need to fix that.

We should allow the user to leave the field blank when a date field isn't required. Basically right now rendered widgets are decorellated from actual form data state, which is confusing and likely to introduce mistakes.

So I think we should add new blank `option`s to every date widget selects, so by default we:

- allow users to leave these blank, so no value at all is assigned to the formData associated with the field (useful when the field is *not* required);
- allow users to explicitly start entering the actual value they want, and reflect this value to state.

We might also consider adding "Now" links to allow easily populate these fields to the current date/time with a single explicit click, as well as a "Clear" button to allow resetting the widget to an undefined value.

Later on, probably when we'll get widget options, we shall add an option to allow setting the value to the current date by default. Alternatively we could add new `AutoDateWidget` and `AutoDateTimeWidget` with appropriate aliases to use for `ui:widget`, eg. `auto-date` and `auto-datetime`.

For now one will have to click the newly introduced "Now" button.