### PR TITLE
Added a safeRenderCompletion to ease testing.

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -7,7 +7,8 @@ import {
   getDefaultFormState,
   shouldRender,
   toErrorSchema,
-  toIdSchema
+  toIdSchema,
+  setState
 } from "../utils";
 import ErrorList from "./ErrorList";
 
@@ -16,6 +17,7 @@ export default class Form extends Component {
   static defaultProps = {
     uiSchema: {},
     liveValidate: false,
+    safeRenderCompletion: false,
   }
 
   constructor(props) {
@@ -62,13 +64,12 @@ export default class Form extends Component {
     const errors = liveValidate ? this.validate(formData) :
                                   this.state.errors;
     const errorSchema = toErrorSchema(errors);
-    this.setState({
+    setState(this, {
       status: "editing",
       formData,
       errors,
       errorSchema
-    });
-    setImmediate(() => {
+    }, () => {
       if (this.props.onChange) {
         this.props.onChange(this.state);
       }
@@ -81,8 +82,7 @@ export default class Form extends Component {
     const errors = this.validate(this.state.formData);
     if (Object.keys(errors).length > 0) {
       const errorSchema = toErrorSchema(errors);
-      this.setState({errors, errorSchema});
-      setImmediate(() => {
+      setState(this, {errors, errorSchema}, () => {
         if (this.props.onError) {
           this.props.onError(errors);
         } else {
@@ -113,7 +113,7 @@ export default class Form extends Component {
   }
 
   render() {
-    const {children, schema, uiSchema} = this.props;
+    const {children, schema, uiSchema, safeRenderCompletion} = this.props;
     const {formData, errorSchema, idSchema} = this.state;
     const registry = this.getRegistry();
     const _SchemaField = registry.fields.SchemaField;
@@ -127,7 +127,8 @@ export default class Form extends Component {
           idSchema={idSchema}
           formData={formData}
           onChange={this.onChange}
-          registry={registry}/>
+          registry={registry}
+          safeRenderCompletion={safeRenderCompletion} />
         { children ? children :
           <p>
             <button type="submit" className="btn btn-info">Submit</button>
@@ -148,6 +149,7 @@ if (process.env.NODE_ENV !== "production") {
     onError: PropTypes.func,
     onSubmit: PropTypes.func,
     liveValidate: PropTypes.bool,
+    safeRenderCompletion: PropTypes.bool,
   };
 }
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -9,7 +9,8 @@ import {
   retrieveSchema,
   toIdSchema,
   shouldRender,
-  getDefaultRegistry
+  getDefaultRegistry,
+  setState
 } from "../../utils";
 import SelectWidget from "./../widgets/SelectWidget";
 
@@ -51,9 +52,10 @@ class ArrayField extends Component {
     return itemsSchema.type === "string" && itemsSchema.minLength > 0;
   }
 
-  asyncSetState(state, options) {
-    this.setState(state);
-    setImmediate(() => this.props.onChange(this.state.items, options));
+  asyncSetState(state) {
+    setState(this, state, () => {
+      this.props.onChange(this.state.items, {validate: false});
+    });
   }
 
   onAddClick = (event) => {
@@ -66,8 +68,10 @@ class ArrayField extends Component {
       itemSchema = schema.additionalItems;
     }
     this.asyncSetState({
-      items: items.concat([getDefaultFormState(itemSchema, undefined, definitions)])
-    }, {validate: false});
+      items: items.concat([
+        getDefaultFormState(itemSchema, undefined, definitions)
+      ])
+    });
   };
 
   onDropIndexClick = (index) => {
@@ -75,7 +79,7 @@ class ArrayField extends Component {
       event.preventDefault();
       this.asyncSetState({
         items: this.state.items.filter((_, i) => i !== index)
-      }, {validate: false});
+      });
     };
   };
 
@@ -85,12 +89,12 @@ class ArrayField extends Component {
         items: this.state.items.map((item, i) => {
           return index === i ? value : item;
         })
-      }, {validate: false});
+      });
     };
   };
 
   onSelectChange = (value) => {
-    this.asyncSetState({items: value}, {validate: false});
+    this.asyncSetState({items: value});
   };
 
   render() {

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -5,7 +5,8 @@ import {
   orderProperties,
   retrieveSchema,
   shouldRender,
-  getDefaultRegistry
+  getDefaultRegistry,
+  setState
 } from "../../utils";
 
 
@@ -42,8 +43,7 @@ class ObjectField extends Component {
   }
 
   asyncSetState(state) {
-    this.setState(state);
-    setImmediate(() => this.props.onChange(this.state));
+    setState(this, state, () => this.props.onChange(this.state));
   }
 
   onPropertyChange = (name) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -358,3 +358,13 @@ export function pad(num, size) {
   }
   return s;
 }
+
+export function setState(instance, state, callback) {
+  const {safeRenderCompletion} = instance.props;
+  if (safeRenderCompletion) {
+    instance.setState(state, callback);
+  } else {
+    instance.setState(state);
+    setImmediate(callback);
+  }
+}

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
+import { Simulate } from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
+import { createFormComponent, createSandbox } from "./test_utils";
 
 
 describe("ArrayField", () => {
@@ -52,11 +53,10 @@ describe("ArrayField", () => {
     it("should add a new field when clicking the add button", () => {
       const {node} = createFormComponent({schema});
 
-      return SimulateAsync().click(node.querySelector(".array-item-add button"))
-        .then(() => {
-          expect(node.querySelectorAll(".field-string"))
-            .to.have.length.of(1);
-        });
+      Simulate.click(node.querySelector(".array-item-add button"));
+
+      expect(node.querySelectorAll(".field-string"))
+        .to.have.length.of(1);
     });
 
     it("should fill an array field with data", () => {
@@ -72,12 +72,11 @@ describe("ArrayField", () => {
       const {node} = createFormComponent({schema, formData: ["foo", "bar"]});
       const dropBtns = node.querySelectorAll(".array-item-remove button");
 
-      return SimulateAsync().click(dropBtns[0])
-        .then(() => {
-          const inputs = node.querySelectorAll(".field-string input[type=text]");
-          expect(inputs).to.have.length.of(1);
-          expect(inputs[0].value).eql("bar");
-        });
+      Simulate.click(dropBtns[0]);
+
+      const inputs = node.querySelectorAll(".field-string input[type=text]");
+      expect(inputs).to.have.length.of(1);
+      expect(inputs[0].value).eql("bar");
     });
 
     it("should render the input widgets with the expected ids", () => {
@@ -162,14 +161,15 @@ describe("ArrayField", () => {
     it("should handle a change event", () => {
       const {comp, node} = createFormComponent({schema});
 
-      return SimulateAsync().change(node.querySelector(".field select"), {
+      Simulate.change(node.querySelector(".field select"), {
         target: {options: [
           {selected: true, value: "foo"},
           {selected: true, value: "bar"},
           {selected: false, value: "fuzz"},
         ]}
-      })
-        .then(() => expect(comp.state.formData).eql(["foo", "bar"]));
+      });
+
+      expect(comp.state.formData).eql(["foo", "bar"]);
     });
 
     it("should fill field with data", () => {
@@ -211,10 +211,9 @@ describe("ArrayField", () => {
       const {node} = createFormComponent({schema});
       expect(node.querySelectorAll("fieldset fieldset")).to.be.empty;
 
-      return SimulateAsync().click(node.querySelector(".array-item-add button"))
-        .then(() => {
-          expect(node.querySelectorAll("fieldset fieldset")).to.have.length.of(1);
-        });
+      Simulate.click(node.querySelector(".array-item-add button"));
+
+      expect(node.querySelectorAll("fieldset fieldset")).to.have.length.of(1);
     });
   });
 
@@ -294,9 +293,10 @@ describe("ArrayField", () => {
       const numInput =
           node.querySelector("fieldset .field-number input[type=text]");
 
-      return SimulateAsync().change(strInput, {target: { value: "bar" }})
-        .then(() => SimulateAsync().change(numInput, {target: { value: "101" }}))
-        .then(() => expect(comp.state.formData).eql(["bar", 101]));
+      Simulate.change(strInput, {target: { value: "bar" }});
+      Simulate.change(numInput, {target: { value: "101" }});
+
+      expect(comp.state.formData).eql(["bar", 101]);
     });
 
     it("should generate additional fields and fill data", () => {
@@ -319,36 +319,34 @@ describe("ArrayField", () => {
       it("should add a field when clicking add button", () => {
         const addBtn = node.querySelector(".array-item-add button");
 
-        return SimulateAsync().click(addBtn)
-          .then(() => {
-            expect(node.querySelectorAll(".field-string")).to.have.length.of(2);
-            expect(comp.state.formData).eql([1, 2, "foo", undefined]);
-          });
+        Simulate.click(addBtn);
+
+        expect(node.querySelectorAll(".field-string")).to.have.length.of(2);
+        expect(comp.state.formData).eql([1, 2, "foo", undefined]);
       });
 
       it("should change the state when changing input value", () => {
         const inputs = node.querySelectorAll(".field-string input[type=text]");
 
-        return SimulateAsync().change(inputs[0], {target: {value: "bar"}})
-          .then(() => SimulateAsync().change(inputs[1], {target: {value: "baz"}}))
-          .then(() => expect(comp.state.formData).eql([1, 2, "bar", "baz"]));
+        Simulate.change(inputs[0], {target: {value: "bar"}});
+        Simulate.change(inputs[1], {target: {value: "baz"}});
+
+        expect(comp.state.formData).eql([1, 2, "bar", "baz"]);
       });
 
       it("should remove array items when clicking remove buttons", () => {
         let dropBtns = node.querySelectorAll(".array-item-remove button");
 
-        return SimulateAsync().click(dropBtns[0])
-          .then(() => {
-            expect(node.querySelectorAll(".field-string")).to.have.length.of(1);
-            expect(comp.state.formData).eql([1, 2, "baz"]);
+        Simulate.click(dropBtns[0]);
 
-            dropBtns = node.querySelectorAll(".array-item-remove button");
-            return SimulateAsync().click(dropBtns[0]);
-          })
-          .then(() => {
-            expect(node.querySelectorAll(".field-string")).to.be.empty;
-            expect(comp.state.formData).eql([1, 2]);
-          });
+        expect(node.querySelectorAll(".field-string")).to.have.length.of(1);
+        expect(comp.state.formData).eql([1, 2, "baz"]);
+
+        dropBtns = node.querySelectorAll(".array-item-remove button");
+        Simulate.click(dropBtns[0]);
+
+        expect(node.querySelectorAll(".field-string")).to.be.empty;
+        expect(comp.state.formData).eql([1, 2]);
       });
     });
   });

--- a/test/BooleanField_test.js
+++ b/test/BooleanField_test.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
+import { Simulate } from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
+import { createFormComponent, createSandbox } from "./test_utils";
 
 
 describe("BooleanField", () => {
@@ -65,9 +66,11 @@ describe("BooleanField", () => {
       default: false,
     }});
 
-    return SimulateAsync().change(node.querySelector("input"), {
+    Simulate.change(node.querySelector("input"), {
       target: {checked: true}
-    }).then(() => expect(comp.state.formData).eql(true));
+    });
+
+    expect(comp.state.formData).eql(true);
   });
 
   it("should fill field with data", () => {

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
+import { Simulate } from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
+import { createFormComponent, createSandbox } from "./test_utils";
 
 
 describe("NumberField", () => {
@@ -65,10 +66,11 @@ describe("NumberField", () => {
         type: "number",
       }});
 
-      return SimulateAsync().change(node.querySelector("input"), {
+      Simulate.change(node.querySelector("input"), {
         target: {value: "2"}
-      })
-        .then(() => expect(comp.state.formData).eql(2));
+      });
+
+      expect(comp.state.formData).eql(2);
     });
 
     it("should fill field with data", () => {
@@ -85,10 +87,11 @@ describe("NumberField", () => {
         type: "number",
       }});
 
-      return SimulateAsync().change(node.querySelector("input"), {
+      Simulate.change(node.querySelector("input"), {
         target: {value: "2."}
-      })
-        .then(() => expect(comp.state.formData).eql("2."));
+      });
+
+      expect(comp.state.formData).eql("2.");
     });
 
     it("should render the widget with the expected id", () => {
@@ -150,10 +153,11 @@ describe("NumberField", () => {
         enum: [1, 2],
       }});
 
-      return SimulateAsync().change(node.querySelector("select"), {
+      Simulate.change(node.querySelector("select"), {
         target: {value: "2"}
-      })
-        .then(() => expect(comp.state.formData).eql(2));
+      });
+
+      expect(comp.state.formData).eql(2);
     });
 
     it("should fill field with data", () => {

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -1,7 +1,8 @@
 import React from "react";
 import { expect } from "chai";
+import { Simulate } from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
+import { createFormComponent, createSandbox } from "./test_utils";
 
 
 describe("ObjectField", () => {
@@ -112,10 +113,11 @@ describe("ObjectField", () => {
     it("should handle object fields change events", () => {
       const {comp, node} = createFormComponent({schema});
 
-      return SimulateAsync().change(node.querySelector("input[type=text]"), {
+      Simulate.change(node.querySelector("input[type=text]"), {
         target: {value: "changed"}
-      })
-        .then(() => expect(comp.state.formData.foo).eql("changed"));
+      });
+
+      expect(comp.state.formData.foo).eql("changed");
     });
 
     it("should render the widget with the expected id", () => {

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -1,7 +1,8 @@
 import { expect } from "chai";
+import { Simulate } from "react-addons-test-utils";
 
 import { parseDateString, toDateString } from "../src/utils";
-import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
+import { createFormComponent, createSandbox } from "./test_utils";
 
 
 describe("StringField", () => {
@@ -66,9 +67,11 @@ describe("StringField", () => {
         type: "string",
       }});
 
-      return SimulateAsync().change(node.querySelector("input"), {
+      Simulate.change(node.querySelector("input"), {
         target: {value: "yo"}
-      }).then(() => expect(comp.state.formData).eql("yo"));
+      });
+
+      expect(comp.state.formData).eql("yo");
     });
 
     it("should fill field with data", () => {
@@ -139,9 +142,11 @@ describe("StringField", () => {
         enum: ["foo", "bar"],
       }});
 
-      return SimulateAsync().change(node.querySelector("select"), {
+      Simulate.change(node.querySelector("select"), {
         target: {value: "foo"}
-      }).then(() => expect(comp.state.formData).eql("foo"));
+      });
+
+      expect(comp.state.formData).eql("foo");
     });
 
     it("should reflect the change into the dom", () => {
@@ -150,9 +155,11 @@ describe("StringField", () => {
         enum: ["foo", "bar"],
       }});
 
-      return SimulateAsync().change(node.querySelector("select"), {
+      Simulate.change(node.querySelector("select"), {
         target: {value: "foo"}
-      }).then(() => expect(node.querySelector("select").value).eql("foo"));
+      });
+
+      expect(node.querySelector("select").value).eql("foo");
     });
 
     it("should fill field with data", () => {
@@ -204,14 +211,14 @@ describe("StringField", () => {
       }});
 
       const newDatetime = new Date().toJSON();
-      return SimulateAsync().change(node.querySelector("[type=datetime-local]"), {
+
+      Simulate.change(node.querySelector("[type=datetime-local]"), {
         target: {value: newDatetime}
-      })
-        .then(() => {
-          return expect(node.querySelector("[type=datetime-local]").value)
-            // XXX import and use conversion helper
-            .eql(newDatetime.slice(0, 19));
-        });
+      });
+
+      expect(node.querySelector("[type=datetime-local]").value)
+        // XXX import and use conversion helper
+        .eql(newDatetime.slice(0, 19));
     });
 
     it("should fill field with data", () => {
@@ -240,10 +247,11 @@ describe("StringField", () => {
         format: "date-time",
       }, liveValidate: true});
 
-      return SimulateAsync().change(node.querySelector("[type=datetime-local]"), {
+      Simulate.change(node.querySelector("[type=datetime-local]"), {
         target: {value: "invalid"}
-      })
-        .then(() => expect(comp.state.errors).to.have.length.of(1));
+      });
+
+      expect(comp.state.errors).to.have.length.of(1);
     });
   });
 
@@ -278,14 +286,14 @@ describe("StringField", () => {
       }, uiSchema});
 
       const newDatetime = new Date().toJSON();
-      return SimulateAsync().change(node.querySelector("[type=date]"), {
+
+      Simulate.change(node.querySelector("[type=date]"), {
         target: {value: newDatetime}
-      })
-        .then(() => {
-          return expect(node.querySelector("[type=date]").value)
-            // XXX import and use conversion helper
-            .eql(newDatetime.slice(0, 10));
-        });
+      });
+
+      expect(node.querySelector("[type=date]").value)
+        // XXX import and use conversion helper
+        .eql(newDatetime.slice(0, 10));
     });
 
     it("should fill field with data", () => {
@@ -314,10 +322,11 @@ describe("StringField", () => {
         format: "date-time",
       }, uiSchema, liveValidate: true});
 
-      return SimulateAsync().change(node.querySelector("[type=date]"), {
+      Simulate.change(node.querySelector("[type=date]"), {
         target: {value: "invalid"}
-      })
-        .then(() => expect(comp.state.errors).to.have.length.of(1));
+      });
+
+      expect(comp.state.errors).to.have.length.of(1);
     });
   });
 
@@ -362,23 +371,14 @@ describe("StringField", () => {
         format: "date-time",
       }, uiSchema});
 
-      return Promise.all([
-        SimulateAsync().change(
-          node.querySelector("#root_year"), {target: {value: 2012}}),
-        SimulateAsync().change(
-          node.querySelector("#root_month"), {target: {value: 10}}),
-        SimulateAsync().change(
-          node.querySelector("#root_day"), {target: {value: 2}}),
-        SimulateAsync().change(
-          node.querySelector("#root_hour"), {target: {value: 1}}),
-        SimulateAsync().change(
-          node.querySelector("#root_minute"), {target: {value: 2}}),
-        SimulateAsync().change(
-          node.querySelector("#root_second"), {target: {value: 3}}),
-      ])
-        .then(() => {
-          expect(comp.state.formData).eql("2012-10-02T01:02:03.000Z");
-        });
+      Simulate.change(node.querySelector("#root_year"), {target: {value: 2012}});
+      Simulate.change(node.querySelector("#root_month"), {target: {value: 10}});
+      Simulate.change(node.querySelector("#root_day"), {target: {value: 2}});
+      Simulate.change(node.querySelector("#root_hour"), {target: {value: 1}});
+      Simulate.change(node.querySelector("#root_minute"), {target: {value: 2}});
+      Simulate.change(node.querySelector("#root_second"), {target: {value: 3}});
+
+      expect(comp.state.formData).eql("2012-10-02T01:02:03.000Z");
     });
 
     it("should fill field with data", () => {
@@ -464,13 +464,12 @@ describe("StringField", () => {
           format: "date-time",
         }, uiSchema});
 
-        return SimulateAsync().click(node.querySelector("a.btn-now"))
-          .then(() => {
-            // Test that the two DATETIMEs are within 5 seconds of each other.
-            const now = new Date().getTime();
-            const timeDiff = now - new Date(comp.state.formData).getTime();
-            expect(timeDiff).to.be.at.most(5000);
-          });
+        Simulate.click(node.querySelector("a.btn-now"));
+
+        // Test that the two DATETIMEs are within 5 seconds of each other.
+        const now = new Date().getTime();
+        const timeDiff = now - new Date(comp.state.formData).getTime();
+        expect(timeDiff).to.be.at.most(5000);
       });
 
       it("should clear current date when pressing the Clear button", () => {
@@ -479,9 +478,10 @@ describe("StringField", () => {
           format: "date-time",
         }, uiSchema});
 
-        return SimulateAsync().click(node.querySelector("a.btn-now"))
-          .then(() => SimulateAsync().click(node.querySelector("a.btn-clear")))
-          .then(() => expect(comp.state.formData).eql(undefined));
+        Simulate.click(node.querySelector("a.btn-now"));
+        Simulate.click(node.querySelector("a.btn-clear"));
+
+        expect(comp.state.formData).eql(undefined);
       });
     });
   });
@@ -527,17 +527,11 @@ describe("StringField", () => {
         format: "date-time",
       }, uiSchema});
 
-      return Promise.all([
-        SimulateAsync().change(
-            node.querySelector("#root_year"), {target: {value: 2012}}),
-        SimulateAsync().change(
-            node.querySelector("#root_month"), {target: {value: 10}}),
-        SimulateAsync().change(
-            node.querySelector("#root_day"), {target: {value: 2}}),
-      ])
-        .then(() => {
-          expect(comp.state.formData).eql("2012-10-02T00:00:00.000Z");
-        });
+      Simulate.change(node.querySelector("#root_year"), {target: {value: 2012}});
+      Simulate.change(node.querySelector("#root_month"), {target: {value: 10}});
+      Simulate.change(node.querySelector("#root_day"), {target: {value: 2}});
+
+      expect(comp.state.formData).eql("2012-10-02T00:00:00.000Z");
     });
 
     it("should fill field with data", () => {
@@ -616,11 +610,10 @@ describe("StringField", () => {
           format: "date-time",
         }, uiSchema});
 
-        return SimulateAsync().click(node.querySelector("a.btn-now"))
-          .then(() => {
-            const expected = toDateString(parseDateString(new Date().toJSON(), false));
-            expect(comp.state.formData).eql(expected);
-          });
+        Simulate.click(node.querySelector("a.btn-now"));
+
+        const expected = toDateString(parseDateString(new Date().toJSON(), false));
+        expect(comp.state.formData).eql(expected);
       });
 
       it("should clear current date when pressing the Clear button", () => {
@@ -629,9 +622,10 @@ describe("StringField", () => {
           format: "date-time",
         }, uiSchema});
 
-        return SimulateAsync().click(node.querySelector("a.btn-now"))
-          .then(() => SimulateAsync().click(node.querySelector("a.btn-clear")))
-          .then(() => expect(comp.state.formData).eql(undefined));
+        Simulate.click(node.querySelector("a.btn-now"));
+        Simulate.click(node.querySelector("a.btn-clear"));
+
+        expect(comp.state.formData).eql(undefined);
       });
     });
   });
@@ -687,13 +681,13 @@ describe("StringField", () => {
       }});
 
       const newDatetime = new Date().toJSON();
-      return SimulateAsync().change(node.querySelector("[type=email]"), {
+
+      Simulate.change(node.querySelector("[type=email]"), {
         target: {value: newDatetime}
-      })
-        .then(() => {
-          return expect(node.querySelector("[type=email]").value)
-            .eql(newDatetime);
-        });
+      });
+
+      expect(node.querySelector("[type=email]").value)
+        .eql(newDatetime);
     });
 
     it("should fill field with data", () => {
@@ -722,10 +716,11 @@ describe("StringField", () => {
         format: "email",
       }, liveValidate: true});
 
-      return SimulateAsync().change(node.querySelector("[type=email]"), {
+      Simulate.change(node.querySelector("[type=email]"), {
         target: {value: "invalid"}
-      })
-        .then(() => expect(comp.state.errors).to.have.length.of(1));
+      });
+
+      expect(comp.state.errors).to.have.length.of(1);
     });
   });
 
@@ -780,10 +775,11 @@ describe("StringField", () => {
       }});
 
       const newDatetime = new Date().toJSON();
-      return SimulateAsync().change(node.querySelector("[type=url]"), {
+      Simulate.change(node.querySelector("[type=url]"), {
         target: {value: newDatetime}
-      })
-        .then(() => expect(node.querySelector("[type=url]").value).eql(newDatetime));
+      });
+
+      expect(node.querySelector("[type=url]").value).eql(newDatetime);
     });
 
     it("should fill field with data", () => {
@@ -812,10 +808,11 @@ describe("StringField", () => {
         format: "uri",
       }, liveValidate: true});
 
-      return SimulateAsync().change(node.querySelector("[type=url]"), {
+      Simulate.change(node.querySelector("[type=url]"), {
         target: {value: "invalid"}
-      })
-        .then(() => expect(comp.state.errors).to.have.length.of(1));
+      });
+
+      expect(comp.state.errors).to.have.length.of(1);
     });
   });
 
@@ -850,13 +847,13 @@ describe("StringField", () => {
       }, uiSchema});
 
       const newColor = "#654321";
-      return SimulateAsync().change(node.querySelector("[type=color]"), {
+
+      Simulate.change(node.querySelector("[type=color]"), {
         target: {value: newColor}
-      })
-        .then(() => {
-          return expect(node.querySelector("[type=color]").value)
-            .eql(newColor);
-        });
+      });
+
+      expect(node.querySelector("[type=color]").value)
+        .eql(newColor);
     });
 
     it("should fill field with data", () => {
@@ -885,10 +882,11 @@ describe("StringField", () => {
         format: "color",
       }, uiSchema, liveValidate: true});
 
-      return SimulateAsync().change(node.querySelector("[type=color]"), {
+      Simulate.change(node.querySelector("[type=color]"), {
         target: {value: "invalid"}
-      })
-        .then(() => expect(comp.state.errors).to.have.length.of(1));
+      });
+
+      expect(comp.state.errors).to.have.length.of(1);
     });
   });
 });

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -4,9 +4,9 @@ import React from "react";
 import sinon from "sinon";
 import { renderIntoDocument } from "react-addons-test-utils";
 import { findDOMNode } from "react-dom";
-import { Simulate } from "react-addons-test-utils";
 
 import Form from "../src";
+
 
 export function createComponent(Component, props) {
   const comp = renderIntoDocument(<Component {...props} />);
@@ -15,7 +15,7 @@ export function createComponent(Component, props) {
 }
 
 export function createFormComponent(props) {
-  return createComponent(Form, props);
+  return createComponent(Form, {...props, safeRenderCompletion: true});
 }
 
 export function createSandbox() {
@@ -25,21 +25,4 @@ export function createSandbox() {
     throw new Error(error);
   });
   return sandbox;
-}
-
-export function SimulateAsync(delay = 15) {
-  return Object.keys(Simulate).reduce((acc, key) => {
-    const prop = Simulate[key];
-    if (typeof prop === "function") {
-      acc[key] = (...args) => {
-        return new Promise((resolve) => {
-          Simulate[key](...args);
-          setTimeout(resolve, delay);
-        });
-      };
-    } else {
-      acc[key] = prop;
-    }
-    return acc;
-  }, {});
 }

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -1,7 +1,8 @@
 import { expect } from "chai";
 import React from "react";
+import { Simulate } from "react-addons-test-utils";
 
-import { createFormComponent, createSandbox, SimulateAsync } from "./test_utils";
+import { createFormComponent, createSandbox } from "./test_utils";
 
 
 describe("uiSchema", () => {
@@ -153,10 +154,11 @@ describe("uiSchema", () => {
           foo: "a"
         }});
 
-        return SimulateAsync().change(node.querySelector("textarea"), {
+        Simulate.change(node.querySelector("textarea"), {
           target: {value: "b"}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: "b"}));
+        });
+
+        expect(comp.state.formData).eql({foo: "b"});
       });
     });
 
@@ -188,10 +190,11 @@ describe("uiSchema", () => {
           foo: "a"
         }});
 
-        return SimulateAsync().change(node.querySelector("[type=password]"), {
+        Simulate.change(node.querySelector("[type=password]"), {
           target: {value: "b"}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: "b"}));
+        });
+
+        expect(comp.state.formData).eql({foo: "b"});
       });
     });
 
@@ -223,10 +226,11 @@ describe("uiSchema", () => {
           foo: "#151ce6"
         }});
 
-        return SimulateAsync().change(node.querySelector("[type=color]"), {
+        Simulate.change(node.querySelector("[type=color]"), {
           target: {value: "#001122"}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: "#001122"}));
+        });
+
+        expect(comp.state.formData).eql({foo: "#001122"});
       });
     });
 
@@ -302,10 +306,11 @@ describe("uiSchema", () => {
           foo: "a"
         }});
 
-        return SimulateAsync().change(node.querySelectorAll("[type=radio]")[1], {
+        Simulate.change(node.querySelectorAll("[type=radio]")[1], {
           target: {checked: true}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: "b"}));
+        });
+
+        expect(comp.state.formData).eql({foo: "b"});
       });
     });
   });
@@ -348,10 +353,11 @@ describe("uiSchema", () => {
           foo: 3.14
         }});
 
-        return SimulateAsync().change(node.querySelector("[type=number]"), {
+        Simulate.change(node.querySelector("[type=number]"), {
           target: {value: "6.28"}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: 6.28}));
+        });
+
+        expect(comp.state.formData).eql({foo: 6.28});
       });
     });
 
@@ -383,10 +389,11 @@ describe("uiSchema", () => {
           foo: 3.14
         }});
 
-        return SimulateAsync().change(node.querySelector("[type=range]"), {
+        Simulate.change(node.querySelector("[type=range]"), {
           target: {value: "6.28"}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: 6.28}));
+        });
+
+        expect(comp.state.formData).eql({foo: 6.28});
       });
     });
 
@@ -461,10 +468,11 @@ describe("uiSchema", () => {
           foo: 3
         }});
 
-        return SimulateAsync().change(node.querySelector("[type=number]"), {
+        Simulate.change(node.querySelector("[type=number]"), {
           target: {value: "6"}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: 6}));
+        });
+
+        expect(comp.state.formData).eql({foo: 6});
       });
     });
 
@@ -496,10 +504,11 @@ describe("uiSchema", () => {
           foo: 3
         }});
 
-        return SimulateAsync().change(node.querySelector("[type=range]"), {
+        Simulate.change(node.querySelector("[type=range]"), {
           target: {value: "6"}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: 6}));
+        });
+
+        expect(comp.state.formData).eql({foo: 6});
       });
     });
 
@@ -588,10 +597,11 @@ describe("uiSchema", () => {
           foo: true
         }});
 
-        return SimulateAsync().change(node.querySelectorAll("[type=radio]")[1], {
+        Simulate.change(node.querySelectorAll("[type=radio]")[1], {
           target: {checked: true}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: false}));
+        });
+
+        expect(comp.state.formData).eql({foo: false});
       });
 
       it("should update state when true is checked", () => {
@@ -599,10 +609,11 @@ describe("uiSchema", () => {
           foo: false
         }});
 
-        return SimulateAsync().change(node.querySelectorAll("[type=radio]")[0], {
+        Simulate.change(node.querySelectorAll("[type=radio]")[0], {
           target: {checked: true}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: true}));
+        });
+
+        expect(comp.state.formData).eql({foo: true});
       });
     });
 
@@ -634,11 +645,12 @@ describe("uiSchema", () => {
           foo: false
         }});
 
-        return SimulateAsync().change(node.querySelector("select"), {
+        Simulate.change(node.querySelector("select"), {
           // DOM option change events always return strings
           target: {value: "true"}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: true}));
+        });
+
+        expect(comp.state.formData).eql({foo: true});
       });
 
       it("should update state when false is selected", () => {
@@ -646,11 +658,12 @@ describe("uiSchema", () => {
           foo: false
         }});
 
-        return SimulateAsync().change(node.querySelector("select"), {
+        Simulate.change(node.querySelector("select"), {
           // DOM option change events always return strings
           target: {value: "false"}
-        })
-          .then(() => expect(comp.state.formData).eql({foo: false}));
+        });
+
+        expect(comp.state.formData).eql({foo: false});
       });
     });
 


### PR DESCRIPTION
This patch adds a `safeRenderCompletion` Form prop in order to define the way we wait for components rendering to be finished before processing further.

This option is mostly useful in a test environment when we don't really want to bother waiting for an arbitrary amount of time for renders to fully complete, so tests are easier to write and read.  