### PR TITLE
Add widget capability to Array and Object fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,8 @@ You can provide your own custom widgets to a uiSchema for the following json dat
 - `number`
 - `integer`
 - `boolean`
+- `array`
+- `object`
 
 ```jsx
 const schema = {

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from "react";
 
 import {
   getDefaultFormState,
+  getAlternativeWidget,
   isMultiSelect,
   isFilesArray,
   isFixedItems,
@@ -121,6 +122,10 @@ class ArrayField extends Component {
 
   render() {
     const {schema, uiSchema} = this.props;
+    const widget = uiSchema["ui:widget"] || schema.format;
+    if (widget && widget !== 'checkboxes') {
+      return this.renderWidget();
+    }
     if (isFilesArray(schema, uiSchema)) {
       return this.renderFiles();
     }
@@ -131,6 +136,25 @@ class ArrayField extends Component {
       return this.renderMultiSelect();
     }
     return this.renderNormalArray();
+  }
+
+  renderWidget() {
+    const {schema, idSchema, uiSchema, name, required} = this.props;
+    const {title, description} = schema;
+    const {items} = this.state;
+    const {widgets} = this.props.registry;
+
+    const widget = uiSchema["ui:widget"] || schema.format;
+    const Widget = getAlternativeWidget(schema, widget, widgets);
+    return <Widget
+        id={idSchema && idSchema.id}
+        label={title || name}
+        placeholder={description}
+        onChange={this.onSelectChange}
+        schema={schema}
+        value={items}
+        required={required}
+      />;
   }
 
   renderNormalArray() {

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from "react";
 
 import {
   getDefaultFormState,
+  getAlternativeWidget,
   orderProperties,
   retrieveSchema,
   shouldRender,
@@ -57,6 +58,10 @@ class ObjectField extends Component {
     };
   };
 
+  onObjectChange = (value) => {
+    this.asyncSetState(value);
+  };
+
   render() {
     const {
       uiSchema,
@@ -67,10 +72,12 @@ class ObjectField extends Component {
       disabled,
       readonly
     } = this.props;
-    const {definitions, fields} = this.props.registry;
+    const {definitions, fields, widgets} = this.props.registry;
     const {SchemaField, TitleField, DescriptionField} = fields;
     const schema = retrieveSchema(this.props.schema, definitions);
     const title = schema.title || name;
+    const {description} = schema;
+    const widget = uiSchema['ui:widget'] || schema.format;
     let orderedProperties;
     try {
       const properties = Object.keys(schema.properties);
@@ -85,6 +92,18 @@ class ObjectField extends Component {
           <pre>{JSON.stringify(schema)}</pre>
         </div>
       );
+    }
+    if(widget) {
+      const Widget = getAlternativeWidget(schema, widget, widgets);
+      return <Widget
+          id={idSchema && idSchema.id}
+          label={title}
+          placeholder={description}
+          onChange={this.onObjectChange}
+          schema={schema}
+          value={this.state}
+          required={required}
+        />;
     }
     return (
       <fieldset>


### PR DESCRIPTION
I had an array of roles for a user which I wanted to present as switches.  I wanted to be able to do this inline without having to declare all my fields manually.  Adding the capability for a widget to be used on ArrayField and ObjectField gives more flexibility.