### PR TITLE
Custom description field

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ A field component will always be passed the following props:
 
 The `registry` is an object containing the registered custom fields and widgets as well as root schema definitions.
 
- - `fields`: The [custom registered fields](#custom-field-components). By default this object contains the standard `SchemaField` and `TitleField` components;
+ - `fields`: The [custom registered fields](#custom-field-components). By default this object contains the standard `SchemaField`, `TitleField` and `DescriptionField` components;
  - `widgets`: The [custom registered widgets](#custom-widget-components), if any;
  - `definitions`: The root schema [definitions](#schema-definitions-and-references), if any.
 
@@ -623,6 +623,31 @@ const CustomTitleField = ({title, required}) => {
 
 const fields = {
   TitleField: CustomTitleField
+};
+
+render((
+  <Form schema={schema}
+        uiSchema={uiSchema}
+        formData={formData}
+        fields={fields} />
+), document.getElementById("app"));
+```
+
+### Custom descriptions
+
+You can provide your own implementation of the `DescriptionField` base React component for rendering any description.
+
+
+Simply pass a `fields` object having a `DescriptionField` property to your `Form` component:
+
+```jsx
+
+const CustomDescriptionField = ({id, description}) => {
+  return <div id={id}>{description}</div>;
+};
+
+const fields = {
+  DescriptionField: CustomDescriptionField
 };
 
 render((

--- a/README.md
+++ b/README.md
@@ -611,7 +611,6 @@ Props passed to a custom SchemaField are the same as [the ones passed to a custo
 
 You can provide your own implementation of the `TitleField` base React component for rendering any title. This is useful when you want to augment how titles are handled.
 
-
 Simply pass a `fields` object having a `TitleField` property to your `Form` component:
 
 ```jsx
@@ -636,7 +635,6 @@ render((
 ### Custom descriptions
 
 You can provide your own implementation of the `DescriptionField` base React component for rendering any description.
-
 
 Simply pass a `fields` object having a `DescriptionField` property to your `Form` component:
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -2,6 +2,8 @@ import React, { Component, PropTypes } from "react";
 
 import SchemaField from "./fields/SchemaField";
 import TitleField from "./fields/TitleField";
+import DescriptionField from "./fields/DescriptionField";
+
 import ErrorList from "./ErrorList";
 import {
   getDefaultFormState,
@@ -101,9 +103,12 @@ export default class Form extends Component {
     // the "fields" registry one.
     const _SchemaField = this.props.SchemaField || SchemaField;
     const _TitleField = this.props.TitleField || TitleField;
+    const _DescriptionField = this.props.DescriptionField || DescriptionField;
+
     const fields = Object.assign({
       SchemaField: _SchemaField,
       TitleField: _TitleField,
+      DescriptionField: _DescriptionField
     }, this.props.fields);
     return {
       fields,

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -23,6 +23,14 @@ function ArrayFieldTitle({TitleField, idSchema, title, required}) {
   return <TitleField id={id} title={title} required={required} />;
 }
 
+function DescriptionFieldTitle({DescriptionField, idSchema, description}) {
+  if (!description) {
+    return null;
+  }
+  const id = `${idSchema.id}__description`;
+  return <DescriptionField id={id} description={description} />;
+}
+
 class ArrayField extends Component {
   static defaultProps = {
     uiSchema: {},
@@ -133,7 +141,7 @@ class ArrayField extends Component {
     const title = schema.title || name;
     const {items} = this.state;
     const {definitions, fields} = this.props.registry;
-    const {TitleField} = fields;
+    const {TitleField, DescriptionField} = fields;
     const itemsSchema = retrieveSchema(schema.items, definitions);
 
     return (
@@ -145,7 +153,10 @@ class ArrayField extends Component {
           title={title}
           required={required} />
         {schema.description ?
-          <div className="field-description">{schema.description}</div> : null}
+          <DescriptionFieldTitle
+            DescriptionField={DescriptionField}
+            idSchema={idSchema}
+            description={description} /> : null}
         <div className="row array-item-list">{
           items.map((item, index) => {
             const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -23,7 +23,7 @@ function ArrayFieldTitle({TitleField, idSchema, title, required}) {
   return <TitleField id={id} title={title} required={required} />;
 }
 
-function DescriptionFieldTitle({DescriptionField, idSchema, description}) {
+function ArrayFieldDescription({DescriptionField, idSchema, description}) {
   if (!description) {
     return null;
   }
@@ -153,7 +153,7 @@ class ArrayField extends Component {
           title={title}
           required={required} />
         {schema.description ?
-          <DescriptionFieldTitle
+          <ArrayFieldDescription
             DescriptionField={DescriptionField}
             idSchema={idSchema}
             description={schema.description} /> : null}

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -156,7 +156,7 @@ class ArrayField extends Component {
           <DescriptionFieldTitle
             DescriptionField={DescriptionField}
             idSchema={idSchema}
-            description={description} /> : null}
+            description={schema.description} /> : null}
         <div className="row array-item-list">{
           items.map((item, index) => {
             const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;

--- a/src/components/fields/DescriptionField.js
+++ b/src/components/fields/DescriptionField.js
@@ -1,8 +1,8 @@
 import React, {PropTypes} from "react";
 
 function DescriptionField(props) {
-  const {description} = props;
-  return <div className="field-description">{description}</div>;
+  const {id, description} = props;
+  return <div id={id} className="field-description">{description}</div>;
 }
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/components/fields/DescriptionField.js
+++ b/src/components/fields/DescriptionField.js
@@ -1,0 +1,15 @@
+import React, {PropTypes} from "react";
+
+function DescriptionField(props) {
+  const {description} = props;
+  return <div className="field-description">{description}</div>;
+}
+
+if (process.env.NODE_ENV !== "production") {
+  DescriptionField.propTypes = {
+    id: PropTypes.string,
+    description: PropTypes.string,
+  };
+}
+
+export default DescriptionField;

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -68,7 +68,7 @@ class ObjectField extends Component {
       readonly
     } = this.props;
     const {definitions, fields} = this.props.registry;
-    const {SchemaField, TitleField} = fields;
+    const {SchemaField, TitleField, DescriptionField} = fields;
     const schema = retrieveSchema(this.props.schema, definitions);
     const title = schema.title || name;
     let orderedProperties;
@@ -93,7 +93,10 @@ class ObjectField extends Component {
                    title={title}
                    required={required} /> : null}
         {schema.description ?
-          <p className="field-description">{schema.description}</p> : null}
+          <DescriptionField
+            id={`${idSchema.id}__description`}
+            description={schema.description}
+          /> : null}
         {
         orderedProperties.map((name, index) => {
           return (

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ import "setimmediate";
 import deeper from "deeper";
 
 import TitleField from "./components/fields/TitleField";
+import DescriptionField from "./components/fields/DescriptionField";
 import PasswordWidget from "./components/widgets/PasswordWidget";
 import RadioWidget from "./components/widgets/RadioWidget";
 import UpDownWidget from "./components/widgets/UpDownWidget";
@@ -70,6 +71,7 @@ export function getDefaultRegistry() {
       // SchemaField itself.
       SchemaField: require("./components/fields/SchemaField").default,
       TitleField,
+      DescriptionField,
     },
     widgets: {},
     definitions: {},

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -44,7 +44,7 @@ describe("ArrayField", () => {
     it("should render a description", () => {
       const {node} = createFormComponent({schema});
 
-      const description = node.querySelector("fieldset > div");
+      const description = node.querySelector("fieldset > div.field-description");
 
       expect(description.textContent).eql("my description");
       expect(description.id).eql("root__description");
@@ -53,17 +53,21 @@ describe("ArrayField", () => {
     it("should render a customized title", () => {
       const CustomTitleField = ({title}) => <div id="custom">{title}</div>;
 
-      const {node} = createFormComponent({schema, TitleField: CustomTitleField});
+      const {node} = createFormComponent({schema,
+        fields: {TitleField: CustomTitleField}
+      });
       expect(node.querySelector("fieldset > #custom").textContent)
-      .to.eql("my list");
+        .to.eql("my list");
     });
 
     it("should render a customized description", () => {
       const CustomDescriptionField = ({description}) => <div id="custom">{description}</div>;
 
-      const {node} = createFormComponent({schema, DescriptionField: CustomDescriptionField});
+      const {node} = createFormComponent({schema, fields: {
+        DescriptionField: CustomDescriptionField}
+      });
       expect(node.querySelector("fieldset > #custom").textContent)
-      .to.eql("my description");
+        .to.eql("my description");
     });
 
     it("should contain no field in the list by default", () => {

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -1,3 +1,5 @@
+import React from "react";
+
 import { expect } from "chai";
 import { Simulate } from "react-addons-test-utils";
 
@@ -19,6 +21,7 @@ describe("ArrayField", () => {
     const schema = {
       type: "array",
       title: "my list",
+      description: "my description",
       items: {type: "string"}
     };
 
@@ -36,6 +39,31 @@ describe("ArrayField", () => {
 
       expect(legend.textContent).eql("my list");
       expect(legend.id).eql("root__title");
+    });
+
+    it("should render a description", () => {
+      const {node} = createFormComponent({schema});
+
+      const description = node.querySelector("fieldset > div");
+
+      expect(description.textContent).eql("my description");
+      expect(description.id).eql("root__description");
+    });
+
+    it("should render a customized title", () => {
+      const CustomTitleField = ({title}) => <div id="custom">{title}</div>;
+
+      const {node} = createFormComponent({schema, TitleField: CustomTitleField});
+      expect(node.querySelector("fieldset > #custom").textContent)
+      .to.eql("my list");
+    });
+
+    it("should render a customized description", () => {
+      const CustomDescriptionField = ({description}) => <div id="custom">{description}</div>;
+
+      const {node} = createFormComponent({schema, DescriptionField: CustomDescriptionField});
+      expect(node.querySelector("fieldset > #custom").textContent)
+      .to.eql("my description");
     });
 
     it("should contain no field in the list by default", () => {

--- a/test/DescriptionField_test.js
+++ b/test/DescriptionField_test.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { expect } from "chai";
+
+import DescriptionField from "../src/components/fields/DescriptionField";
+import { createSandbox, createComponent } from "./test_utils";
+
+describe("DescriptionField", () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  // For some reason, stateless components needs to be wrapped into a stateful
+  // one to be rendered into the document.
+  class DescriptionFieldWrapper extends React.Component {
+    constructor(props) {
+      super(props);
+    }
+    render() {
+      return <DescriptionField {...this.props} />;
+    }
+  }
+
+  it("should return a div", () => {
+    const props = {
+      description: "Field description",
+    };
+    const {node} = createComponent(DescriptionFieldWrapper, props);
+
+    expect(node.tagName).to.equal("DIV");
+  });
+
+  it("should have the expected id", () => {
+    const props = {
+      description: "Field description",
+      id: "sample_id"
+    };
+    const {node} = createComponent(DescriptionFieldWrapper, props);
+
+    expect(node.id).to.equal("sample_id");
+  });
+});

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -20,6 +20,7 @@ describe("ObjectField", () => {
     const schema = {
       type: "object",
       title: "my object",
+      description: "my description",
       required: ["foo"],
       default: {
         foo: "hey",
@@ -58,6 +59,14 @@ describe("ObjectField", () => {
       const {node} = createFormComponent({schema, TitleField: CustomTitleField});
       expect(node.querySelector("fieldset > #custom").textContent)
       .to.eql("my object");
+    });
+
+    it("should render a customized description", () => {
+      const CustomDescriptionField = ({description}) => <div id="custom">{description}</div>;
+
+      const {node} = createFormComponent({schema, DescriptionField: CustomDescriptionField});
+      expect(node.querySelector("fieldset > #custom").textContent)
+      .to.eql("my description");
     });
 
     it("should render a default property label", () => {

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -56,7 +56,9 @@ describe("ObjectField", () => {
     it("should render a customized title", () => {
       const CustomTitleField = ({title}) => <div id="custom">{title}</div>;
 
-      const {node} = createFormComponent({schema, TitleField: CustomTitleField});
+      const {node} = createFormComponent({schema, fields: {
+        TitleField: CustomTitleField
+      }});
       expect(node.querySelector("fieldset > #custom").textContent)
       .to.eql("my object");
     });

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -3,6 +3,8 @@ import { expect } from "chai";
 
 import SchemaField from "../src/components/fields/SchemaField";
 import TitleField from "../src/components/fields/TitleField";
+import DescriptionField from "../src/components/fields/DescriptionField";
+
 import { createFormComponent, createSandbox } from "./test_utils";
 
 
@@ -82,6 +84,7 @@ describe("SchemaField", () => {
       expect(registry.fields).to.be.an("object");
       expect(registry.fields.SchemaField).eql(SchemaField);
       expect(registry.fields.TitleField).eql(TitleField);
+      expect(registry.fields.DescriptionField).eql(DescriptionField);
     });
 
     it("should use registered custom component for object", () => {


### PR DESCRIPTION
This adds the ability to customize the description using a description field.

This breaks the previous behaviour: it was returning a `p` for ArrayFields and `divs` for ObjectFields. This is now returning a `div` for both.

I also added some tests in the ArrayField to check that it's able to handle custom TitleFields.

paired with @Natim, r? @n1k0 