### PR TITLE
Fixes #206: Load platform specific polyfills in the playground.

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>react-jsonschema-form playground</title>
   <link rel="stylesheet" id="theme" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  <script src="//cdn.polyfill.io/v2/polyfill.min.js"></script>
 </head>
 <body>
   <div id="app"></div>

--- a/playground/index.prod.html
+++ b/playground/index.prod.html
@@ -7,6 +7,7 @@
   <title>react-jsonschema-form playground</title>
   <link rel="stylesheet" id="theme" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
   <link rel="stylesheet" href="./styles.css">
+  <script src="//cdn.polyfill.io/v2/polyfill.min.js"></script>
 </head>
 <body>
   <div id="app"></div>


### PR DESCRIPTION
Refs #206 

@alex-perfilov-reisys could you please confirm this solves the issue with IE11? I've deployed the patch to the [gh-pages hosted demo](https://mozilla-services.github.io/react-jsonschema-form). Thanks.