### PR TITLE
Ensure use of property specific ui:field suppresses the default label

### DIFF
--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -149,6 +149,9 @@ function SchemaField(props) {
   if (schema.type === "boolean" && !uiSchema["ui:widget"]) {
     displayLabel = false;
   }
+  if (uiSchema["ui:field"]) {
+    displayLabel = false;
+  }
 
   return (
     <Wrapper

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -62,6 +62,24 @@ describe("SchemaField", () => {
 
       expect(node.querySelectorAll("#custom"))
         .to.have.length.of(1);
+
+      expect(node.querySelectorAll("label")).to.have.length.of(0);
+    });
+
+    it("should use provided direct custom component for specific property", () => {
+      const uiSchema = {
+        foo: {"ui:field": MyObject}
+      };
+
+      const {node} = createFormComponent({schema, uiSchema});
+
+      expect(node.querySelectorAll("#custom"))
+        .to.have.length.of(1);
+
+      expect(node.querySelectorAll("input"))
+        .to.have.length.of(1);
+
+      expect(node.querySelectorAll("label")).to.have.length.of(1);
     });
 
     it("should provide custom field the expected fields", () => {


### PR DESCRIPTION
My understanding from the documentation is that a custom field will suppress the default label.  That is not the case when a field is set on a specific schema property.

Also, I think this could be a fix for #230 