### PR TITLE
Enable windows development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 build
 dist
 lib
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ build
 dist
 lib
 
-.idea

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:readme": "toctoc README.md -w",
-    "build:lib": "rimraf lib && NODE_ENV=production babel -d lib/ src/",
-    "build:dist": "rimraf dist && NODE_ENV=production webpack --config webpack.config.dist.js --optimize-minimize",
-    "build:playground": "rimraf build && NODE_ENV=production webpack --config webpack.config.prod.js --optimize-minimize && cp playground/index.prod.html build/index.html",
+    "build:lib": "rimraf lib && cross-env NODE_ENV=production babel -d lib/ src/",
+    "build:dist": "rimraf dist && cross-env NODE_ENV=production webpack --config webpack.config.dist.js --optimize-minimize",
+    "build:playground": "rimraf build && cross-env NODE_ENV=production webpack --config webpack.config.prod.js --optimize-minimize && cp playground/index.prod.html build/index.html",
     "dist": "npm run build:lib && npm run build:dist",
     "lint": "eslint src test",
     "publish-to-gh-pages": "npm run build:playground && gh-pages --dist build/",
     "publish-to-npm": "npm run build:readme && npm run dist && npm publish",
     "start": "node devServer.js",
-    "tdd": "NODE_ENV=test babel-node node_modules/.bin/_mocha --watch --require ./test/setup-jsdom.js 'test/**/*_test.js'",
-    "test": "NODE_ENV=test babel-node node_modules/.bin/_mocha --require ./test/setup-jsdom.js 'test/**/*_test.js'"
+    "tdd": "cross-env NODE_ENV=test  mocha --compilers js:babel-register --watch --require ./test/setup-jsdom.js test/**/*_test.js",
+    "test": " cross-env NODE_ENV=test   mocha --compilers js:babel-register --require ./test/setup-jsdom.js test/**/*_test.js"
   },
   "main": "lib/index.js",
   "files": [
@@ -43,8 +43,10 @@
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "babel-register": "^6.14.0",
     "chai": "^3.3.0",
     "codemirror": "^5.13.2",
+    "cross-env": "^2.0.1",
     "css-loader": "^0.23.1",
     "eslint": "^2.9.0",
     "eslint-plugin-react": "^4.2.3",


### PR DESCRIPTION
Modifies the scripts which set environment variables as these were erroring when trying to build this on my windows machine. Uses the [cross-env package](github.com/kentcdodds/cross-env)

In addition I also ignored the files generated by the commonly used Intellij editors, e.g. webstorm.