### PR TITLE
Support for hiding array type widgets

### DIFF
--- a/playground/samples/hidden.js
+++ b/playground/samples/hidden.js
@@ -1,0 +1,44 @@
+module.exports = {
+  schema: {
+    type: "object",
+    properties: {
+      visible: {
+        type: "string",
+        title: "Inspect elements below",
+      },
+      hiddenString: {
+        type: "string",
+        title: "First name",
+      },
+      hiddenNumber: {
+        title: "Number",
+        type: "number"
+      },
+      hiddenArray: {
+        type: "array",
+        title: "A hidden list",
+        items: {
+          type: "string",
+          enum: ["foo", "bar", "baz"],
+        }
+      },
+    }
+  },
+  uiSchema: {
+    hiddenString: {
+      "ui:widget": "hidden"
+    },
+    hiddenNumber: {
+      "ui:widget": "hidden"
+    },
+    hiddenArray: {
+      "ui:widget": "hidden"
+    }    
+  },
+  formData: {
+    visible: 'To see some hidden items...',
+    hiddenString: 'John Doe',
+    hiddenNumber: 42,
+    hiddenArray: ["foo", "bar"]
+  }
+};

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -11,6 +11,7 @@ import large from "./large";
 import date from "./date";
 import validation from "./validation";
 import files from "./files";
+import hidden from "./hidden";
 
 export const samples = {
   Simple: simple,
@@ -26,4 +27,5 @@ export const samples = {
   "Date & time": date,
   Validation: validation,
   Files: files,
+  Hidden: hidden
 };

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -5,6 +5,7 @@ import {
   isMultiSelect,
   isFilesArray,
   isFixedItems,
+  isHidden,
   allowAdditionalItems,
   optionsList,
   retrieveSchema,
@@ -16,6 +17,7 @@ import {
 import SelectWidget from "./../widgets/SelectWidget";
 import FileWidget from "./../widgets/FileWidget";
 import CheckboxesWidget from "./../widgets/CheckboxesWidget";
+import HiddenWidget from "../widgets/HiddenWidget";
 
 
 function ArrayFieldTitle({TitleField, idSchema, title, required}) {
@@ -140,6 +142,9 @@ class ArrayField extends Component {
 
   render() {
     const {schema, uiSchema} = this.props;
+    if (isHidden(uiSchema)) {
+      return this.renderHidden();
+    }
     if (isFilesArray(schema, uiSchema)) {
       return this.renderFiles();
     }
@@ -376,6 +381,17 @@ class ArrayField extends Component {
           : null
         }
       </div>
+    );
+  }
+
+  renderHidden() {
+    const {idSchema} = this.props;
+    const {items} = this.state;
+    return (
+      <HiddenWidget
+        id={idSchema && idSchema.$id}
+        value={items}
+      />
     );
   }
 }

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from "react";
 
 import {
   isMultiSelect,
+  isHidden,
   retrieveSchema,
   getDefaultRegistry,
   isFilesArray
@@ -167,7 +168,7 @@ function SchemaField(props) {
   const description = props.schema.description || schema.description;
   const errors = errorSchema.__errors;
   const help = uiSchema["ui:help"];
-  const hidden = uiSchema["ui:widget"] === "hidden";
+  const hidden = isHidden(uiSchema);
   const classNames = [
     "form-group",
     "field",

--- a/src/components/widgets/HiddenWidget.js
+++ b/src/components/widgets/HiddenWidget.js
@@ -13,6 +13,7 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number,
+      React.PropTypes.array,
       React.PropTypes.bool,
     ]),
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,6 +53,7 @@ const altWidgetMap = {
   },
   array: {
     checkboxes: CheckboxesWidget,
+    hidden: HiddenWidget
   }
 };
 
@@ -257,6 +258,10 @@ export function isFixedItems(schema) {
   return Array.isArray(schema.items) &&
          schema.items.length > 0 &&
          schema.items.every(item => isObject(item));
+}
+
+export function isHidden(uiSchema) {
+  return uiSchema["ui:widget"] === "hidden";
 }
 
 export function allowAdditionalItems(schema) {

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -944,8 +944,10 @@ describe("uiSchema", () => {
           foo: ["foo", "bar"]
         }});
 
+        // array values will be stored as comma seperated list in the DOM,
+        // it's the best we can do (pull request #324).
         expect(node.querySelector("[type=hidden]").value)
-          .eql(["foo", "bar"]);
+          .eql("foo,bar");
       });
 
       it("should map widget value to a typed state one", () => {

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -909,6 +909,55 @@ describe("uiSchema", () => {
     });
   });
 
+  describe("array", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {
+          type: "array",
+          title: "A hidden list",
+          items: {
+            type: "string",
+            enum: ["foo", "bar", "baz"],
+          },
+          uniqueItems: true
+        }
+      }
+    };
+
+    describe("hidden", () => {
+      const uiSchema = {
+        foo: {
+          "ui:widget": "hidden"
+        }
+      };
+
+      it("should accept a uiSchema object", () => {
+        const {node} = createFormComponent({schema, uiSchema});
+
+        expect(node.querySelectorAll("[type=hidden]"))
+          .to.have.length.of(1);
+      });
+
+      it("should support formData", () => {
+        const {node} = createFormComponent({schema, uiSchema, formData: {
+          foo: ["foo", "bar"]
+        }});
+
+        expect(node.querySelector("[type=hidden]").value)
+          .eql(["foo", "bar"]);
+      });
+
+      it("should map widget value to a typed state one", () => {
+        const {comp} = createFormComponent({schema, uiSchema, formData: {
+          foo: ["foo", "bar"]
+        }});
+
+        expect(comp.state.formData.foo).eql(["foo", "bar"]);
+      });
+    });
+  });
+
   describe("custom root field id", () => {
     it("should use a custom root field id for objects", () => {
       const schema = {


### PR DESCRIPTION
Pull request for https://github.com/mozilla-services/react-jsonschema-form/issues/322

> The limitation is due to the `<input type="hidden" ... />` input field that is used for hidden fields. Probably to support forms that don't submit with React? 

In this PR I've tried to see what happens if we just keep this approach and use it for arrays as well. This is not ideal but IMO better then not supporting hidden fields on arrays at all. 

I'll add some comments to the code for more explanation. 
