### PR TITLE
Allow numbers with a 0 after the decimal place to be typed into a Number Field

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -192,6 +192,10 @@ export function asNumber(value) {
     // user is most likely entering a float.
     return value;
   }
+  if (/\.0$/.test(value)) {
+    // we need to return this as a string here, to allow for input like 3.07
+    return value;
+  }
   const n = Number(value);
   const valid = typeof n === "number" && !Number.isNaN(n);
   return valid ? n : value;

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -245,6 +245,15 @@ describe("utils", () => {
     it("should return the raw value if the input ends with a dot", () => {
       expect(asNumber("3.")).eql("3.");
     });
+
+    it("should not convert the value to an integer if the input ends with a 0", () => {
+      // this is to allow users to input 3.07
+      expect(asNumber("3.0")).eql("3.0");
+    });
+
+    it("should allow numbers with a 0 in the first decimal place", () => {
+      expect(asNumber("3.07")).eql(3.07);
+    });
   });
 
   describe("isMultiSelect()", () => {


### PR DESCRIPTION
### Description

A user is not able to enter the string "3.07" into a number field by typing, only by copy & paste.


### Steps to Reproduce

1) Have a number field with the definition:

```
{
  exclusiveMinimum: true
  minimum: 0
  title: "Title"
  type: "number"
}
```

2) Try to type "3.07" into the field
3) Notice that field resets to "3" once the "3.0" string has been entered


#### Expected behavior

Should allow typing of 3.07

#### Actual behavior

Resets the field to 3

### Version

`0.30.2`