### PR TITLE
fix HiddenWidget error when value is undefined

### DIFF
--- a/src/components/widgets/HiddenWidget.js
+++ b/src/components/widgets/HiddenWidget.js
@@ -3,7 +3,7 @@ import React, { PropTypes } from "react";
 
 function HiddenWidget({id, value}) {
   return (
-    <input type="hidden" id={id} value={value} />
+    <input type="hidden" id={id} value={typeof value === "undefined" ? "" : value} />
   );
 }
 


### PR DESCRIPTION
This commit makes sure that HiddenWidget is always a 'controller' component. If HiddenWidget's value was undefined, and later on it threw this error when giving it some value: 

>"Warning: HiddenWidget is changing an uncontrolled input of type hidden to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components".