### PR TITLE
Allows the modification of default fields

### DIFF
--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -32,6 +32,9 @@ function getFieldComponent(schema, uiSchema, fields) {
   if (typeof field === "string" && field in fields) {
     return fields[field];
   }
+  if (schema.type != "object" && schema.type in fields) {
+    return fields[schema.type];
+  }
   return COMPONENT_TYPES[schema.type] || UnsupportedField;
 }
 


### PR DESCRIPTION
This addition in `getFieldComponent` function allows us to override default type fields components by customized fields without needing to specify `ui:field` in the uiSchema. This is useful if you want to render the schema in another context than a form. 

I have added an exception for `object` type because of the complexity of the component.
