### PR TITLE
Fixes #180: Added support for the date string format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ The built-in string field also supports the JSONSchema `format` property, and wi
 
 - `email`: An `input[type=email]` element is used;
 - `uri`: An `input[type=url]` element is used;
-- `date-time`: By default, an `input[type=datetime-local]` element is used; if you solely want to rely on a date, a `date` uiSchema alternative widget is available:
+- `date`: By default, an `input[type=date]` element is used;
+- `date-time`: By default, an `input[type=datetime-local]` element is used.
 
 ![](http://i.imgur.com/xqu6Lcp.png)
 

--- a/playground/samples/date.js
+++ b/playground/samples/date.js
@@ -14,7 +14,7 @@ module.exports = {
           },
           "date": {
             type: "string",
-            format: "date-time"
+            format: "date"
           }
         }
       },
@@ -29,18 +29,13 @@ module.exports = {
           },
           "alt-date": {
             type: "string",
-            format: "date-time"
+            format: "date"
           }
         }
       }
     }
   },
   uiSchema: {
-    native: {
-      date: {
-        "ui:widget": "date"
-      }
-    },
     alternative: {
       "alt-datetime": {
         "ui:widget": "alt-datetime"

--- a/src/components/widgets/AltDateWidget.js
+++ b/src/components/widgets/AltDateWidget.js
@@ -12,7 +12,7 @@ function rangeOptions(type, start, stop) {
   return options;
 }
 
-function valid(state) {
+function readyForChange(state) {
   return Object.keys(state).every(key => state[key] !== -1);
 }
 
@@ -50,8 +50,8 @@ class AltDateWidget extends Component {
   onChange = (property, value) => {
     this.setState({[property]: value}, () => {
       // Only propagate to parent state if we have a complete date{time}
-      if (valid(this.state)) {
-        this.props.onChange(toDateString(this.state));
+      if (readyForChange(this.state)) {
+        this.props.onChange(toDateString(this.state, this.props.time));
       }
     });
   };
@@ -60,7 +60,7 @@ class AltDateWidget extends Component {
     event.preventDefault();
     const {time, onChange} = this.props;
     const nowDateObj = parseDateString(new Date().toJSON(), time);
-    this.setState(nowDateObj, () => onChange(toDateString(this.state)));
+    this.setState(nowDateObj, () => onChange(toDateString(this.state, time)));
   };
 
   clear = (event) => {

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -1,16 +1,6 @@
 import React, { PropTypes } from "react";
 
 
-function fromJSONDate(jsonDate) {
-  return jsonDate ? jsonDate.slice(0, 10) : "";
-}
-
-function toJSONDate(dateString) {
-  if (dateString) {
-    return new Date(dateString).toJSON();
-  }
-}
-
 function DateWidget({
   schema,
   id,
@@ -22,9 +12,9 @@ function DateWidget({
     <input type="date"
       id={id}
       className="form-control"
-      value={fromJSONDate(value)}
+      value={typeof value === "undefined" ? "" : value}
       required={required}
-      onChange={(event) => onChange(toJSONDate(event.target.value))} />
+      onChange={(event) => onChange(event.target.value)} />
   );
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,6 +51,7 @@ const altWidgetMap = {
 
 const stringFormatWidgets = {
   "date-time": DateTimeWidget,
+  "date": DateWidget,
   "email": EmailWidget,
   "hostname": TextWidget,
   "ipv4": TextWidget,
@@ -350,9 +351,17 @@ export function parseDateString(dateString, includeTime = true) {
   };
 }
 
-export function toDateString({year, month, day, hour=0, minute=0, second=0}) {
+export function toDateString({
+  year,
+  month,
+  day,
+  hour=0,
+  minute=0,
+  second=0
+}, time = true) {
   const utcTime = Date.UTC(year, month - 1, day, hour, minute, second);
-  return new Date(utcTime).toJSON();
+  const datetime = new Date(utcTime).toJSON();
+  return time ? datetime : datetime.slice(0, 10);
 }
 
 export function pad(num, size) {

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -261,7 +261,7 @@ describe("StringField", () => {
     it("should render a date field", () => {
       const {node} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
       }, uiSchema});
 
       expect(node.querySelectorAll(".field [type=date]"))
@@ -272,7 +272,7 @@ describe("StringField", () => {
       const datetime = new Date().toJSON();
       const {comp} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
         default: datetime,
       }, uiSchema});
 
@@ -282,10 +282,10 @@ describe("StringField", () => {
     it("should reflect the change into the dom", () => {
       const {node} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
       }, uiSchema});
 
-      const newDatetime = new Date().toJSON();
+      const newDatetime = "2012-12-12";
 
       Simulate.change(node.querySelector("[type=date]"), {
         target: {value: newDatetime}
@@ -300,7 +300,7 @@ describe("StringField", () => {
       const datetime = new Date().toJSON();
       const {comp} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
       }, formData: datetime});
 
       expect(comp.state.formData).eql(datetime);
@@ -309,17 +309,31 @@ describe("StringField", () => {
     it("should render the widget with the expected id", () => {
       const {node} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
       }, uiSchema});
 
       expect(node.querySelector("[type=date]").id)
         .eql("root");
     });
 
-    it("should reject an invalid entered datetime", () => {
+    it("should accept a valid entered date", () => {
       const {comp, node} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
+      }, uiSchema, liveValidate: true});
+
+      Simulate.change(node.querySelector("[type=date]"), {
+        target: {value: "2012-12-12"}
+      });
+
+      expect(comp.state.errors).to.have.length.of(0);
+      expect(comp.state.formData).eql("2012-12-12");
+    });
+
+    it("should reject an invalid entered date", () => {
+      const {comp, node} = createFormComponent({schema: {
+        type: "string",
+        format: "date",
       }, uiSchema, liveValidate: true});
 
       Simulate.change(node.querySelector("[type=date]"), {
@@ -492,7 +506,7 @@ describe("StringField", () => {
     it("should render a date field", () => {
       const {node} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
       }, uiSchema});
 
       expect(node.querySelectorAll(".field select"))
@@ -502,7 +516,7 @@ describe("StringField", () => {
     it("should render a string field with a main label", () => {
       const {node} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
         title: "foo",
       }, uiSchema});
 
@@ -511,10 +525,10 @@ describe("StringField", () => {
     });
 
     it("should assign a default value", () => {
-      const datetime = new Date().toJSON();
+      const datetime = "2012-12-12";
       const {comp} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
         default: datetime,
       }, uiSchema});
 
@@ -524,21 +538,21 @@ describe("StringField", () => {
     it("should reflect the change into the dom", () => {
       const {comp, node} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
       }, uiSchema});
 
       Simulate.change(node.querySelector("#root_year"), {target: {value: 2012}});
       Simulate.change(node.querySelector("#root_month"), {target: {value: 10}});
       Simulate.change(node.querySelector("#root_day"), {target: {value: 2}});
 
-      expect(comp.state.formData).eql("2012-10-02T00:00:00.000Z");
+      expect(comp.state.formData).eql("2012-10-02");
     });
 
     it("should fill field with data", () => {
-      const datetime = new Date().toJSON();
+      const datetime = "2012-12-12";
       const {comp} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
       }, uiSchema, formData: datetime});
 
       expect(comp.state.formData).eql(datetime);
@@ -547,7 +561,7 @@ describe("StringField", () => {
     it("should render the widgets with the expected ids", () => {
       const {node} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
       }, uiSchema});
 
       const ids = [].map.call(node.querySelectorAll("select"), node => node.id);
@@ -562,7 +576,7 @@ describe("StringField", () => {
     it("should render the widgets with the expected options' values", () => {
       const {node} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
       }, uiSchema});
 
       const lengths = [].map.call(node.querySelectorAll("select"),
@@ -582,7 +596,7 @@ describe("StringField", () => {
     it("should render the widgets with the expected options' labels", () => {
       const {node} = createFormComponent({schema: {
         type: "string",
-        format: "date-time",
+        format: "date",
       }, uiSchema});
 
       const monthOptions = node.querySelectorAll("select#root_month option");
@@ -592,11 +606,22 @@ describe("StringField", () => {
         "07", "08", "09", "10", "11", "12"]);
     });
 
+    it("should accept a valid date", () => {
+      const {comp} = createFormComponent({schema: {
+        type: "string",
+        format: "date",
+      }, uiSchema, liveValidate: true});
+
+      comp.componentWillReceiveProps({formData: "2012-12-12"});
+
+      expect(comp.state.errors).to.have.length.of(0);
+    });
+
     describe("Action buttons", () => {
       it("should render action buttons", () => {
         const {node} = createFormComponent({schema: {
           type: "string",
-          format: "date-time",
+          format: "date",
         }, uiSchema});
 
         const buttonLabels = [].map.call(node.querySelectorAll("a.btn"),
@@ -607,19 +632,19 @@ describe("StringField", () => {
       it("should set current date when pressing the Now button", () => {
         const {comp, node} = createFormComponent({schema: {
           type: "string",
-          format: "date-time",
+          format: "date",
         }, uiSchema});
 
         Simulate.click(node.querySelector("a.btn-now"));
 
-        const expected = toDateString(parseDateString(new Date().toJSON(), false));
+        const expected = toDateString(parseDateString(new Date().toJSON()), false);
         expect(comp.state.formData).eql(expected);
       });
 
       it("should clear current date when pressing the Clear button", () => {
         const {comp, node} = createFormComponent({schema: {
           type: "string",
-          format: "date-time",
+          format: "date",
         }, uiSchema});
 
         Simulate.click(node.querySelector("a.btn-now"));

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -585,7 +585,7 @@ describe("utils", () => {
   });
 
   describe("toDateString()", () => {
-    it("should transform an object to a valid json datetime", () => {
+    it("should transform an object to a valid json datetime if time=true", () => {
       expect(toDateString({
         "year": 2016,
         "month": 4,
@@ -595,6 +595,15 @@ describe("utils", () => {
         "second": 30,
       }))
         .eql("2016-04-05T14:01:30.000Z");
+    });
+
+    it("should transform an object to a valid date string if time=false", () => {
+      expect(toDateString({
+        "year": 2016,
+        "month": 4,
+        "day": 5,
+      }, false))
+        .eql("2016-04-05");
     });
   });
 


### PR DESCRIPTION
This adds support for the `"date"` json schema string format, which is supported by the jsonschema lib and provide a much more convenient way to describe dates comparatively to datetimes.

This also updates the `AltDateWidget` behavior accordingly. 

/cc @kaihendry
r=? @natim @glasserc @leplatrem 