### PR TITLE
Improved async rendering strategy

### DIFF
--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -7,6 +7,7 @@ import ordering from "./ordering";
 import references from "./references";
 import custom from "./custom";
 import errors from "./errors";
+import large from "./large";
 
 export const samples = {
   Simple: simple,
@@ -18,4 +19,5 @@ export const samples = {
   References: references,
   Custom: custom,
   Errors: errors,
+  Large: large,
 };

--- a/playground/samples/large.js
+++ b/playground/samples/large.js
@@ -1,0 +1,32 @@
+function largeEnum(n) {
+  const list = [];
+  for (let i=0; i<n;i++) {
+    list.push("option #" + i);
+  }
+  return list;
+}
+
+module.exports = {
+  schema: {
+    title: "A rather large form",
+    type: "object",
+    properties: {
+      string: {
+        type: "string",
+        title: "Some string",
+      },
+      choice1: {type: "string", enum: largeEnum(100)},
+      choice2: {type: "string", enum: largeEnum(100)},
+      choice3: {type: "string", enum: largeEnum(100)},
+      choice4: {type: "string", enum: largeEnum(100)},
+      choice5: {type: "string", enum: largeEnum(100)},
+      choice6: {type: "string", enum: largeEnum(100)},
+      choice7: {type: "string", enum: largeEnum(100)},
+      choice8: {type: "string", enum: largeEnum(100)},
+      choice9: {type: "string", enum: largeEnum(100)},
+      choice10: {type: "string", enum: largeEnum(100)},
+    }
+  },
+  uiSchema: {},
+  formData: {}
+};

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -67,7 +67,8 @@ export default class Form extends Component {
       formData,
       errors,
       errorSchema
-    }, _ => {
+    });
+    setImmediate(() => {
       if (this.props.onChange) {
         this.props.onChange(this.state);
       }
@@ -80,7 +81,8 @@ export default class Form extends Component {
     const errors = this.validate(this.state.formData);
     if (Object.keys(errors).length > 0) {
       const errorSchema = toErrorSchema(errors);
-      this.setState({errors, errorSchema}, _ => {
+      this.setState({errors, errorSchema});
+      setImmediate(() => {
         if (this.props.onError) {
           this.props.onError(errors);
         } else {

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -52,8 +52,8 @@ class ArrayField extends Component {
   }
 
   asyncSetState(state, options) {
-    // ensure state is propagated to parent component when it's actually set
-    this.setState(state, _ => this.props.onChange(this.state.items, options));
+    this.setState(state);
+    setImmediate(() => this.props.onChange(this.state.items, options));
   }
 
   onAddClick = (event) => {

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -42,8 +42,8 @@ class ObjectField extends Component {
   }
 
   asyncSetState(state) {
-    // ensure state is propagated to parent component when it's actually set
-    this.setState(state, _ => this.props.onChange(this.state));
+    this.setState(state);
+    setImmediate(() => this.props.onChange(this.state));
   }
 
   onPropertyChange = (name) => {

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -1,7 +1,6 @@
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox } from "./test_utils";
+import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
 
 
 describe("ArrayField", () => {
@@ -53,10 +52,11 @@ describe("ArrayField", () => {
     it("should add a new field when clicking the add button", () => {
       const {node} = createFormComponent({schema});
 
-      Simulate.click(node.querySelector(".array-item-add button"));
-
-      expect(node.querySelectorAll(".field-string"))
-        .to.have.length.of(1);
+      return SimulateAsync().click(node.querySelector(".array-item-add button"))
+        .then(() => {
+          expect(node.querySelectorAll(".field-string"))
+            .to.have.length.of(1);
+        });
     });
 
     it("should fill an array field with data", () => {
@@ -72,11 +72,12 @@ describe("ArrayField", () => {
       const {node} = createFormComponent({schema, formData: ["foo", "bar"]});
       const dropBtns = node.querySelectorAll(".array-item-remove button");
 
-      Simulate.click(dropBtns[0]);
-
-      const inputs = node.querySelectorAll(".field-string input[type=text]");
-      expect(inputs).to.have.length.of(1);
-      expect(inputs[0].value).eql("bar");
+      return SimulateAsync().click(dropBtns[0])
+        .then(() => {
+          const inputs = node.querySelectorAll(".field-string input[type=text]");
+          expect(inputs).to.have.length.of(1);
+          expect(inputs[0].value).eql("bar");
+        });
     });
 
     it("should render the input widgets with the expected ids", () => {
@@ -161,15 +162,14 @@ describe("ArrayField", () => {
     it("should handle a change event", () => {
       const {comp, node} = createFormComponent({schema});
 
-      Simulate.change(node.querySelector(".field select"), {
+      return SimulateAsync().change(node.querySelector(".field select"), {
         target: {options: [
           {selected: true, value: "foo"},
           {selected: true, value: "bar"},
           {selected: false, value: "fuzz"},
         ]}
-      });
-
-      expect(comp.state.formData).eql(["foo", "bar"]);
+      })
+        .then(() => expect(comp.state.formData).eql(["foo", "bar"]));
     });
 
     it("should fill field with data", () => {
@@ -210,8 +210,11 @@ describe("ArrayField", () => {
     it("should add an inner list when clicking the add button", () => {
       const {node} = createFormComponent({schema});
       expect(node.querySelectorAll("fieldset fieldset")).to.be.empty;
-      Simulate.click(node.querySelector(".array-item-add button"));
-      expect(node.querySelectorAll("fieldset fieldset")).to.have.length.of(1);
+
+      return SimulateAsync().click(node.querySelector(".array-item-add button"))
+        .then(() => {
+          expect(node.querySelectorAll("fieldset fieldset")).to.have.length.of(1);
+        });
     });
   });
 
@@ -230,7 +233,7 @@ describe("ArrayField", () => {
         }
       ]
     };
-    
+
     const schemaAdditional = {
       type: "array",
       title: "List of fixed items",
@@ -249,7 +252,7 @@ describe("ArrayField", () => {
         title: "Additional item"
       }
     };
-    
+
     it("should render a fieldset", () => {
       const {node} = createFormComponent({schema});
 
@@ -291,14 +294,9 @@ describe("ArrayField", () => {
       const numInput =
           node.querySelector("fieldset .field-number input[type=text]");
 
-      Simulate.change(strInput, {
-        target: { value: "bar" }
-      });
-      Simulate.change(numInput, {
-        target: { value: "101" }
-      });
-
-      expect(comp.state.formData).eql(["bar", 101]);
+      return SimulateAsync().change(strInput, {target: { value: "bar" }})
+        .then(() => SimulateAsync().change(numInput, {target: { value: "101" }}))
+        .then(() => expect(comp.state.formData).eql(["bar", 101]));
     });
 
     it("should generate additional fields and fill data", () => {
@@ -320,36 +318,37 @@ describe("ArrayField", () => {
 
       it("should add a field when clicking add button", () => {
         const addBtn = node.querySelector(".array-item-add button");
-        
-        Simulate.click(addBtn);
-        
-        expect(node.querySelectorAll(".field-string")).to.have.length.of(2);
-        expect(comp.state.formData).eql([1, 2, "foo", undefined]);
+
+        return SimulateAsync().click(addBtn)
+          .then(() => {
+            expect(node.querySelectorAll(".field-string")).to.have.length.of(2);
+            expect(comp.state.formData).eql([1, 2, "foo", undefined]);
+          });
       });
-      
+
       it("should change the state when changing input value", () => {
         const inputs = node.querySelectorAll(".field-string input[type=text]");
-        
-        Simulate.change(inputs[0], {target: {value: "bar"}});
-        Simulate.change(inputs[1], {target: {value: "baz"}});
-        
-        expect(comp.state.formData).eql([1, 2, "bar", "baz"]);
+
+        return SimulateAsync().change(inputs[0], {target: {value: "bar"}})
+          .then(() => SimulateAsync().change(inputs[1], {target: {value: "baz"}}))
+          .then(() => expect(comp.state.formData).eql([1, 2, "bar", "baz"]));
       });
-      
+
       it("should remove array items when clicking remove buttons", () => {
         let dropBtns = node.querySelectorAll(".array-item-remove button");
-        
-        Simulate.click(dropBtns[0]);
-        
-        expect(node.querySelectorAll(".field-string")).to.have.length.of(1);
-        expect(comp.state.formData).eql([1, 2, "baz"]);
-        
-        dropBtns = node.querySelectorAll(".array-item-remove button");
-        
-        Simulate.click(dropBtns[0]);
-        
-        expect(node.querySelectorAll(".field-string")).to.be.empty;
-        expect(comp.state.formData).eql([1, 2]);
+
+        return SimulateAsync().click(dropBtns[0])
+          .then(() => {
+            expect(node.querySelectorAll(".field-string")).to.have.length.of(1);
+            expect(comp.state.formData).eql([1, 2, "baz"]);
+
+            dropBtns = node.querySelectorAll(".array-item-remove button");
+            return SimulateAsync().click(dropBtns[0]);
+          })
+          .then(() => {
+            expect(node.querySelectorAll(".field-string")).to.be.empty;
+            expect(comp.state.formData).eql([1, 2]);
+          });
       });
     });
   });

--- a/test/BooleanField_test.js
+++ b/test/BooleanField_test.js
@@ -1,7 +1,6 @@
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox } from "./test_utils";
+import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
 
 
 describe("BooleanField", () => {
@@ -66,11 +65,9 @@ describe("BooleanField", () => {
       default: false,
     }});
 
-    Simulate.change(node.querySelector("input"), {
+    return SimulateAsync().change(node.querySelector("input"), {
       target: {checked: true}
-    });
-
-    expect(comp.state.formData).eql(true);
+    }).then(() => expect(comp.state.formData).eql(true));
   });
 
   it("should fill field with data", () => {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1,11 +1,11 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import React from "react";
-import { Simulate, renderIntoDocument } from "react-addons-test-utils";
+import { renderIntoDocument } from "react-addons-test-utils";
 import { findDOMNode } from "react-dom";
 
 import Form from "../src";
-import { createFormComponent, createSandbox } from "./test_utils";
+import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
 
 
 describe("Form", () => {
@@ -197,10 +197,11 @@ describe("Form", () => {
 
       const {node} = createFormComponent({schema});
 
-      Simulate.click(node.querySelector(".array-item-add button"));
-
-      expect(node.querySelector("input[type=text]").value)
-        .eql("hello");
+      return SimulateAsync().click(node.querySelector(".array-item-add button"))
+        .then(() => {
+          expect(node.querySelector("input[type=text]").value)
+            .eql("hello");
+        });
     });
 
     it("should priorize definition over schema type property", () => {
@@ -261,18 +262,19 @@ describe("Form", () => {
     it("should propagate deeply nested defaults to form state", () => {
       const {comp, node} = createFormComponent({schema});
 
-      Simulate.click(node.querySelector(".array-item-add button"));
-      Simulate.submit(node);
-
-      expect(comp.state.formData).eql({
-        object: {
-          array: [
-            {
-              bool: true
+      return SimulateAsync().click(node.querySelector(".array-item-add button"))
+        .then(() => SimulateAsync().submit(node))
+        .then(() => {
+          expect(comp.state.formData).eql({
+            object: {
+              array: [
+                {
+                  bool: true
+                }
+              ]
             }
-          ]
-        }
-      });
+          });
+        });
     });
   });
 
@@ -297,7 +299,7 @@ describe("Form", () => {
         comp = compInfo.comp;
         node = compInfo.node;
 
-        Simulate.submit(node);
+        return SimulateAsync().submit(node);
       });
 
       it("should validate a required field", () => {
@@ -343,7 +345,7 @@ describe("Form", () => {
         comp = compInfo.comp;
         node = compInfo.node;
 
-        Simulate.submit(node);
+        return SimulateAsync().submit(node);
       });
 
       it("should validate a minLength field", () => {
@@ -383,9 +385,10 @@ describe("Form", () => {
       const onSubmit = sandbox.spy();
       const {comp, node} = createFormComponent({schema, formData, onSubmit});
 
-      Simulate.submit(node);
-
-      sinon.assert.calledWithExactly(onSubmit, comp.state);
+      return SimulateAsync().submit(node)
+        .then(() => {
+          sinon.assert.calledWithExactly(onSubmit, comp.state);
+        });
     });
 
     it("should not call provided submit handler on validation errors", () => {
@@ -405,9 +408,10 @@ describe("Form", () => {
       const onError = sandbox.spy();
       const {node} = createFormComponent({schema, formData, onSubmit, onError});
 
-      Simulate.submit(node);
-
-      sinon.assert.notCalled(onSubmit);
+      return SimulateAsync().submit(node)
+        .then(() => {
+          sinon.assert.notCalled(onSubmit);
+        });
     });
   });
 
@@ -427,15 +431,16 @@ describe("Form", () => {
       const onChange = sandbox.spy();
       const {node} = createFormComponent({schema, formData, onChange});
 
-      Simulate.change(node.querySelector("[type=text]"), {
+      return SimulateAsync().change(node.querySelector("[type=text]"), {
         target: {value: "new"}
-      });
-
-      sinon.assert.calledWithMatch(onChange, {
-        formData: {
-          foo: "new"
-        }
-      });
+      })
+        .then(() => {
+          sinon.assert.calledWithMatch(onChange, {
+            formData: {
+              foo: "new"
+            }
+          });
+        });
     });
   });
 
@@ -456,9 +461,10 @@ describe("Form", () => {
       const onError = sandbox.spy();
       const {node} = createFormComponent({schema, formData, onError});
 
-      Simulate.submit(node);
-
-      sinon.assert.calledOnce(onError);
+      return SimulateAsync().submit(node)
+        .then(() => {
+          sinon.assert.calledOnce(onError);
+        });
     });
   });
 
@@ -535,22 +541,22 @@ describe("Form", () => {
         it("should not update the errorSchema when the formData changes", () => {
           const {comp, node} = createFormComponent({schema});
 
-          Simulate.change(node.querySelector("input[type=text]"), {
+          return SimulateAsync().change(node.querySelector("input[type=text]"), {
             target: {value: "short"}
-          });
-
-          expect(comp.state.errorSchema).eql({});
+          })
+            .then(() => expect(comp.state.errorSchema).eql({}));
         });
 
         it("should not denote an error in the field", () => {
           const {node} = createFormComponent({schema});
 
-          Simulate.change(node.querySelector("input[type=text]"), {
+          return SimulateAsync().change(node.querySelector("input[type=text]"), {
             target: {value: "short"}
-          });
-
-          expect(node.querySelectorAll(".field-error"))
-            .to.have.length.of(0);
+          })
+            .then(() => {
+              expect(node.querySelectorAll(".field-error"))
+                .to.have.length.of(0);
+            });
         });
       });
 
@@ -558,26 +564,28 @@ describe("Form", () => {
         it("should update the errorSchema when the formData changes", () => {
           const {comp, node} = createFormComponent({schema, liveValidate: true});
 
-          Simulate.change(node.querySelector("input[type=text]"), {
+          return SimulateAsync().change(node.querySelector("input[type=text]"), {
             target: {value: "short"}
-          });
-
-          expect(comp.state.errorSchema).eql({
-            errors: ["does not meet minimum length of 8"]
-          });
+          })
+            .then(() => {
+              expect(comp.state.errorSchema).eql({
+                errors: ["does not meet minimum length of 8"]
+              });
+            });
         });
 
         it("should denote the new error in the field", () => {
           const {node} = createFormComponent({schema, liveValidate: true});
 
-          Simulate.change(node.querySelector("input[type=text]"), {
+          return SimulateAsync().change(node.querySelector("input[type=text]"), {
             target: {value: "short"}
-          });
-
-          expect(node.querySelectorAll(".field-error"))
-            .to.have.length.of(1);
-          expect(node.querySelector(".field-string .error-detail").textContent)
-            .eql("does not meet minimum length of 8");
+          })
+            .then(() => {
+              expect(node.querySelectorAll(".field-error"))
+                .to.have.length.of(1);
+              expect(node.querySelector(".field-string .error-detail").textContent)
+                .eql("does not meet minimum length of 8");
+            });
         });
       });
     });
@@ -591,31 +599,31 @@ describe("Form", () => {
       it("should update the errorSchema on form submission", () => {
         const {comp, node} = createFormComponent({schema, onError: () => {}});
 
-        Simulate.change(node.querySelector("input[type=text]"), {
+        return SimulateAsync().change(node.querySelector("input[type=text]"), {
           target: {value: "short"}
-        });
-
-        Simulate.submit(node);
-
-        expect(comp.state.errorSchema).eql({
-          errors: ["does not meet minimum length of 8"]
-        });
+        })
+          .then(() => SimulateAsync().submit(node))
+          .then(() => {
+            expect(comp.state.errorSchema).eql({
+              errors: ["does not meet minimum length of 8"]
+            });
+          });
       });
 
       it("should call the onError handler", () => {
         const onError = sandbox.spy();
         const {node} = createFormComponent({schema, onError});
 
-        Simulate.change(node.querySelector("input[type=text]"), {
+        return SimulateAsync().change(node.querySelector("input[type=text]"), {
           target: {value: "short"}
-        });
-
-        Simulate.submit(node);
-
-        sinon.assert.calledWithMatch(onError, sinon.match(value => {
-          return value.length === 1 &&
-                 value[0].message === "does not meet minimum length of 8";
-        }));
+        })
+          .then(() => SimulateAsync().submit(node))
+          .then(() => {
+            sinon.assert.calledWithMatch(onError, sinon.match(value => {
+              return value.length === 1 &&
+                     value[0].message === "does not meet minimum length of 8";
+            }));
+          });
       });
     });
 

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -1,7 +1,6 @@
 import { expect } from "chai";
-import { Simulate} from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox } from "./test_utils";
+import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
 
 
 describe("NumberField", () => {
@@ -66,11 +65,10 @@ describe("NumberField", () => {
         type: "number",
       }});
 
-      Simulate.change(node.querySelector("input"), {
+      return SimulateAsync().change(node.querySelector("input"), {
         target: {value: "2"}
-      });
-
-      expect(comp.state.formData).eql(2);
+      })
+        .then(() => expect(comp.state.formData).eql(2));
     });
 
     it("should fill field with data", () => {
@@ -87,11 +85,10 @@ describe("NumberField", () => {
         type: "number",
       }});
 
-      Simulate.change(node.querySelector("input"), {
+      return SimulateAsync().change(node.querySelector("input"), {
         target: {value: "2."}
-      });
-
-      expect(comp.state.formData).eql("2.");
+      })
+        .then(() => expect(comp.state.formData).eql("2."));
     });
 
     it("should render the widget with the expected id", () => {
@@ -153,11 +150,10 @@ describe("NumberField", () => {
         enum: [1, 2],
       }});
 
-      Simulate.change(node.querySelector("select"), {
+      return SimulateAsync().change(node.querySelector("select"), {
         target: {value: "2"}
-      });
-
-      expect(comp.state.formData).eql(2);
+      })
+        .then(() => expect(comp.state.formData).eql(2));
     });
 
     it("should fill field with data", () => {

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -1,8 +1,7 @@
 import React from "react";
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox } from "./test_utils";
+import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
 
 
 describe("ObjectField", () => {
@@ -113,11 +112,10 @@ describe("ObjectField", () => {
     it("should handle object fields change events", () => {
       const {comp, node} = createFormComponent({schema});
 
-      Simulate.change(node.querySelector("input[type=text]"), {
+      return SimulateAsync().change(node.querySelector("input[type=text]"), {
         target: {value: "changed"}
-      });
-
-      expect(comp.state.formData.foo).eql("changed");
+      })
+        .then(() => expect(comp.state.formData.foo).eql("changed"));
     });
 
     it("should render the widget with the expected id", () => {

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -1,7 +1,6 @@
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox } from "./test_utils";
+import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
 
 
 describe("StringField", () => {
@@ -66,11 +65,9 @@ describe("StringField", () => {
         type: "string",
       }});
 
-      Simulate.change(node.querySelector("input"), {
+      return SimulateAsync().change(node.querySelector("input"), {
         target: {value: "yo"}
-      });
-
-      expect(comp.state.formData).eql("yo");
+      }).then(() => expect(comp.state.formData).eql("yo"));
     });
 
     it("should fill field with data", () => {
@@ -141,11 +138,9 @@ describe("StringField", () => {
         enum: ["foo", "bar"],
       }});
 
-      Simulate.change(node.querySelector("select"), {
+      return SimulateAsync().change(node.querySelector("select"), {
         target: {value: "foo"}
-      });
-
-      expect(comp.state.formData).eql("foo");
+      }).then(() => expect(comp.state.formData).eql("foo"));
     });
 
     it("should reflect the change into the dom", () => {
@@ -154,11 +149,9 @@ describe("StringField", () => {
         enum: ["foo", "bar"],
       }});
 
-      Simulate.change(node.querySelector("select"), {
+      return SimulateAsync().change(node.querySelector("select"), {
         target: {value: "foo"}
-      });
-
-      expect(node.querySelector("select").value).eql("foo");
+      }).then(() => expect(node.querySelector("select").value).eql("foo"));
     });
 
     it("should fill field with data", () => {
@@ -220,14 +213,17 @@ describe("StringField", () => {
         format: "date-time",
       }});
 
-      Simulate.change(node.querySelector("#root_year"), {target: {value: "2012"}});
-      Simulate.change(node.querySelector("#root_month"), {target: {value: "10"}});
-      Simulate.change(node.querySelector("#root_day"), {target: {value: "2"}});
-      Simulate.change(node.querySelector("#root_hour"), {target: {value: "1"}});
-      Simulate.change(node.querySelector("#root_minute"), {target: {value: "2"}});
-      Simulate.change(node.querySelector("#root_second"), {target: {value: "3"}});
-
-      expect(comp.state.formData).eql("2012-10-02T01:02:03.000Z");
+      return Promise.all([
+        SimulateAsync().change(node.querySelector("#root_year"), {target: {value: "2012"}}),
+        SimulateAsync().change(node.querySelector("#root_month"), {target: {value: "10"}}),
+        SimulateAsync().change(node.querySelector("#root_day"), {target: {value: "2"}}),
+        SimulateAsync().change(node.querySelector("#root_hour"), {target: {value: "1"}}),
+        SimulateAsync().change(node.querySelector("#root_minute"), {target: {value: "2"}}),
+        SimulateAsync().change(node.querySelector("#root_second"), {target: {value: "3"}}),
+      ])
+        .then(() => {
+          expect(comp.state.formData).eql("2012-10-02T01:02:03.000Z");
+        });
     });
 
     it("should fill field with data", () => {
@@ -334,11 +330,14 @@ describe("StringField", () => {
         format: "date-time",
       }, uiSchema});
 
-      Simulate.change(node.querySelector("#root_year"), {target: {value: "2012"}});
-      Simulate.change(node.querySelector("#root_month"), {target: {value: "10"}});
-      Simulate.change(node.querySelector("#root_day"), {target: {value: "2"}});
-
-      expect(comp.state.formData).eql("2012-10-02T00:00:00.000Z");
+      return Promise.all([
+        SimulateAsync().change(node.querySelector("#root_year"), {target: {value: "2012"}}),
+        SimulateAsync().change(node.querySelector("#root_month"), {target: {value: "10"}}),
+        SimulateAsync().change(node.querySelector("#root_day"), {target: {value: "2"}}),
+      ])
+        .then(() => {
+          expect(comp.state.formData).eql("2012-10-02T00:00:00.000Z");
+        });
     });
 
     it("should fill field with data", () => {
@@ -449,11 +448,10 @@ describe("StringField", () => {
       }});
 
       const newDatetime = new Date().toJSON();
-      Simulate.change(node.querySelector("[type=email]"), {
+      return SimulateAsync().change(node.querySelector("[type=email]"), {
         target: {value: newDatetime}
-      });
-
-      expect(node.querySelector("[type=email]").value).eql(newDatetime);
+      })
+        .then(() => expect(node.querySelector("[type=email]").value).eql(newDatetime));
     });
 
     it("should fill field with data", () => {
@@ -482,11 +480,10 @@ describe("StringField", () => {
         format: "email",
       }, liveValidate: true});
 
-      Simulate.change(node.querySelector("[type=email]"), {
+      return SimulateAsync().change(node.querySelector("[type=email]"), {
         target: {value: "invalid"}
-      });
-
-      expect(comp.state.errors).to.have.length.of(1);
+      })
+        .then(() => expect(comp.state.errors).to.have.length.of(1));
     });
   });
 
@@ -541,11 +538,10 @@ describe("StringField", () => {
       }});
 
       const newDatetime = new Date().toJSON();
-      Simulate.change(node.querySelector("[type=url]"), {
+      return SimulateAsync().change(node.querySelector("[type=url]"), {
         target: {value: newDatetime}
-      });
-
-      expect(node.querySelector("[type=url]").value).eql(newDatetime);
+      })
+        .then(() => expect(node.querySelector("[type=url]").value).eql(newDatetime));
     });
 
     it("should fill field with data", () => {
@@ -574,11 +570,10 @@ describe("StringField", () => {
         format: "uri",
       }, liveValidate: true});
 
-      Simulate.change(node.querySelector("[type=url]"), {
+      return SimulateAsync().change(node.querySelector("[type=url]"), {
         target: {value: "invalid"}
-      });
-
-      expect(comp.state.errors).to.have.length.of(1);
+      })
+        .then(() => expect(comp.state.errors).to.have.length.of(1));
     });
   });
 });

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -4,6 +4,7 @@ import React from "react";
 import sinon from "sinon";
 import { renderIntoDocument } from "react-addons-test-utils";
 import { findDOMNode } from "react-dom";
+import { Simulate } from "react-addons-test-utils";
 
 import Form from "../src";
 
@@ -24,4 +25,21 @@ export function createSandbox() {
     throw new Error(error);
   });
   return sandbox;
+}
+
+export function SimulateAsync(delay = 15) {
+  return Object.keys(Simulate).reduce((acc, key) => {
+    const prop = Simulate[key];
+    if (typeof prop === "function") {
+      acc[key] = (...args) => {
+        return new Promise((resolve) => {
+          Simulate[key](...args);
+          setTimeout(resolve, delay);
+        });
+      };
+    } else {
+      acc[key] = prop;
+    }
+    return acc;
+  }, {});
 }

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -1,8 +1,7 @@
 import { expect } from "chai";
 import React from "react";
-import { Simulate } from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox } from "./test_utils";
+import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
 
 
 describe("uiSchema", () => {
@@ -154,11 +153,10 @@ describe("uiSchema", () => {
           foo: "a"
         }});
 
-        Simulate.change(node.querySelector("textarea"), {
+        return SimulateAsync().change(node.querySelector("textarea"), {
           target: {value: "b"}
-        });
-
-        expect(comp.state.formData).eql({foo: "b"});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: "b"}));
       });
     });
 
@@ -190,11 +188,10 @@ describe("uiSchema", () => {
           foo: "a"
         }});
 
-        Simulate.change(node.querySelector("[type=password]"), {
+        return SimulateAsync().change(node.querySelector("[type=password]"), {
           target: {value: "b"}
-        });
-
-        expect(comp.state.formData).eql({foo: "b"});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: "b"}));
       });
     });
 
@@ -270,11 +267,10 @@ describe("uiSchema", () => {
           foo: "a"
         }});
 
-        Simulate.change(node.querySelectorAll("[type=radio]")[1], {
+        return SimulateAsync().change(node.querySelectorAll("[type=radio]")[1], {
           target: {checked: true}
-        });
-
-        expect(comp.state.formData).eql({foo: "b"});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: "b"}));
       });
     });
   });
@@ -317,11 +313,10 @@ describe("uiSchema", () => {
           foo: 3.14
         }});
 
-        Simulate.change(node.querySelector("[type=number]"), {
+        return SimulateAsync().change(node.querySelector("[type=number]"), {
           target: {value: "6.28"}
-        });
-
-        expect(comp.state.formData).eql({foo: 6.28});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: 6.28}));
       });
     });
 
@@ -353,11 +348,10 @@ describe("uiSchema", () => {
           foo: 3.14
         }});
 
-        Simulate.change(node.querySelector("[type=range]"), {
+        return SimulateAsync().change(node.querySelector("[type=range]"), {
           target: {value: "6.28"}
-        });
-
-        expect(comp.state.formData).eql({foo: 6.28});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: 6.28}));
       });
     });
 
@@ -432,11 +426,10 @@ describe("uiSchema", () => {
           foo: 3
         }});
 
-        Simulate.change(node.querySelector("[type=number]"), {
+        return SimulateAsync().change(node.querySelector("[type=number]"), {
           target: {value: "6"}
-        });
-
-        expect(comp.state.formData).eql({foo: 6});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: 6}));
       });
     });
 
@@ -468,11 +461,10 @@ describe("uiSchema", () => {
           foo: 3
         }});
 
-        Simulate.change(node.querySelector("[type=range]"), {
+        return SimulateAsync().change(node.querySelector("[type=range]"), {
           target: {value: "6"}
-        });
-
-        expect(comp.state.formData).eql({foo: 6});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: 6}));
       });
     });
 
@@ -561,11 +553,10 @@ describe("uiSchema", () => {
           foo: true
         }});
 
-        Simulate.change(node.querySelectorAll("[type=radio]")[1], {
+        return SimulateAsync().change(node.querySelectorAll("[type=radio]")[1], {
           target: {checked: true}
-        });
-
-        expect(comp.state.formData).eql({foo: false});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: false}));
       });
 
       it("should update state when true is checked", () => {
@@ -573,11 +564,10 @@ describe("uiSchema", () => {
           foo: false
         }});
 
-        Simulate.change(node.querySelectorAll("[type=radio]")[0], {
+        return SimulateAsync().change(node.querySelectorAll("[type=radio]")[0], {
           target: {checked: true}
-        });
-
-        expect(comp.state.formData).eql({foo: true});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: true}));
       });
     });
 
@@ -609,12 +599,11 @@ describe("uiSchema", () => {
           foo: false
         }});
 
-        Simulate.change(node.querySelector("select"), {
+        return SimulateAsync().change(node.querySelector("select"), {
           // DOM option change events always return strings
           target: {value: "true"}
-        });
-
-        expect(comp.state.formData).eql({foo: true});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: true}));
       });
 
       it("should update state when false is selected", () => {
@@ -622,12 +611,11 @@ describe("uiSchema", () => {
           foo: false
         }});
 
-        Simulate.change(node.querySelector("select"), {
+        return SimulateAsync().change(node.querySelector("select"), {
           // DOM option change events always return strings
           target: {value: "false"}
-        });
-
-        expect(comp.state.formData).eql({foo: false});
+        })
+          .then(() => expect(comp.state.formData).eql({foo: false}));
       });
     });
 


### PR DESCRIPTION
This supersedes #152 trying to address #147.

This patch updates our approach for dealing with asynchronous state propagation from field components to their parent; previously we were waiting for setState issued renderings to be fully processed before starting propagating changes upstream. This new approach brings a perceivable performance boost as we're now propagating nearly immediately making the UI much more responsive; definitely an improvement while we're probably not entirely done in the performances improvement area.

I had to update our tests accordingly, hence introducing a new `SimulateAsync` test helper for ensuring that we wait an appropriate amount of time before checking for async rendes to be fully rendered after DOM events triggering them have been fired.

/cc @kaihendry

r=? @leplatrem   