### PR TITLE
Fixes #231: Reset object state on diffing formData keys.

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -19,6 +19,10 @@ app.use(require("webpack-dev-middleware")(compiler, {
 
 app.use(require("webpack-hot-middleware")(compiler));
 
+app.get("/favicon.ico", function(req, res) {
+  res.status(204).end();
+});
+
 app.get("/", function(req, res) {
   res.sendFile(path.join(__dirname, "playground", "index.html"));
 });

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -45,7 +45,16 @@ export default class Form extends Component {
         errorSchema: state.errorSchema || {}
       };
     const idSchema = toIdSchema(schema, uiSchema["ui:rootFieldId"], definitions);
-    return {status: "initial", formData, edit, errors, errorSchema, idSchema};
+    return {
+      status: "initial",
+      schema,
+      uiSchema,
+      idSchema,
+      formData,
+      edit,
+      errors,
+      errorSchema
+    };
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -120,8 +129,6 @@ export default class Form extends Component {
   render() {
     const {
       children,
-      schema,
-      uiSchema,
       safeRenderCompletion,
       id,
       className,
@@ -134,7 +141,7 @@ export default class Form extends Component {
       acceptcharset
     } = this.props;
 
-    const {formData, errorSchema, idSchema} = this.state;
+    const {schema, uiSchema, formData, errorSchema, idSchema} = this.state;
     const registry = this.getRegistry();
     const _SchemaField = registry.fields.SchemaField;
 

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -662,7 +662,7 @@ describe("Form", () => {
         expect(comp.state.errorSchema).eql({
           __errors: [
             "does not meet minimum length of 8",
-            `does not match pattern "\d+"`
+            "does not match pattern \"\d+\""
           ]
         });
       });
@@ -675,7 +675,7 @@ describe("Form", () => {
 
         expect(errors).eql([
           "does not meet minimum length of 8",
-          `does not match pattern "\d+"`
+          "does not match pattern \"\d+\""
         ]);
       });
     });
@@ -923,6 +923,58 @@ describe("Form", () => {
         expect(errors)
           .eql(["does not meet minimum length of 4"]);
       });
+    });
+  });
+
+  describe("Schema and formData updates", () => {
+    // https://github.com/mozilla-services/react-jsonschema-form/issues/231
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {type: "string"},
+        bar: {type: "string"},
+      }
+    };
+
+    it("should replace state when formData have keys removed", () => {
+      const formData = {foo: "foo", bar: "bar"};
+      const {comp, node} = createFormComponent({schema, formData});
+      comp.componentWillReceiveProps({
+        schema: {
+          type: "object",
+          properties: {
+            bar: {type: "string"},
+          }
+        },
+        formData: {bar: "bar"},
+      });
+
+      Simulate.change(node.querySelector("#root_bar"), {
+        target: {value: "baz"}
+      });
+
+      expect(comp.state.formData).eql({bar: "baz"});
+    });
+
+    it("should replace state when formData keys have changed", () => {
+      const formData = {foo: "foo", bar: "bar"};
+      const {comp, node} = createFormComponent({schema, formData});
+      comp.componentWillReceiveProps({
+        schema: {
+          type: "object",
+          properties: {
+            foo: {type: "string"},
+            baz: {type: "string"},
+          }
+        },
+        formData: {foo: "foo", baz: "bar"},
+      });
+
+      Simulate.change(node.querySelector("#root_baz"), {
+        target: {value: "baz"}
+      });
+
+      expect(comp.state.formData).eql({foo: "foo", baz: "baz"});
     });
   });
 


### PR DESCRIPTION
This is an attempt at fixing #231. When an `ObjectField` receives a new `formData` prop, we can't simply rely on `setState` to reflect the possible changes as `setState` *merges* the new data with the previous state ones, which means you cannot drop an object key atm (as the previously existing one will be kept along its associated value).

The patch detects diffing `formData` keys and replaces the component state entirely when these have changed.

Feedback? @dpwrussell @mplis-jetsetter 

Update: I've updated the [playground](https://mozilla-services.github.io/react-jsonschema-form/) with the patch for easier QA.