### PR TITLE
Radio Support for integers and numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Please note that while standardized, `datetime-local` and `date` input elements 
 
   * `updown`: an `input[type=number]` updown selector;
   * `range`: an `input[type=range]` slider;
+  * `radio`: a radio button group with enum values. **can only be used when `enum` values are specified for this input**
   * by default, a regular `input[type=text]` element is used.
 
 > Note: for numbers, `min`, `max` and `step` input attributes values will be handled according to JSONSchema's `minimum`, `maximium` and `multipleOf` values when they're defined.

--- a/playground/samples/numbers.js
+++ b/playground/samples/numbers.js
@@ -16,6 +16,11 @@ module.exports = {
         title: "Number enum",
         enum: [1, 2, 3]
       },
+      numberEnumRadio: {
+        type: "number",
+        title: "Number enum",
+        enum: [1, 2, 3]
+      },
       integerRange: {
         title: "Integer range",
         type: "integer",
@@ -34,6 +39,9 @@ module.exports = {
   uiSchema: {
     integer: {
       "ui:widget": "updown"
+    },
+    numberEnumRadio: {
+      "ui:widget": "radio"
     },
     integerRange: {
       "ui:widget": "range"

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,11 +44,13 @@ const altWidgetMap = {
   number: {
     updown: UpDownWidget,
     range: RangeWidget,
+    radio: RadioWidget,
     hidden: HiddenWidget,
   },
   integer: {
     updown: UpDownWidget,
     range: RangeWidget,
+    radio: RadioWidget,
     hidden: HiddenWidget,
   },
   array: {

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -606,6 +606,52 @@ describe("uiSchema", () => {
       });
     });
 
+    describe("radio", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "number",
+            enum: [3.14159, 2.718, 1.4142],
+          }
+        }
+      };
+
+      const uiSchema = {
+        foo: {
+          "ui:widget": "radio"
+        }
+      };
+
+      it("should accept a uiSchema object", () => {
+        const {node} = createFormComponent({schema, uiSchema});
+
+        expect(node.querySelectorAll("[type=radio]"))
+          .to.have.length.of(3);
+      });
+
+      it("should support formData", () => {
+        const {node} = createFormComponent({schema, uiSchema, formData: {
+          foo: 2.718
+        }});
+
+        expect(node.querySelectorAll("[type=radio]")[1].checked)
+          .eql(true);
+      });
+
+      it("should update state when value is updated", () => {
+        const {comp, node} = createFormComponent({schema, uiSchema, formData: {
+          foo: 1.4142
+        }});
+
+        Simulate.change(node.querySelectorAll("[type=radio]")[2], {
+          target: {checked: true}
+        });
+
+        expect(comp.state.formData).eql({foo: 1.4142});
+      });
+    });
+
     describe("hidden", () => {
       const uiSchema = {
         foo: {
@@ -718,6 +764,52 @@ describe("uiSchema", () => {
         });
 
         expect(comp.state.formData).eql({foo: 6});
+      });
+    });
+
+    describe("radio", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "integer",
+            enum: [1, 2],
+          }
+        }
+      };
+
+      const uiSchema = {
+        foo: {
+          "ui:widget": "radio"
+        }
+      };
+
+      it("should accept a uiSchema object", () => {
+        const {node} = createFormComponent({schema, uiSchema});
+
+        expect(node.querySelectorAll("[type=radio]"))
+          .to.have.length.of(2);
+      });
+
+      it("should support formData", () => {
+        const {node} = createFormComponent({schema, uiSchema, formData: {
+          foo: 2
+        }});
+
+        expect(node.querySelectorAll("[type=radio]")[1].checked)
+          .eql(true);
+      });
+
+      it("should update state when value is updated", () => {
+        const {comp, node} = createFormComponent({schema, uiSchema, formData: {
+          foo: 1
+        }});
+
+        Simulate.change(node.querySelectorAll("[type=radio]")[1], {
+          target: {checked: true}
+        });
+
+        expect(comp.state.formData).eql({foo: 2});
       });
     });
 


### PR DESCRIPTION
Added an example to the numbers examples as well so you can check it out. 

This works only if user provided an enum for that integer or number. 

This could optionally be added to this pr. Something like this in `getAlternativeWidget` could check that: 

```js
if(
    (schema.type === 'integer' || schema.type === 'integer')
  && widget === 'radio' && !widgetOptions.enumOptions
) {
  throw new Error(`No radio possible without enumOptions`);
}
```