### PR TITLE
Fixes #201: Add an array example to the uiSchema docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,17 @@ const schema = {
       properties: {
         bar: {type: "string"}
       }
+    },
+    baz: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          description: {
+            "type": "string"
+          },
+        }
+      }
     }
   }
 }
@@ -176,6 +187,14 @@ const uiSchema = {
   foo: {
     bar: {
       "ui:widget": "textarea"
+    }
+    baz: {
+      // note the "items" for an array
+      items: {
+        description: {
+          "ui:widget": "textarea"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Add some docs on how to reference properties in an array when using a custom uiSchema.

Fixes #201 and #208 