### PR TITLE
Fix #284: Introduce a field template API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
      - [Placeholders](#placeholders)
      - [Form attributes](#form-attributes)
   - [Advanced customization](#advanced-customization)
+     - [Field template](#field-template)
+     - [Custom widgets and fields](#custom-widgets-and-fields)
      - [Custom widget components](#custom-widget-components)
         - [Custom component registration](#custom-component-registration)
         - [Custom widget options](#custom-widget-options)

--- a/README.md
+++ b/README.md
@@ -553,9 +553,9 @@ Form component supports the following html attributes:
 
 ### Field templates
 
-To take control over the inner organization of each field (each form row), you can use a generic *field template*.
+To take control over the inner organization of each field (each form row), you can define a custom *field template*.
 
-A custom field template is a React stateless component being passed properties so you can structure your form row as you like:
+A field template is basically a React stateless component being passed field-related props so you can structure your form row as you like:
 
 ```jsx
 function CustomFieldTemplate(props) {

--- a/README.md
+++ b/README.md
@@ -580,16 +580,16 @@ render((
 The following props are passed to a custom field template component:
 
 - `id`: The id of the field in the hierarchy. You can use it to render a label targetting the wrapped widget;
-- `classNames`: A string containing the base bootstrap CSS classes merged with any custom ones defined in your uiSchema;
-- `label`: The label for this field;
-- `children`: The field component instance itself;
-- `errors`: A component instance listing any encountered errors;
+- `classNames`: A string containing the base bootstrap CSS classes merged with any [custom ones](#custom-css-class-names) defined in your uiSchema;
+- `label`: The computed label for this field, as a string;
+- `description`: A component instance rendering the field description, if any defined (this will use any [custom `DescriptionField`](#custom-descriptions) defined);
+- `children`: The field or widget component instance for this field row;
+- `errors`: A component instance listing any encountered errors for this field;
 - `help`: A component instance rendering any `ui:help` uiSchema directive defined;
-- `description`: A component instance rendering the field description, if any defined;
 - `hidden`: A boolean value stating if the field should be hidden;
 - `required`: A boolean value stating if the field is required;
 - `readonly`: A boolean value stating if the field is read-only;
-- `displayLabel`: A boolean value stating if the label should be rendered or not. This is useful for nested fields in array where you don't want to clutter the UI.
+- `displayLabel`: A boolean value stating if the label should be rendered or not. This is useful for nested fields in arrays where you don't want to clutter the UI.
 
 > Note: you can only define a single field template for a form. If you need many, it's probably time to look for [custom fields](#custom-field-components) instead.
 

--- a/README.md
+++ b/README.md
@@ -551,7 +551,49 @@ Form component supports the following html attributes:
 
 ## Advanced customization
 
-The API allows to specify your own custom *widgets* and *fields* components:
+### Field templates
+
+To take control over the inner organization of each field (each form row), you can use a generic *field template*.
+
+A custom field template is a React stateless component being passed properties so you can structure your form row as you like:
+
+```jsx
+function CustomFieldTemplate(props) {
+  const {id, classNames, label, help, required, description, errors, children} = props;
+  return (
+    <div className={classNames}>
+      <label htmlFor={id}>{label}{required ? "*" : null}</label>
+      {description}
+      {children}
+      {errors}
+      {help}
+    </div>
+  );
+}
+
+render((
+  <Form schema={schema}
+        FieldTemplate={CustomFieldTemplate} />,
+), document.getElementById("app"));
+```
+
+The following props are passed to a custom field template component:
+
+- `id`: The id of the field in the hierarchy. You can use it to render a label targetting the wrapped widget;
+- `classNames`: A string containing the base bootstrap CSS classes merged with any custom ones defined in your uiSchema;
+- `label`: The label for this field;
+- `children`: The field component instance itself;
+- `errors`: A component instance listing any encountered errors;
+- `help`: A component instance rendering any `ui:help` uiSchema directive defined;
+- `description`: A component instance rendering the field description, if any defined;
+- `hidden`: A boolean value stating if the field should be hidden;
+- `required`: A boolean value stating if the field is required;
+- `readonly`: A boolean value stating if the field is read-only;
+- `displayLabel`: A boolean value stating if the label should be rendered or not. This is useful for nested fields in array where you don't want to clutter the UI.
+
+### Custom widgets and fields
+
+The API allows to specify your own custom *widget* and *field* components:
 
 - A *widget* represents a HTML tag for the user to enter data, eg. `input`, `select`, etc.
 - A *field* usually wraps one or more widgets and most often handles internal field state; think of a field as a form row, including the labels.

--- a/README.md
+++ b/README.md
@@ -551,9 +551,9 @@ Form component supports the following html attributes:
 
 ## Advanced customization
 
-### Field templates
+### Field template
 
-To take control over the inner organization of each field (each form row), you can define a custom *field template*.
+To take control over the inner organization of each field (each form row), you can define a *field template* for your form.
 
 A field template is basically a React stateless component being passed field-related props so you can structure your form row as you like:
 
@@ -590,6 +590,8 @@ The following props are passed to a custom field template component:
 - `required`: A boolean value stating if the field is required;
 - `readonly`: A boolean value stating if the field is read-only;
 - `displayLabel`: A boolean value stating if the label should be rendered or not. This is useful for nested fields in array where you don't want to clutter the UI.
+
+> Note: you can only define a single field template for a form. If you need many, it's probably time to look for [custom fields](#custom-field-components) instead.
 
 ### Custom widgets and fields
 

--- a/playground/samples/date.js
+++ b/playground/samples/date.js
@@ -20,7 +20,7 @@ module.exports = {
       },
       alternative: {
         title: "Alternative",
-        description: "These work on every platform.",
+        description: "These work on most platforms.",
         type: "object",
         properties: {
           "alt-datetime": {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -125,10 +125,11 @@ export default class Form extends Component {
     const fields = Object.assign({
       SchemaField: _SchemaField,
       TitleField: _TitleField,
-      DescriptionField: _DescriptionField
+      DescriptionField: _DescriptionField,
     }, this.props.fields);
     return {
       fields,
+      FieldTemplate: this.props.FieldTemplate,
       widgets: this.props.widgets || {},
       definitions: this.props.schema.definitions || {},
     };
@@ -193,6 +194,7 @@ if (process.env.NODE_ENV !== "production") {
       PropTypes.object,
     ])),
     fields: PropTypes.objectOf(PropTypes.func),
+    FieldTemplate: PropTypes.func,
     onChange: PropTypes.func,
     onError: PropTypes.func,
     showErrorList: PropTypes.bool,

--- a/src/components/fields/DescriptionField.js
+++ b/src/components/fields/DescriptionField.js
@@ -2,6 +2,9 @@ import React, {PropTypes} from "react";
 
 function DescriptionField(props) {
   const {id, description} = props;
+  if (!description) {
+    return null;
+  }
   if (typeof description === "string") {
     return <p id={id} className="field-description">{description}</p>;
   } else {

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -165,14 +165,13 @@ function SchemaField(props) {
   const label = props.schema.title || schema.title || name;
   const description = props.schema.description || schema.description;
   const errors = errorSchema.__errors;
-  const isError = errors && errors.length > 0;
   const help = uiSchema["ui:help"];
   const hidden = uiSchema["ui:widget"] === "hidden";
   const classNames = [
     "form-group",
     "field",
     `field-${type}`,
-    isError ? "field-error has-error" : "",
+    errors && errors.length > 0 ? "field-error has-error" : "",
     uiSchema.classNames,
   ].join(" ").trim();
 

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -16,12 +16,12 @@ import UnsupportedField from "./UnsupportedField";
 
 const REQUIRED_FIELD_SYMBOL = "*";
 const COMPONENT_TYPES = {
-  "array":   ArrayField,
-  "boolean": BooleanField,
-  "integer": NumberField,
-  "number":  NumberField,
-  "object":  ObjectField,
-  "string":  StringField,
+  array:   ArrayField,
+  boolean: BooleanField,
+  integer: NumberField,
+  number:  NumberField,
+  object:  ObjectField,
+  string:  StringField,
 };
 
 function getFieldComponent(schema, uiSchema, fields) {

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -75,19 +75,19 @@ function ErrorList(props) {
   );
 }
 
-function DefaultTemplate({
-    type,
+function DefaultTemplate(props) {
+  const {
+    id,
     classNames,
-    errors,
     label,
+    children,
+    errors,
+    help,
     description,
     hidden,
-    help,
     required,
     displayLabel,
-    id,
-    children,
-  }) {
+  } = props;
   if (hidden) {
     return children;
   }
@@ -104,24 +104,23 @@ function DefaultTemplate({
 
 if (process.env.NODE_ENV !== "production") {
   DefaultTemplate.propTypes = {
-    type: PropTypes.string.isRequired,
     id: PropTypes.string,
     classNames: PropTypes.string,
     label: PropTypes.string,
-    description: PropTypes.element,
+    children: PropTypes.node.isRequired,
+    errors: PropTypes.element,
     help: PropTypes.element,
+    description: PropTypes.element,
     hidden: PropTypes.bool,
     required: PropTypes.bool,
     readonly: PropTypes.bool,
     displayLabel: PropTypes.bool,
-    children: PropTypes.node.isRequired,
   };
 }
 
 DefaultTemplate.defaultProps = {
-  classNames: "",
-  errorSchema: {errors: []},
   hidden: false,
+  readonly: false,
   required: false,
   displayLabel: true,
 };
@@ -179,7 +178,6 @@ function SchemaField(props) {
     description: <DescriptionField id={id + "__description"} description={description} />,
     help: <Help help={help} />,
     errors: <ErrorList errors={errors} />,
-    type,
     id,
     label,
     hidden,

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -13,14 +13,15 @@ import ObjectField from "./ObjectField";
 import StringField from "./StringField";
 import UnsupportedField from "./UnsupportedField";
 
+
 const REQUIRED_FIELD_SYMBOL = "*";
 const COMPONENT_TYPES = {
-  "array":     ArrayField,
-  "boolean":   BooleanField,
-  "integer":   NumberField,
-  "number":    NumberField,
-  "object":    ObjectField,
-  "string":    StringField,
+  "array":   ArrayField,
+  "boolean": BooleanField,
+  "integer": NumberField,
+  "number":  NumberField,
+  "object":  ObjectField,
+  "string":  StringField,
 };
 
 function getFieldComponent(schema, uiSchema, fields) {
@@ -34,7 +35,8 @@ function getFieldComponent(schema, uiSchema, fields) {
   return COMPONENT_TYPES[schema.type] || UnsupportedField;
 }
 
-function getLabel(label, required, id) {
+function Label(props) {
+  const {label, required, id} = props;
   if (!label) {
     return null;
   }
@@ -45,7 +47,8 @@ function getLabel(label, required, id) {
   );
 }
 
-function renderHelp(help) {
+function Help(props) {
+  const {help} = props;
   if (!help) {
     return null;
   }
@@ -55,12 +58,16 @@ function renderHelp(help) {
   return <div className="help-block">{help}</div>;
 }
 
-function ErrorList({errors}) {
+function ErrorList(props) {
+  const {errors = []} = props;
+  if (errors.length === 0) {
+    return null;
+  }
   return (
     <div>
       <p/>
       <ul className="error-detail bs-callout bs-callout-info">{
-        (errors || []).map((error, index) => {
+        errors.map((error, index) => {
           return <li className="text-danger" key={index}>{error}</li>;
         })
       }</ul>
@@ -68,10 +75,10 @@ function ErrorList({errors}) {
   );
 }
 
-function Wrapper({
+function DefaultTemplate({
     type,
     classNames,
-    errorSchema,
+    errors,
     label,
     description,
     hidden,
@@ -80,55 +87,38 @@ function Wrapper({
     displayLabel,
     id,
     children,
-    DescriptionField,
   }) {
   if (hidden) {
     return children;
   }
-  const errors = errorSchema.__errors;
-  const isError = errors && errors.length > 0;
-  const classList = [
-    "form-group",
-    "field",
-    `field-${type}`,
-    isError ? "field-error has-error" : "",
-    classNames,
-  ].join(" ").trim();
   return (
-    <div className={classList}>
-      {displayLabel && label ? getLabel(label, required, id) : null}
-      {displayLabel && description ?
-        <DescriptionField id={`${id}__description`} description={description} /> : null}
+    <div className={classNames}>
+      {displayLabel ? <Label label={label} required={required} id={id} /> : null}
+      {displayLabel && description ? description : null}
       {children}
-      {isError ? <ErrorList errors={errors} /> : <div/>}
-      {renderHelp(help)}
+      {errors}
+      {help}
     </div>
   );
 }
 
 if (process.env.NODE_ENV !== "production") {
-  Wrapper.propTypes = {
+  DefaultTemplate.propTypes = {
     type: PropTypes.string.isRequired,
     id: PropTypes.string,
     classNames: PropTypes.string,
     label: PropTypes.string,
-    description: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.element,
-    ]),
-    help: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.element,
-    ]),
+    description: PropTypes.element,
+    help: PropTypes.element,
     hidden: PropTypes.bool,
     required: PropTypes.bool,
+    readonly: PropTypes.bool,
     displayLabel: PropTypes.bool,
     children: PropTypes.node.isRequired,
-    DescriptionField: PropTypes.func,
   };
 }
 
-Wrapper.defaultProps = {
+DefaultTemplate.defaultProps = {
   classNames: "",
   errorSchema: {errors: []},
   hidden: false,
@@ -138,9 +128,10 @@ Wrapper.defaultProps = {
 
 function SchemaField(props) {
   const {uiSchema, errorSchema, idSchema, name, required, registry} = props;
-  const {definitions, fields} = registry;
+  const {definitions, fields, FieldTemplate = DefaultTemplate} = registry;
   const schema = retrieveSchema(props.schema, definitions);
   const FieldComponent = getFieldComponent(schema, uiSchema, fields);
+  const {DescriptionField} = fields;
   const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);
   const readonly = Boolean(props.readonly || uiSchema["ui:readonly"]);
 
@@ -162,25 +153,44 @@ function SchemaField(props) {
     displayLabel = false;
   }
 
-  return (
-    <Wrapper
-      label={props.schema.title || schema.title || name}
-      description={props.schema.description || schema.description}
-      errorSchema={errorSchema}
-      hidden={uiSchema["ui:widget"] === "hidden"}
-      help={uiSchema["ui:help"]}
-      required={required}
-      type={schema.type}
-      displayLabel={displayLabel}
-      id={idSchema.$id}
-      classNames={uiSchema.classNames}
-      DescriptionField={fields.DescriptionField}>
-      <FieldComponent {...props}
-        schema={schema}
-        disabled={disabled}
-        readonly={readonly} />
-    </Wrapper>
+  const field = (
+    <FieldComponent {...props}
+      schema={schema}
+      disabled={disabled}
+      readonly={readonly} />
   );
+
+  const {type} = schema;
+  const id = idSchema.$id;
+  const label = props.schema.title || schema.title || name;
+  const description = props.schema.description || schema.description;
+  const errors = errorSchema.__errors;
+  const isError = errors && errors.length > 0;
+  const help = uiSchema["ui:help"];
+  const hidden = uiSchema["ui:widget"] === "hidden";
+  const classNames = [
+    "form-group",
+    "field",
+    `field-${type}`,
+    isError ? "field-error has-error" : "",
+    uiSchema.classNames,
+  ].join(" ").trim();
+
+  const fieldProps = {
+    description: <DescriptionField id={id + "__description"} description={description} />,
+    help: <Help help={help} />,
+    errors: <ErrorList errors={errors} />,
+    type,
+    id,
+    label,
+    hidden,
+    required,
+    readonly,
+    displayLabel,
+    classNames,
+  };
+
+  return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
 }
 
 SchemaField.defaultProps = {
@@ -206,6 +216,7 @@ if (process.env.NODE_ENV !== "production") {
       ])).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
+      FieldTemplate: PropTypes.func,
     })
   };
 }

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -47,6 +47,80 @@ describe("Form", () => {
     });
   });
 
+  describe("Custom field template", () => {
+    const schema = {
+      type: "object",
+      title: "root object",
+      required: ["foo"],
+      properties: {
+        foo: {
+          type: "string",
+          description: "this is description",
+          minLength: 32,
+        }
+      }
+    };
+
+    const uiSchema = {
+      foo: {
+        "ui:help": "this is help"
+      }
+    };
+
+    const formData = {foo: "invalid"};
+
+    function FieldTemplate(props) {
+      const {id, classNames, label, help, required, description, errors, children} = props;
+      return (
+        <div className={"my-template " + classNames}>
+          <label htmlFor={id}>{label}{required ? "*" : null}</label>
+          {description}
+          {children}
+          {errors}
+          {help}
+        </div>
+      );
+    }
+
+    let node;
+
+    beforeEach(() => {
+      node = createFormComponent({
+        schema,
+        uiSchema,
+        formData,
+        FieldTemplate,
+        liveValidate: true,
+      }).node;
+    });
+
+    it("should use the provided field template", () => {
+      expect(node.querySelector(".my-template")).to.exist;
+    });
+
+    it("should use the provided template for labels", () => {
+      expect(node.querySelector(".my-template > label").textContent)
+        .eql("root object");
+      expect(node.querySelector(".my-template .field-string > label").textContent)
+        .eql("foo*");
+    });
+
+    it("should use the provided template for descriptions", () => {
+      expect(node.querySelector("#root_foo__description").textContent)
+        .eql("this is description");
+    });
+
+    it("should use the provided template for errors", () => {
+      expect(node.querySelectorAll(".error-detail li"))
+        .to.have.length.of(1);
+    });
+
+    it("should use the provided template for help", () => {
+      expect(node.querySelector(".help-block").textContent)
+        .eql("this is help");
+    });
+  });
+
   describe("Custom submit buttons", () => {
     it("should submit the form when clicked", () => {
       const onSubmit = sandbox.spy();


### PR DESCRIPTION
Refs #284, WiP. Early feedback appreciated :)

### Field template

To take control over the inner organization of each field (each form row), you can define a *field template* for your form.

A field template is basically a React stateless component being passed field-related props so you can structure your form row as you like:

```jsx
function CustomFieldTemplate(props) {
  const {id, classNames, label, help, required, description, errors, children} = props;
  return (
    <div className={classNames}>
      <label htmlFor={id}>{label}{required ? "*" : null}</label>
      {description}
      {children}
      {errors}
      {help}
    </div>
  );
}

render((
  <Form schema={schema}
        FieldTemplate={CustomFieldTemplate} />,
), document.getElementById("app"));
```

The following props are passed to a custom field template component:

- `id`: The id of the field in the hierarchy. You can use it to render a label targetting the wrapped widget;
- `classNames`: A string containing the base bootstrap CSS classes merged with any [custom ones](#custom-css-class-names) defined in your uiSchema;
- `label`: The computed label for this field, as a string;
- `description`: A component instance rendering the field description, if any defined (this will use any [custom `DescriptionField`](#custom-descriptions) defined);
- `children`: The field or widget component instance for this field row;
- `errors`: A component instance listing any encountered errors for this field;
- `help`: A component instance rendering any `ui:help` uiSchema directive defined;
- `hidden`: A boolean value stating if the field should be hidden;
- `required`: A boolean value stating if the field is required;
- `readonly`: A boolean value stating if the field is read-only;
- `displayLabel`: A boolean value stating if the label should be rendered or not. This is useful for nested fields in arrays where you don't want to clutter the UI.

> Note: you can only define a single field template for a form. If you need many, it's probably time to look for [custom fields](#custom-field-components) instead.