### PR TITLE
Always assign a value to defaults in computeDefaults

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -173,6 +173,11 @@ function computeDefaults(schema, parentDefaults, definitions={}) {
       return acc;
     }, {});
   }
+  
+  if (typeof(defaults) === "undefined") {
+    defaults = {};
+  }
+  
   return defaults;
 }
 


### PR DESCRIPTION
This was causing an issue for me where `computeDefaults` was returning `undefined`, which led to errors being thrown when I was trying to pass default values for `formData`.