### PR TITLE
Fix #255: Replace deeper dependency with local deepEquals helper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,34 +878,6 @@ This component follows [JSON Schema](http://json-schema.org/documentation.html) 
 * `additionalItems` keyword for arrays
     This keyword works when `items` is an array. `additionalItems: true` is not supported because there's no widget to represent an item of any type. In this case it will be treated as no additional items allowed. `additionalItems` being a valid schema is supported.
 
-## Troubleshooting
-
-### Build error wrt missing "buffertools" module
-
-> Build error: Cannot find module 'buffertools' from  .../node_modules/react-jsonschema-form/node_modules/deeper
-
-This is [an issue](https://github.com/othiym23/node-deeper/issues/3#issuecomment-206232232) in the way `deeper` handles the optional `buffertools` dependency (by using try/catch around a require('buffertools')).
-
-If you use **webpack** you can do the following to ignore this import:
-
-```javascript
-module.exports = {
-  entry: "app",
-  output: { ... },
-  plugins: [
-    new webpack.IgnorePlugin(/^(buffertools)$/), // unwanted "deeper" dependency
-    ...
-  ]
-}
-```
-
-If you are using **browserify** instead, do the following:
-
-```javascript
-    var bundler = browserify({ ... yourconfig ... }).ignore('buffertools')
-```
-
-
 ## Contributing
 
 ### Development server

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "react": "^15.0.0"
   },
   "dependencies": {
-    "deeper": "^2.1.0",
     "jsonschema": "^1.0.2",
     "setimmediate": "^1.0.4"
   },

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
-import deeper from "deeper";
+
+import { deepEquals } from "../../utils";
 
 
 import {
@@ -20,7 +21,7 @@ function objectKeysHaveChanged(formData, state) {
     return true;
   }
   // deep check on sorted keys
-  if (!deeper(newKeys.sort(), oldKeys.sort())) {
+  if (!deepEquals(newKeys.sort(), oldKeys.sort())) {
     return true;
   }
   return false;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
 import "setimmediate";
-import deeper from "deeper";
 
 import TitleField from "./components/fields/TitleField";
 import DescriptionField from "./components/fields/DescriptionField";
@@ -296,8 +295,88 @@ export function retrieveSchema(schema, definitions={}) {
   return {...$refSchema, ...localSchema};
 }
 
+function isArguments (object) {
+  return Object.prototype.toString.call(object) === "[object Arguments]";
+}
+
+export function deepEquals(a, b, ca = [], cb = []) {
+  // Partially extracted from node-deeper and adapted to exclude comparison
+  // checks for functions.
+  // https://github.com/othiym23/node-deeper
+  if (a === b) {
+    return true;
+  } else if (typeof a === "function" || typeof b === "function") {
+    // Assume all functions are equivalent
+    // see https://github.com/mozilla-services/react-jsonschema-form/issues/255
+    return true;
+  } else if (typeof a !== "object" || typeof b !== "object") {
+    return false;
+  } else if (a === null || b === null) {
+    return false;
+  } else if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  } else if (a instanceof RegExp && b instanceof RegExp) {
+    return a.source === b.source &&
+    a.global === b.global &&
+    a.multiline === b.multiline &&
+    a.lastIndex === b.lastIndex &&
+    a.ignoreCase === b.ignoreCase;
+  } else if (isArguments(a) || isArguments(b)) {
+    if (!(isArguments(a) && isArguments(b))) {
+      return false;
+    }
+    let slice = Array.prototype.slice;
+    return deepEquals(slice.call(a), slice.call(b), ca, cb);
+  } else {
+    if (a.constructor !== b.constructor) {
+      return false;
+    }
+
+    let ka = Object.keys(a);
+    let kb = Object.keys(b);
+    // don't bother with stack acrobatics if there's nothing there
+    if (ka.length === 0 && kb.length === 0) {
+      return true;
+    }
+    if (ka.length !== kb.length) {
+      return false;
+    }
+
+    let cal = ca.length;
+    while (cal--) {
+      if (ca[cal] === a) {
+        return cb[cal] === b;
+      }
+    }
+    ca.push(a);
+    cb.push(b);
+
+    ka.sort();
+    kb.sort();
+    for (var j = ka.length - 1; j >= 0; j--) {
+      if (ka[j] !== kb[j]) {
+        return false;
+      }
+    }
+
+    let key;
+    for (let k = ka.length - 1; k >= 0; k--) {
+      key = ka[k];
+      if (!deepEquals(a[key], b[key], ca, cb)) {
+        return false;
+      }
+    }
+
+    ca.pop();
+    cb.pop();
+
+    return true;
+  }
+}
+
 export function shouldRender(comp, nextProps, nextState) {
-  return !deeper(comp.props, nextProps) || !deeper(comp.state, nextState);
+  const {props, state} = comp;
+  return !deepEquals(props, nextProps) || !deepEquals(state, nextState);
 }
 
 export function toIdSchema(schema, id, definitions) {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import {
   asNumber,
   dataURItoBlob,
+  deepEquals,
   getDefaultFormState,
   isMultiSelect,
   mergeObjects,
@@ -690,6 +691,17 @@ describe("utils", () => {
       expect(name).eql("test.png");
       expect(blob).to.have.property("size").eql(8);
       expect(blob).to.have.property("type").eql("image/png");
+    });
+  });
+
+  describe("deepEquals()", () => {
+    // Note: deepEquals implementation being extracted from node-deeper, it's
+    // worthless to reproduce all the tests existing for it; so we focus on the
+    // behavioral differences we introduced.
+    it("should assume functions are always equivalent", () => {
+      expect(deepEquals(() => {}, () => {})).eql(true);
+      expect(deepEquals({foo(){}}, {foo(){}})).eql(true);
+      expect(deepEquals({foo: {bar(){}}}, {foo: {bar(){}}})).eql(true);
     });
   });
 });

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -13,13 +13,9 @@ module.exports = {
     publicPath: "/static/"
   },
   plugins: [
-    new webpack.IgnorePlugin(/^(buffertools)$/), // unwanted "deeper" dependency
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin()
   ],
-  node: {
-    Buffer: "mock",
-  },
   module: {
     loaders: [
       {

--- a/webpack.config.dist.js
+++ b/webpack.config.dist.js
@@ -12,16 +12,12 @@ module.exports = {
     libraryTarget: "umd"
   },
   plugins: [
-    new webpack.IgnorePlugin(/^(buffertools)$/), // unwanted "deeper" dependency
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify("production")
       }
     })
   ],
-  node: {
-    Buffer: "mock",
-  },
   devtool: "source-map",
   externals: {
     react: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -10,7 +10,6 @@ module.exports = {
     publicPath: "/static/"
   },
   plugins: [
-    new webpack.IgnorePlugin(/^(buffertools)$/), // unwanted "deeper" dependency
     new ExtractTextPlugin("styles.css", {allChunks: true}),
     new webpack.DefinePlugin({
       "process.env": {
@@ -20,9 +19,6 @@ module.exports = {
   ],
   resolve: {
     extensions: ["", ".js", ".jsx", ".css"]
-  },
-  node: {
-    Buffer: "mock",
   },
   module: {
     loaders: [


### PR DESCRIPTION
This removes our dependency to [deeper](https://github.com/othiym23/node-deeper), introduces a new `deepEquals` util leveraging part of its implementation and tweaks the comparison alg. to whitelist functions, so that solves #255 as well.

We had troubles with *deeper* in the past, and the project doesn't seem to move forward anymore (see [this PR](https://github.com/othiym23/node-deeper/pull/4) which has not even received a comment in 3 months), so I think now is a good time to move to something else more immediately suited to our needs.