### PR TITLE
Fix #275: Denote optional field more explicitely.

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,8 +791,8 @@ Simply pass a `fields` object having a `TitleField` property to your `Form` comp
 
 ```jsx
 
-const CustomTitleField = ({title, required}) => {
-  const legend = required ? title + '*' : title;
+const CustomTitleField = ({title, required, root}) => {
+  const legend = root || required ? title + '*' : title;
   return <div id="custom">{legend}</div>;
 };
 
@@ -807,6 +807,8 @@ render((
         fields={fields} />
 ), document.getElementById("app"));
 ```
+
+> Note: the Boolean `root` prop denotes if the associated field is the root Form schema field itself; usually, you want to consider it to be always required.
 
 ### Custom descriptions
 

--- a/playground/samples/arrays.js
+++ b/playground/samples/arrays.js
@@ -1,6 +1,12 @@
 module.exports = {
   schema: {
     type: "object",
+    required: [
+      "listOfStrings",
+      "multipleChoicesList",
+      "fixedItemsList",
+      "nestedList",
+    ],
     properties: {
       listOfStrings: {
         type: "array",

--- a/playground/samples/date.js
+++ b/playground/samples/date.js
@@ -2,6 +2,7 @@ module.exports = {
   schema: {
     title: "Date and time widgets",
     type: "object",
+    required: ["native", "alternative"],
     properties: {
       native: {
         title: "Native",

--- a/playground/samples/large.js
+++ b/playground/samples/large.js
@@ -13,6 +13,7 @@ module.exports = {
     },
     title: "A rather large form",
     type: "object",
+    required: ["string"],
     properties: {
       string: {
         type: "string",
@@ -31,5 +32,7 @@ module.exports = {
     }
   },
   uiSchema: {},
-  formData: {}
+  formData: {
+    string: "This is large."
+  }
 };

--- a/playground/samples/nested.js
+++ b/playground/samples/nested.js
@@ -2,7 +2,7 @@ module.exports = {
   schema: {
     title: "A list of tasks",
     type: "object",
-    required: ["title"],
+    required: ["title", "tasks"],
     properties: {
       title: {
         type: "string",

--- a/playground/samples/numbers.js
+++ b/playground/samples/numbers.js
@@ -2,6 +2,13 @@ module.exports = {
   schema: {
     type: "object",
     title: "Number fields & widgets",
+    required: [
+      "number",
+      "integer",
+      "numberEnum",
+      "integerRange",
+      "integerRangeSteps"
+    ],
     properties: {
       number: {
         title: "Number",

--- a/playground/samples/ordering.js
+++ b/playground/samples/ordering.js
@@ -2,7 +2,7 @@ module.exports = {
   schema: {
     title: "A registration form",
     type: "object",
-    required: ["firstName", "lastName"],
+    required: ["firstName", "lastName", "password"],
     properties: {
       password: {
         type: "string",

--- a/playground/samples/references.js
+++ b/playground/samples/references.js
@@ -12,6 +12,9 @@ module.exports = {
       }
     },
     type: "object",
+    "required": [
+      "shipping_address"
+    ],
     properties: {
       billing_address: {
         title: "Billing address",

--- a/playground/samples/simple.js
+++ b/playground/samples/simple.js
@@ -3,7 +3,7 @@ module.exports = {
     title: "A registration form",
     description: "A simple form example.",
     type: "object",
-    required: ["firstName", "lastName"],
+    required: ["firstName", "lastName", "password"],
     properties: {
       firstName: {
         type: "string",

--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -5,6 +5,16 @@ module.exports = {
   schema: {
     title: "Widgets",
     type: "object",
+    required: [
+      "stringFormats",
+      "boolean",
+      "string",
+      "secret",
+      "disabled",
+      "readonly",
+      "widgetOptions",
+      "selectWidgetOptions",
+    ],
     properties: {
       stringFormats: {
         type: "object",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -166,6 +166,7 @@ export default class Form extends Component {
         onSubmit={this.onSubmit}>
         {this.renderErrors()}
         <_SchemaField
+          root
           schema={schema}
           uiSchema={uiSchema}
           errorSchema={errorSchema}

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -18,12 +18,12 @@ import FileWidget from "./../widgets/FileWidget";
 import CheckboxesWidget from "./../widgets/CheckboxesWidget";
 
 
-function ArrayFieldTitle({TitleField, idSchema, title, required}) {
+function ArrayFieldTitle({TitleField, idSchema, title, required, root}) {
   if (!title) {
     return null;
   }
   const id = `${idSchema.$id}__title`;
-  return <TitleField id={id} title={title} required={required} />;
+  return <TitleField id={id} title={title} required={required} root={root} />;
 }
 
 function ArrayFieldDescription({DescriptionField, idSchema, description}) {
@@ -36,6 +36,7 @@ function ArrayFieldDescription({DescriptionField, idSchema, description}) {
 
 class ArrayField extends Component {
   static defaultProps = {
+    root: false,
     uiSchema: {},
     idSchema: {},
     registry: getDefaultRegistry(),
@@ -154,6 +155,7 @@ class ArrayField extends Component {
 
   renderNormalArray() {
     const {
+      root,
       schema,
       uiSchema,
       errorSchema,
@@ -176,7 +178,8 @@ class ArrayField extends Component {
           TitleField={TitleField}
           idSchema={idSchema}
           title={title}
-          required={required} />
+          required={required}
+          root={root} />
         {schema.description ?
           <ArrayFieldDescription
             DescriptionField={DescriptionField}
@@ -247,6 +250,7 @@ class ArrayField extends Component {
 
   renderFixedArray() {
     const {
+      root,
       schema,
       uiSchema,
       errorSchema,
@@ -277,7 +281,8 @@ class ArrayField extends Component {
           TitleField={TitleField}
           idSchema={idSchema}
           title={title}
-          required={required} />
+          required={required}
+          root={root} />
         {schema.description ?
           <div className="field-description">{schema.description}</div> : null}
         <div className="row array-item-list">{
@@ -394,6 +399,7 @@ function AddButton({onClick, disabled}) {
 
 if (process.env.NODE_ENV !== "production") {
   ArrayField.propTypes = {
+    root: PropTypes.bool.isRequired,
     schema: PropTypes.object.isRequired,
     uiSchema: PropTypes.object,
     idSchema: PropTypes.object,

--- a/src/components/fields/LabelText.js
+++ b/src/components/fields/LabelText.js
@@ -10,8 +10,8 @@ function LabelText({label, required}) {
   return (
     <span>
       <span className="label-text">{label}</span>
-      <sup className="field-optional text-muted"
-        style={{marginLeft: ".5rem"}}>Optional</sup>
+      <span className="field-optional text-muted"
+        style={{marginLeft: ".5rem", fontWeight: "normal"}}>- Optional</span>
     </span>
   );
 }

--- a/src/components/fields/LabelText.js
+++ b/src/components/fields/LabelText.js
@@ -1,0 +1,26 @@
+import React, { PropTypes } from "react";
+
+
+function LabelText({label, required}) {
+  // Only denote optionality
+  // see https://uxdesign.cc/design-better-forms-96fadca0f49c
+  if (required) {
+    return <span className="label-text">{label}</span>;
+  }
+  return (
+    <span>
+      <span className="label-text">{label}</span>
+      <sup className="field-optional text-muted"
+        style={{marginLeft: ".5rem"}}>Optional</sup>
+    </span>
+  );
+}
+
+if (process.env.NODE_ENV !== "production") {
+  LabelText.propTypes = {
+    label: PropTypes.string.isRequired,
+    required: PropTypes.bool.isRequired,
+  };
+}
+
+export default LabelText;

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -29,6 +29,7 @@ function objectKeysHaveChanged(formData, state) {
 
 class ObjectField extends Component {
   static defaultProps = {
+    root: false,
     uiSchema: {},
     errorSchema: {},
     idSchema: {},
@@ -85,6 +86,7 @@ class ObjectField extends Component {
 
   render() {
     const {
+      root,
       uiSchema,
       errorSchema,
       idSchema,
@@ -117,7 +119,8 @@ class ObjectField extends Component {
         {title ? <TitleField
                    id={`${idSchema.$id}__title`}
                    title={title}
-                   required={required} /> : null}
+                   required={required}
+                   root={root} /> : null}
         {schema.description ?
           <DescriptionField
             id={`${idSchema.$id}__description`}
@@ -147,6 +150,7 @@ class ObjectField extends Component {
 
 if (process.env.NODE_ENV !== "production") {
   ObjectField.propTypes = {
+    root: PropTypes.bool.isRequired,
     schema: PropTypes.object.isRequired,
     uiSchema: PropTypes.object,
     errorSchema: PropTypes.object,

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -13,8 +13,9 @@ import ObjectField from "./ObjectField";
 import StringField from "./StringField";
 import UnsupportedField from "./UnsupportedField";
 import DescriptionField from "./DescriptionField";
+import LabelText from "./LabelText";
 
-const REQUIRED_FIELD_SYMBOL = "*";
+
 const COMPONENT_TYPES = {
   "array":     ArrayField,
   "boolean":   BooleanField,
@@ -41,7 +42,7 @@ function getLabel(label, required, id) {
   }
   return (
     <label className="control-label" htmlFor={id}>
-      {required ? label + REQUIRED_FIELD_SYMBOL : label}
+      <LabelText label={label} required={required} />
     </label>
   );
 }

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -183,6 +183,7 @@ function SchemaField(props) {
 }
 
 SchemaField.defaultProps = {
+  root: false,
   uiSchema: {},
   errorSchema: {},
   idSchema: {},
@@ -193,6 +194,7 @@ SchemaField.defaultProps = {
 
 if (process.env.NODE_ENV !== "production") {
   SchemaField.propTypes = {
+    root: PropTypes.bool.isRequired,
     schema: PropTypes.object.isRequired,
     uiSchema: PropTypes.object,
     idSchema: PropTypes.object,

--- a/src/components/fields/TitleField.js
+++ b/src/components/fields/TitleField.js
@@ -3,21 +3,25 @@ import React, {PropTypes} from "react";
 import LabelText from "./LabelText";
 
 
-function TitleField(props) {
-  const {id, title, required} = props;
-  // A root field is always required
+function TitleField({id, title, required, root}) {
   return (
     <legend id={id}>
-      <LabelText label={title} required={required} />
+      <LabelText label={title} required={root || required} />
     </legend>
   );
 }
 
+TitleField.defaultProps = {
+  root: false,
+  required: false,
+};
+
 if (process.env.NODE_ENV !== "production") {
   TitleField.propTypes = {
+    root: PropTypes.bool.isRequired,
+    required: PropTypes.bool.isRequired,
     id: PropTypes.string,
     title: PropTypes.string,
-    required: PropTypes.bool,
   };
 }
 

--- a/src/components/fields/TitleField.js
+++ b/src/components/fields/TitleField.js
@@ -1,11 +1,16 @@
 import React, {PropTypes} from "react";
 
-const REQUIRED_FIELD_SYMBOL = "*";
+import LabelText from "./LabelText";
+
 
 function TitleField(props) {
   const {id, title, required} = props;
-  const legend = required ? title + REQUIRED_FIELD_SYMBOL : title;
-  return <legend id={id}>{legend}</legend>;
+  // A root field is always required
+  return (
+    <legend id={id}>
+      <LabelText label={title} required={required} />
+    </legend>
+  );
 }
 
 if (process.env.NODE_ENV !== "production") {

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -35,9 +35,9 @@ describe("ArrayField", () => {
     it("should render a fieldset legend", () => {
       const {node} = createFormComponent({schema});
 
-      const legend = node.querySelector("fieldset > legend");
+      const legend = node.querySelector("fieldset legend");
 
-      expect(legend.textContent).eql("my list");
+      expect(legend.querySelector(".label-text").textContent).eql("my list");
       expect(legend.id).eql("root__title");
     });
 
@@ -256,7 +256,7 @@ describe("ArrayField", () => {
       it("should render a select widget with a label", () => {
         const {node} = createFormComponent({schema});
 
-        expect(node.querySelector(".field label").textContent)
+        expect(node.querySelector(".field .label-text").textContent)
           .eql("My field");
       });
 
@@ -378,7 +378,7 @@ describe("ArrayField", () => {
     it("should render a select widget with a label", () => {
       const {node} = createFormComponent({schema});
 
-      expect(node.querySelector(".field label").textContent)
+      expect(node.querySelector(".field .label-text").textContent)
         .eql("My field");
     });
 
@@ -510,8 +510,9 @@ describe("ArrayField", () => {
 
     it("should render a fieldset legend", () => {
       const {node} = createFormComponent({schema});
-      const legend = node.querySelector("fieldset > legend");
-      expect(legend.textContent).eql("List of fixed items");
+      const legend = node.querySelector("fieldset legend");
+      expect(legend.querySelector(".label-text").textContent)
+        .eql("List of fixed items");
       expect(legend.id).eql("root__title");
     });
 

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -253,7 +253,7 @@ describe("Form", () => {
 
       const {node} = createFormComponent({schema});
 
-      expect(node.querySelector("legend").textContent)
+      expect(node.querySelector("legend .label-text").textContent)
         .eql("custom title");
     });
 

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -31,7 +31,7 @@ describe("NumberField", () => {
         title: "foo"
       }});
 
-      expect(node.querySelector(".field label").textContent)
+      expect(node.querySelector(".field .label-text").textContent)
         .eql("foo");
     });
 
@@ -122,7 +122,7 @@ describe("NumberField", () => {
         title: "foo",
       }});
 
-      expect(node.querySelector(".field label").textContent)
+      expect(node.querySelector(".field .label-text").textContent)
         .eql("foo");
     });
 

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -116,7 +116,7 @@ describe("ObjectField", () => {
       const {node} = createFormComponent({schema});
 
       expect(node.querySelector("[for=root_baz] .field-optional").textContent)
-        .eql("Optional");
+        .eql("- Optional");
     });
 
     it("should fill fields with form data", () => {

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -245,4 +245,37 @@ describe("ObjectField", () => {
       expect(ids).eql(["root_bar", "root_foo"]);
     });
   });
+
+  describe("denoted required field", () => {
+    it("should consider a root Form ObjectField as required", () => {
+      const schema = {
+        title: "Form title",
+        type: "object",
+        properties: {foo: {type: "string"}}
+      };
+
+      const {node} = createFormComponent({schema});
+
+      expect(node.querySelector(".field-object legend .field-optional"))
+        .to.be.null;
+    });
+
+    it("should denote optional sub object fields", () => {
+      const schema = {
+        title: "Form title",
+        type: "object",
+        properties: {
+          foo: {
+            type: "object",
+            properties: {bar: {type: "string"}}
+          }
+        }
+      };
+
+      const {node} = createFormComponent({schema});
+
+      expect(node.querySelector(".field-object .field-object legend .field-optional"))
+        .to.not.be.null;
+    });
+  });
 });

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -33,6 +33,9 @@ describe("ObjectField", () => {
         },
         bar: {
           type: "boolean",
+        },
+        baz: {
+          type: "string",
         }
       }
     };
@@ -49,7 +52,7 @@ describe("ObjectField", () => {
 
       const legend = node.querySelector("fieldset > legend");
 
-      expect(legend.textContent).eql("my object");
+      expect(legend.querySelector(".label-text").textContent).eql("my object");
       expect(legend.id).eql("root__title");
     });
 
@@ -78,11 +81,11 @@ describe("ObjectField", () => {
         .eql("bar");
     });
 
-    it("should render a string property", () => {
+    it("should render string fields", () => {
       const {node} = createFormComponent({schema});
 
       expect(node.querySelectorAll(".field input[type=text]"))
-        .to.have.length.of(1);
+        .to.have.length.of(2);
     });
 
     it("should render a boolean property", () => {
@@ -107,8 +110,13 @@ describe("ObjectField", () => {
       // Required field is <input type="text" required="">
       expect(node.querySelector("input[type=text]").getAttribute("required"))
         .eql("");
-      expect(node.querySelector(".field-string label").textContent)
-        .eql("Foo*");
+    });
+
+    it("should handle optional values", () => {
+      const {node} = createFormComponent({schema});
+
+      expect(node.querySelector("[for=root_baz] .field-optional").textContent)
+        .eql("Optional");
     });
 
     it("should fill fields with form data", () => {
@@ -155,7 +163,7 @@ describe("ObjectField", () => {
         "ui:order": ["bar", "foo"]
       }});
       const labels = [].map.call(
-        node.querySelectorAll(".field > label"), l => l.textContent);
+        node.querySelectorAll(".field .label-text"), l => l.textContent);
 
       expect(labels).eql(["bar", "foo"]);
     });
@@ -194,7 +202,7 @@ describe("ObjectField", () => {
         "ui:order": ["bar", "foo"]
       }});
       const labels = [].map.call(
-        node.querySelectorAll(".field > label"), l => l.textContent);
+        node.querySelectorAll(".field .label-text"), l => l.textContent);
 
       expect(labels).eql(["bar", "foo"]);
     });
@@ -222,7 +230,7 @@ describe("ObjectField", () => {
         }
       }});
       const labels = [].map.call(
-        node.querySelectorAll(".field > label"), l => l.textContent);
+        node.querySelectorAll(".field label .label-text"), l => l.textContent);
 
       expect(labels).eql(["bar", "foo"]);
     });

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -32,7 +32,7 @@ describe("StringField", () => {
         title: "foo"
       }});
 
-      expect(node.querySelector(".field label").textContent)
+      expect(node.querySelector(".field .label-text").textContent)
         .eql("foo");
     });
 
@@ -111,7 +111,7 @@ describe("StringField", () => {
         title: "foo",
       }});
 
-      expect(node.querySelector(".field label").textContent)
+      expect(node.querySelector(".field .label-text").textContent)
         .eql("foo");
     });
 
@@ -353,7 +353,7 @@ describe("StringField", () => {
         title: "foo",
       }, uiSchema});
 
-      expect(node.querySelector(".field label").textContent)
+      expect(node.querySelector(".field .label-text").textContent)
         .eql("foo");
     });
 
@@ -509,7 +509,7 @@ describe("StringField", () => {
         title: "foo",
       }, uiSchema});
 
-      expect(node.querySelector(".field label").textContent)
+      expect(node.querySelector(".field .label-text").textContent)
         .eql("foo");
     });
 
@@ -662,7 +662,7 @@ describe("StringField", () => {
         title: "foo",
       }});
 
-      expect(node.querySelector(".field label").textContent)
+      expect(node.querySelector(".field .label-text").textContent)
         .eql("foo");
     });
 
@@ -756,7 +756,7 @@ describe("StringField", () => {
         title: "foo",
       }});
 
-      expect(node.querySelector(".field label").textContent)
+      expect(node.querySelector(".field .label-text").textContent)
         .eql("foo");
     });
 

--- a/test/TitleField_test.js
+++ b/test/TitleField_test.js
@@ -36,6 +36,16 @@ describe("TitleField", () => {
     expect(node.tagName).eql("LEGEND");
   });
 
+  it("should contain the field title", () => {
+    const props = {
+      title: "Field title",
+      required: true
+    };
+    const {node} = createComponent(TitleFieldWrapper, props);
+
+    expect(node.querySelector(".label-text").textContent).eql(props.title);
+  });
+
   it("should have the expected id", () => {
     const props = {
       title: "Field title",
@@ -57,13 +67,14 @@ describe("TitleField", () => {
     expect(node.querySelector(".field-optional").textContent).eql("- Optional");
   });
 
-  it("should add an asterisk to the title, when field is required", () => {
+  it("should always denote a root field title as required", () => {
     const props = {
       title: "Field title",
-      required: true
+      required: false,
+      root: true,
     };
     const {node} = createComponent(TitleFieldWrapper, props);
 
-    expect(node.textContent).eql(props.title);
+    expect(node.querySelector(".field-optional")).to.be.null;
   });
 });

--- a/test/TitleField_test.js
+++ b/test/TitleField_test.js
@@ -33,7 +33,7 @@ describe("TitleField", () => {
     };
     const {node} = createComponent(TitleFieldWrapper, props);
 
-    expect(node.tagName).to.equal("LEGEND");
+    expect(node.tagName).eql("LEGEND");
   });
 
   it("should have the expected id", () => {
@@ -44,17 +44,17 @@ describe("TitleField", () => {
     };
     const {node} = createComponent(TitleFieldWrapper, props);
 
-    expect(node.id).to.equal("sample_id");
+    expect(node.id).eql("sample_id");
   });
 
-  it("should include only title, when field is not required", () => {
+  it("should denote an optional field", () => {
     const props = {
       title: "Field title",
       required: false
     };
     const {node} = createComponent(TitleFieldWrapper, props);
 
-    expect(node.textContent).to.equal(props.title);
+    expect(node.querySelector(".field-optional").textContent).eql("Optional");
   });
 
   it("should add an asterisk to the title, when field is required", () => {
@@ -64,6 +64,6 @@ describe("TitleField", () => {
     };
     const {node} = createComponent(TitleFieldWrapper, props);
 
-    expect(node.textContent).to.equal(props.title + "*");
+    expect(node.textContent).eql(props.title);
   });
 });

--- a/test/TitleField_test.js
+++ b/test/TitleField_test.js
@@ -54,7 +54,7 @@ describe("TitleField", () => {
     };
     const {node} = createComponent(TitleFieldWrapper, props);
 
-    expect(node.querySelector(".field-optional").textContent).eql("Optional");
+    expect(node.querySelector(".field-optional").textContent).eql("- Optional");
   });
 
   it("should add an asterisk to the title, when field is required", () => {


### PR DESCRIPTION
Refs #275, WiP, cc @kav; patch deployed to [gh-pages](https://mozilla-services.github.io/react-jsonschema-form).

Denoting optional fields instead of required ones, as suggested in [these UX guidelines for forms](https://uxdesign.cc/design-better-forms-96fadca0f49c):

![uxforms](https://cloud.githubusercontent.com/assets/41547/16777733/ff57bf3a-486a-11e6-88f8-4d8050f9d24b.png)

Edit: revamped the patch with better styling for optional fields. it now prevents the Form root schema field to be considered as optional:

![](http://i.imgur.com/i07EEcG.png)

Thoughts?