### PR TITLE
Adds prop topBar for hiding display of Topbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
   - [Form data validation](#form-data-validation)
      - [Live validation](#live-validation)
      - [Custom validation](#custom-validation)
+     - [Error List Display](#error-list-display)
   - [Styling your forms](#styling-your-forms)
   - [Schema definitions and references](#schema-definitions-and-references)
   - [JSON Schema supporting status](#json-schema-supporting-status)
@@ -709,7 +710,6 @@ The `registry` is an object containing the registered custom fields and widgets 
  - `definitions`: The root schema [definitions](#schema-definitions-and-references), if any.
 
 The registry is passed down the component tree, so you can access it from your custom field and `SchemaField` components.
-
 ### Custom SchemaField
 
 **Warning:** This is a powerful feature as you can override the whole form behavior and easily mess it up. Handle with care.
@@ -836,6 +836,27 @@ render(<Form schema={schema} validate={validate} />);
 > - The `validate()` function must **always** return the `errors` object
 >   received as second argument.
 > - The `validate()` function is called **after** the JSON schema validation.
+
+### Error List Display
+
+Form data allows you to hide the display of the validation Header.
+
+To disable the Error List display, you can set Form's showErrorList prop to false. Doing so will still validate the form but only the inline display will show.
+
+```js
+const schema = {
+  type: "object",
+  required: ["foo"],
+  properties: {
+    foo: {type: "string"},
+    bar: {type: "string"},
+  }
+};
+
+render(<Form schema={schema} showErrorList={false}/>);
+
+```
+
 
 
 ## Styling your forms

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -69,7 +69,9 @@ export default class Form extends Component {
 
   renderErrors() {
     const {status, errors} = this.state;
-    if (status !== "editing" && errors.length) {
+    const {topBar} = this.props;
+
+    if (status !== "editing" && errors.length && topBar != false) {
       return <ErrorList errors={errors} />;
     }
     return null;
@@ -193,6 +195,7 @@ if (process.env.NODE_ENV !== "production") {
     fields: PropTypes.objectOf(PropTypes.func),
     onChange: PropTypes.func,
     onError: PropTypes.func,
+    topBar: PropTypes.bool,
     onSubmit: PropTypes.func,
     id: PropTypes.string,
     className: PropTypes.string,

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -69,9 +69,9 @@ export default class Form extends Component {
 
   renderErrors() {
     const {status, errors} = this.state;
-    const {topBar} = this.props;
+    const {showErrorList} = this.props;
 
-    if (status !== "editing" && errors.length && topBar != false) {
+    if (status !== "editing" && errors.length && showErrorList != false) {
       return <ErrorList errors={errors} />;
     }
     return null;
@@ -195,7 +195,7 @@ if (process.env.NODE_ENV !== "production") {
     fields: PropTypes.objectOf(PropTypes.func),
     onChange: PropTypes.func,
     onError: PropTypes.func,
-    topBar: PropTypes.bool,
+    showErrorList: PropTypes.bool,
     onSubmit: PropTypes.func,
     id: PropTypes.string,
     className: PropTypes.string,

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -330,5 +330,51 @@ describe("Validation", () => {
         });
       });
     });
+
+    describe("Topbar prop validation", () => {
+      describe("Required fields", () => {
+        const schema = {
+          type: "object",
+          required: ["foo"],
+          properties: {
+            foo: {type: "string"},
+            bar: {type: "string"},
+          }
+        };
+
+        var comp, node, onError;
+
+        beforeEach(() => {
+          onError = sandbox.spy();
+          const compInfo = createFormComponent({schema, formData: {
+            foo: undefined
+          }, onError, topBar: false});
+          comp = compInfo.comp;
+          node = compInfo.node;
+
+          Simulate.submit(node);
+        });
+
+        it("should validate a required field", () => {
+          expect(comp.state.errors)
+            .to.have.length.of(1);
+          expect(comp.state.errors[0].message)
+            .eql(`requires property "foo"`);
+        });
+
+        it("should not render Topbar errors if prop true", () => {
+          expect(node.querySelectorAll(".errors li"))
+            .to.have.length.of(0);
+        });
+
+        it("should trigger the onError handler", () => {
+          sinon.assert.calledWith(onError, sinon.match(errors => {
+            return errors[0].message === `requires property "foo"`;
+          }));
+        });
+      });
+
+    });
+
   });
 });

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -331,7 +331,7 @@ describe("Validation", () => {
       });
     });
 
-    describe("Topbar prop validation", () => {
+    describe("showErrorList prop validation", () => {
       describe("Required fields", () => {
         const schema = {
           type: "object",
@@ -348,7 +348,7 @@ describe("Validation", () => {
           onError = sandbox.spy();
           const compInfo = createFormComponent({schema, formData: {
             foo: undefined
-          }, onError, topBar: false});
+          }, onError, showErrorList: false});
           comp = compInfo.comp;
           node = compInfo.node;
 
@@ -362,7 +362,7 @@ describe("Validation", () => {
             .eql(`requires property "foo"`);
         });
 
-        it("should not render Topbar errors if prop true", () => {
+        it("should not render error list if showErrorList prop true", () => {
           expect(node.querySelectorAll(".errors li"))
             .to.have.length.of(0);
         });


### PR DESCRIPTION
I added a property topBar to allow the toggle of the Error message bar to be hidden along with some test. [Issue 251](https://github.com/mozilla-services/react-jsonschema-form/issues/251) had also mentioned having the option of setting the top bar hidden.