### PR TITLE
Fixed regression with range and updown widgets.

### DIFF
--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -1,25 +1,14 @@
 import React, { PropTypes } from "react";
 
 
-function BaseInput({
-  id,
-  type,
-  placeholder,
-  value,
-  required,
-  disabled,
-  readonly,
-  onChange
-}) {
+function BaseInput(props) {
+  const {value, readonly, onChange} = props;
   return (
-    <input type={type}
-      id={id}
+    <input
+      {...props}
       className="form-control"
-      value={typeof value === "undefined" ? "" : value}
-      placeholder={placeholder}
-      required={required}
-      disabled={disabled}
       readOnly={readonly}
+      value={typeof value === "undefined" ? "" : value}
       onChange={(event) => onChange(event.target.value)} />
   );
 }

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -321,6 +321,9 @@ describe("uiSchema", () => {
       properties: {
         foo: {
           type: "number",
+          multipleOf: 1,
+          minimum: 10,
+          maximum: 100,
         }
       }
     };
@@ -359,6 +362,27 @@ describe("uiSchema", () => {
 
         expect(comp.state.formData).eql({foo: 6.28});
       });
+
+      describe("Constraint attributes", () => {
+        let input;
+
+        beforeEach(() => {
+          const {node} = createFormComponent({schema, uiSchema});
+          input = node.querySelector("[type=number]");
+        });
+
+        it("should support the minimum constraint", () => {
+          expect(input.getAttribute("min")).eql("10");
+        });
+
+        it("should support maximum constraint", () => {
+          expect(input.getAttribute("max")).eql("100");
+        });
+
+        it("should support the multipleOf constraint", () => {
+          expect(input.getAttribute("step")).eql("1");
+        });
+      });
     });
 
     describe("range", () => {
@@ -394,6 +418,27 @@ describe("uiSchema", () => {
         });
 
         expect(comp.state.formData).eql({foo: 6.28});
+      });
+
+      describe("Constraint attributes", () => {
+        let input;
+
+        beforeEach(() => {
+          const {node} = createFormComponent({schema, uiSchema});
+          input = node.querySelector("[type=range]");
+        });
+
+        it("should support the minimum constraint", () => {
+          expect(input.getAttribute("min")).eql("10");
+        });
+
+        it("should support maximum constraint", () => {
+          expect(input.getAttribute("max")).eql("100");
+        });
+
+        it("should support the multipleOf constraint", () => {
+          expect(input.getAttribute("step")).eql("1");
+        });
       });
     });
 


### PR DESCRIPTION
This is a regression introduced by #183, where we introduced the new `BaseInput` component which only accepts predetermined props, missing specific ones for `updown` and `range` widgets.

You can experiment the broken behavior in the *Numbers* section of the [playground](http://mozilla-services.github.io/react-jsonschema-form/).

The patch fixes this.

r=? @glasserc @leplatrem 