### PR TITLE
Pass data to FieldTemplate as strings instead of as React components

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ A field template is basically a React stateless component being passed field-rel
 
 ```jsx
 function CustomFieldTemplate(props) {
-  const {id, classNames, label, help, required, description, errors, children, fields} = props;
+  const {id, classNames, label, help, required, description, errors, children} = props;
   return (
     <div className={classNames}>
       <label htmlFor={id}>{label}{required ? "*" : null}</label>
@@ -614,7 +614,7 @@ The following props are passed to a custom field template component:
 - `fields`: An array containing all Form's fields including your [custom fields](#custom-field-components) and the built-in fields.
 - `formContext`: The `formContext` object that you passed to Form.
 
-> Note: you can only define a single field template for a form. If you need many, it's probably time to look for [custom fields](#custom-field-components) instead.
+> Note: you can only define a single field template for a form. If you need many, it's probably time to look at [custom fields](#custom-field-components) instead.
 
 ### Custom widgets and fields
 

--- a/README.md
+++ b/README.md
@@ -574,15 +574,21 @@ To take control over the inner organization of each field (each form row), you c
 A field template is basically a React stateless component being passed field-related props so you can structure your form row as you like:
 
 ```jsx
+
+import {Help, ErrorList} from "react-jsonschema-form/lib/components/fields/SchemaField"; // You can import also the default 'Label' from SchemaField. Below we use a custom label.
+
 function CustomFieldTemplate(props) {
   const {id, classNames, label, help, required, description, errors, children} = props;
+
+  const {DescriptionField} = fields;
+
   return (
     <div className={classNames}>
       <label htmlFor={id}>{label}{required ? "*" : null}</label>
-      {description}
+      <DescriptionField id={id + "__description"} description={description} />
       {children}
-      {errors}
-      {help}
+      <ErrorList errors={errors} />
+      <Help help={help} />
     </div>
   );
 }
@@ -595,17 +601,18 @@ render((
 
 The following props are passed to a custom field template component:
 
-- `id`: The id of the field in the hierarchy. You can use it to render a label targetting the wrapped widget;
-- `classNames`: A string containing the base bootstrap CSS classes merged with any [custom ones](#custom-css-class-names) defined in your uiSchema;
-- `label`: The computed label for this field, as a string;
-- `description`: A component instance rendering the field description, if any defined (this will use any [custom `DescriptionField`](#custom-descriptions) defined);
-- `children`: The field or widget component instance for this field row;
-- `errors`: A component instance listing any encountered errors for this field;
-- `help`: A component instance rendering any `ui:help` uiSchema directive defined;
-- `hidden`: A boolean value stating if the field should be hidden;
-- `required`: A boolean value stating if the field is required;
-- `readonly`: A boolean value stating if the field is read-only;
+- `id`: The id of the field in the hierarchy. You can use it to render a label targetting the wrapped widget.
+- `classNames`: A string containing the base bootstrap CSS classes merged with any [custom ones](#custom-css-class-names) defined in your uiSchema.
+- `label`: The computed label for this field, as a string.
+- `description`: A string containing any `ui:description` uiSchema directive defined.
+- `children`: The field or widget component instance for this field row.
+- `errors`: An array of strings listing all generated error messages from encountered errors for this field.
+- `help`: A string containing any `ui:help` uiSchema directive defined.
+- `hidden`: A boolean value stating if the field should be hidden.
+- `required`: A boolean value stating if the field is required.
+- `readonly`: A boolean value stating if the field is read-only.
 - `displayLabel`: A boolean value stating if the label should be rendered or not. This is useful for nested fields in arrays where you don't want to clutter the UI.
+- `fields`: An array containing all Form's fields including your [custom fields](#custom-field-components) and the built-in fields.
 - `formContext`: The `formContext` object that you passed to Form.
 
 > Note: you can only define a single field template for a form. If you need many, it's probably time to look for [custom fields](#custom-field-components) instead.

--- a/README.md
+++ b/README.md
@@ -574,21 +574,15 @@ To take control over the inner organization of each field (each form row), you c
 A field template is basically a React stateless component being passed field-related props so you can structure your form row as you like:
 
 ```jsx
-
-import {Help, ErrorList} from "react-jsonschema-form/lib/components/fields/SchemaField"; // You can import also the default 'Label' from SchemaField. Below we use a custom label.
-
 function CustomFieldTemplate(props) {
-  const {id, classNames, label, help, required, description, errors, children} = props;
-
-  const {DescriptionField} = fields;
-
+  const {id, classNames, label, help, required, description, errors, children, fields} = props;
   return (
     <div className={classNames}>
       <label htmlFor={id}>{label}{required ? "*" : null}</label>
-      <DescriptionField id={id + "__description"} description={description} />
+      {description}
       {children}
-      <ErrorList errors={errors} />
-      <Help help={help} />
+      {errors}
+      {help}
     </div>
   );
 }
@@ -599,15 +593,20 @@ render((
 ), document.getElementById("app"));
 ```
 
+If you want to handle the rendering of each element yourself, you can use the props `rawHelp`, `rawDescription` and `rawErrors`.
+
 The following props are passed to a custom field template component:
 
 - `id`: The id of the field in the hierarchy. You can use it to render a label targetting the wrapped widget.
 - `classNames`: A string containing the base bootstrap CSS classes merged with any [custom ones](#custom-css-class-names) defined in your uiSchema.
 - `label`: The computed label for this field, as a string.
-- `description`: A string containing any `ui:description` uiSchema directive defined.
+- `description`: A component instance rendering the field description, if any defined (this will use any [custom `DescriptionField`](#custom-descriptions) defined).
+- `rawDescription`: A string containing any `ui:description` uiSchema directive defined.
 - `children`: The field or widget component instance for this field row.
-- `errors`: An array of strings listing all generated error messages from encountered errors for this field.
-- `help`: A string containing any `ui:help` uiSchema directive defined.
+- `errors`: A component instance listing any encountered errors for this field.
+- `rawErrors`: An array of strings listing all generated error messages from encountered errors for this field.
+- `help`: A component instance rendering any `ui:help` uiSchema directive defined.
+- `rawHelp`: A string containing any `ui:help` uiSchema directive defined. **NOTE:** `rawHelp` will be `undefined` if passed `ui:help` is a React component instead of a string.
 - `hidden`: A boolean value stating if the field should be hidden.
 - `required`: A boolean value stating if the field is required.
 - `readonly`: A boolean value stating if the field is read-only.

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -48,7 +48,7 @@ function Label(props) {
   );
 }
 
-function Help(props) {
+export function Help(props) {
   const {help} = props;
   if (!help) {
     // See #312: Ensure compatibility with old versions of React.
@@ -60,7 +60,7 @@ function Help(props) {
   return <div className="help-block">{help}</div>;
 }
 
-function ErrorList(props) {
+export function ErrorList(props) {
   const {errors = []} = props;
   if (errors.length === 0) {
     return <div />;
@@ -89,17 +89,26 @@ function DefaultTemplate(props) {
     hidden,
     required,
     displayLabel,
+    fields,
+    formContext
   } = props;
   if (hidden) {
     return children;
   }
+
+  const {DescriptionField} = fields;
+
   return (
     <div className={classNames}>
       {displayLabel ? <Label label={label} required={required} id={id} /> : null}
-      {displayLabel && description ? description : null}
+      {displayLabel && description ?
+        <DescriptionField id={id + "__description"}
+                          description={description}
+                          formContext={formContext} />
+        : null}
       {children}
-      {errors}
-      {help}
+      <ErrorList errors={errors} />
+      <Help help={help} />
     </div>
   );
 }
@@ -110,13 +119,14 @@ if (process.env.NODE_ENV !== "production") {
     classNames: PropTypes.string,
     label: PropTypes.string,
     children: PropTypes.node.isRequired,
-    errors: PropTypes.element,
-    help: PropTypes.element,
-    description: PropTypes.element,
+    errors: PropTypes.arrayOf(PropTypes.string),
+    help: PropTypes.string,
+    description: PropTypes.string,
     hidden: PropTypes.bool,
     required: PropTypes.bool,
     readonly: PropTypes.bool,
     displayLabel: PropTypes.bool,
+    fields: PropTypes.object,
     formContext: PropTypes.object,
   };
 }
@@ -133,7 +143,6 @@ function SchemaField(props) {
   const {definitions, fields, formContext, FieldTemplate = DefaultTemplate} = registry;
   const schema = retrieveSchema(props.schema, definitions);
   const FieldComponent = getFieldComponent(schema, uiSchema, fields);
-  const {DescriptionField} = fields;
   const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);
   const readonly = Boolean(props.readonly || uiSchema["ui:readonly"]);
   const autofocus = Boolean(props.autofocus || uiSchema["ui:autofocus"]);
@@ -182,11 +191,9 @@ function SchemaField(props) {
   ].join(" ").trim();
 
   const fieldProps = {
-    description: <DescriptionField id={id + "__description"}
-                                   description={description}
-                                   formContext={formContext} />,
-    help: <Help help={help} />,
-    errors: <ErrorList errors={errors} />,
+    description,
+    help,
+    errors,
     id,
     label,
     hidden,
@@ -195,6 +202,7 @@ function SchemaField(props) {
     displayLabel,
     classNames,
     formContext,
+    fields,
   };
 
   return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -13,7 +13,6 @@ import ObjectField from "./ObjectField";
 import StringField from "./StringField";
 import UnsupportedField from "./UnsupportedField";
 
-
 const REQUIRED_FIELD_SYMBOL = "*";
 const COMPONENT_TYPES = {
   array:   ArrayField,
@@ -48,7 +47,7 @@ function Label(props) {
   );
 }
 
-export function Help(props) {
+function Help(props) {
   const {help} = props;
   if (!help) {
     // See #312: Ensure compatibility with old versions of React.
@@ -60,7 +59,7 @@ export function Help(props) {
   return <div className="help-block">{help}</div>;
 }
 
-export function ErrorList(props) {
+function ErrorList(props) {
   const {errors = []} = props;
   if (errors.length === 0) {
     return <div />;
@@ -89,26 +88,18 @@ function DefaultTemplate(props) {
     hidden,
     required,
     displayLabel,
-    fields,
-    formContext
   } = props;
   if (hidden) {
     return children;
   }
 
-  const {DescriptionField} = fields;
-
   return (
     <div className={classNames}>
       {displayLabel ? <Label label={label} required={required} id={id} /> : null}
-      {displayLabel && description ?
-        <DescriptionField id={id + "__description"}
-                          description={description}
-                          formContext={formContext} />
-        : null}
+      {displayLabel && description ? description : null}
       {children}
-      <ErrorList errors={errors} />
-      <Help help={help} />
+      {errors}
+      {help}
     </div>
   );
 }
@@ -119,9 +110,12 @@ if (process.env.NODE_ENV !== "production") {
     classNames: PropTypes.string,
     label: PropTypes.string,
     children: PropTypes.node.isRequired,
-    errors: PropTypes.arrayOf(PropTypes.string),
-    help: PropTypes.string,
-    description: PropTypes.string,
+    errors: PropTypes.element,
+    rawErrors: PropTypes.arrayOf(PropTypes.string),
+    help: PropTypes.element,
+    rawHelp: PropTypes.string,
+    description: PropTypes.element,
+    rawDescription: PropTypes.string,
     hidden: PropTypes.bool,
     required: PropTypes.bool,
     readonly: PropTypes.bool,
@@ -143,6 +137,7 @@ function SchemaField(props) {
   const {definitions, fields, formContext, FieldTemplate = DefaultTemplate} = registry;
   const schema = retrieveSchema(props.schema, definitions);
   const FieldComponent = getFieldComponent(schema, uiSchema, fields);
+  const {DescriptionField} = fields;
   const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);
   const readonly = Boolean(props.readonly || uiSchema["ui:readonly"]);
   const autofocus = Boolean(props.autofocus || uiSchema["ui:autofocus"]);
@@ -191,9 +186,14 @@ function SchemaField(props) {
   ].join(" ").trim();
 
   const fieldProps = {
-    description,
-    help,
-    errors,
+    description: <DescriptionField id={id + "__description"}
+                                   description={description}
+                                   formContext={formContext} />,
+    rawDescription: description,
+    help: <Help help={help} />,
+    rawHelp: typeof help === "string" ? help : undefined,
+    errors: <ErrorList errors={errors} />,
+    rawErrors: errors,
     id,
     label,
     hidden,

--- a/test/FormContext_test.js
+++ b/test/FormContext_test.js
@@ -40,8 +40,8 @@ describe("FormContext", () => {
       formContext
     });
 
-    expect(node.querySelectorAll("#" + formContext.foo))
-      .to.have.length.of(1);
+    expect(node.querySelector("#" + formContext.foo))
+      .to.exist;
   });
 
   it("should be passed to custom widget", () => {
@@ -54,8 +54,31 @@ describe("FormContext", () => {
       formContext
     });
 
-    expect(node.querySelectorAll("#" + formContext.foo))
-      .to.have.length.of(1);
+    expect(node.querySelector("#" + formContext.foo))
+      .to.exist;
+  });
+
+  it("should be passed to TemplateField", () => {
+    function CustomTemplateField({formContext}) {
+      return <div id={formContext.foo} />;
+    }
+
+    const {node} = createFormComponent({
+      schema: {
+        type: "object",
+        title: "A title",
+        properties: {
+          prop: {
+            type:  "string"
+          }
+        }
+      },
+      FieldTemplate: CustomTemplateField,
+      formContext
+    });
+
+    expect(node.querySelector("#" + formContext.foo))
+      .to.exist;
   });
 
   it("should be passed to custom TitleField", () => {
@@ -75,23 +98,20 @@ describe("FormContext", () => {
       formContext
     });
 
-    expect(node.querySelectorAll("#" + formContext.foo))
-      .to.have.length.of(1);
+    expect(node.querySelector("#" + formContext.foo))
+      .to.exist;
   });
 
   it("should be passed to custom DescriptionField", () => {
     const fields = {DescriptionField: CustomComponent};
 
     const {node} = createFormComponent({
-      schema: {type: "string"},
-      uiSchema: {
-        "ui:description": "A description"
-      },
+      schema: {type: "string", description: "A description"},
       fields,
       formContext
     });
 
-    expect(node.querySelectorAll("#" + formContext.foo))
-      .to.have.length.of(1);
+    expect(node.querySelector("#" + formContext.foo))
+      .to.exist;
   });
 });

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -6,9 +6,6 @@ import { findDOMNode } from "react-dom";
 
 import Form from "../src";
 import { createFormComponent, createSandbox } from "./test_utils";
-import { Help, ErrorList } from "../src/components/fields/SchemaField";
-import DescriptionField from "../src/components/fields/DescriptionField";
-
 
 describe("Form", () => {
   let sandbox;
@@ -72,15 +69,29 @@ describe("Form", () => {
     const formData = {foo: "invalid"};
 
     function FieldTemplate(props) {
-      const {id, classNames, label, help, required, description, errors, children} = props;
+      const {
+        id,
+        classNames,
+        label,
+        help,
+        rawHelp,
+        required,
+        description,
+        rawDescription,
+        errors,
+        rawErrors,
+        children,
+      } = props;
       return (
         <div className={"my-template " + classNames}>
           <label htmlFor={id}>{label}{required ? "*" : null}</label>
-          <DescriptionField id={`${id}__description`} description={description} />
+          {description}
+          <span id={`${id}__raw_description`}>{`${rawDescription} rendered from the raw format`}</span>
           {children}
-          <ErrorList errors={errors} />
-          <Help help={help} />
+          {errors}
+          {rawErrors ? <ul>{rawErrors.map((error, i) => <li key={i} className="raw-error">{error}</li>)}</ul> : null}
           {help}
+          <span id={`${id}__raw_help`}>{`${rawHelp} rendered from the raw format`}</span>
         </div>
       );
     }
@@ -108,19 +119,34 @@ describe("Form", () => {
         .eql("foo*");
     });
 
-    it("should pass description as text", () => {
+    it("should pass description as the provided React element", () => {
       expect(node.querySelector("#root_foo__description").textContent)
         .eql("this is description");
     });
 
-    it("should use the provided template for errors", () => {
+    it("should pass rawDescription as a string", () => {
+      expect(node.querySelector("#root_foo__raw_description").textContent)
+        .eql("this is description rendered from the raw format");
+    });
+
+    it("should pass errors as the provided React component", () => {
       expect(node.querySelectorAll(".error-detail li"))
         .to.have.length.of(1);
     });
 
-    it("should pass help as text", () => {
+    it("should pass rawErrors as an array of strings", () => {
+      expect(node.querySelectorAll(".raw-error"))
+        .to.have.length.of(1);
+    });
+
+    it("should pass help as a the provided React element", () => {
       expect(node.querySelector(".help-block").textContent)
         .eql("this is help");
+    });
+
+    it("should pass rawHelp as a string", () => {
+      expect(node.querySelector("#root_foo__raw_help").textContent)
+        .eql("this is help rendered from the raw format");
     });
   });
 

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -86,12 +86,19 @@ describe("Form", () => {
         <div className={"my-template " + classNames}>
           <label htmlFor={id}>{label}{required ? "*" : null}</label>
           {description}
-          <span id={`${id}__raw_description`}>{`${rawDescription} rendered from the raw format`}</span>
           {children}
           {errors}
-          {rawErrors ? <ul>{rawErrors.map((error, i) => <li key={i} className="raw-error">{error}</li>)}</ul> : null}
           {help}
-          <span id={`${id}__raw_help`}>{`${rawHelp} rendered from the raw format`}</span>
+          <span className="raw-help">{`${rawHelp} rendered from the raw format`}</span>
+          <span className="raw-description">{`${rawDescription} rendered from the raw format`}</span>
+          {rawErrors ? (
+            <ul>
+              {rawErrors.map(
+                (error, i) => <li key={i} className="raw-error">{error}</li>
+              )}
+            </ul>
+          ) : null
+          }
         </div>
       );
     }
@@ -125,7 +132,7 @@ describe("Form", () => {
     });
 
     it("should pass rawDescription as a string", () => {
-      expect(node.querySelector("#root_foo__raw_description").textContent)
+      expect(node.querySelector(".raw-description").textContent)
         .eql("this is description rendered from the raw format");
     });
 
@@ -145,7 +152,7 @@ describe("Form", () => {
     });
 
     it("should pass rawHelp as a string", () => {
-      expect(node.querySelector("#root_foo__raw_help").textContent)
+      expect(node.querySelector(".raw-help").textContent)
         .eql("this is help rendered from the raw format");
     });
   });

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -6,6 +6,8 @@ import { findDOMNode } from "react-dom";
 
 import Form from "../src";
 import { createFormComponent, createSandbox } from "./test_utils";
+import { Help, ErrorList } from "../src/components/fields/SchemaField";
+import DescriptionField from "../src/components/fields/DescriptionField";
 
 
 describe("Form", () => {
@@ -74,9 +76,10 @@ describe("Form", () => {
       return (
         <div className={"my-template " + classNames}>
           <label htmlFor={id}>{label}{required ? "*" : null}</label>
-          {description}
+          <DescriptionField id={`${id}__description`} description={description} />
           {children}
-          {errors}
+          <ErrorList errors={errors} />
+          <Help help={help} />
           {help}
         </div>
       );
@@ -105,7 +108,7 @@ describe("Form", () => {
         .eql("foo*");
     });
 
-    it("should use the provided template for descriptions", () => {
+    it("should pass description as text", () => {
       expect(node.querySelector("#root_foo__description").textContent)
         .eql("this is description");
     });
@@ -115,7 +118,7 @@ describe("Form", () => {
         .to.have.length.of(1);
     });
 
-    it("should use the provided template for help", () => {
+    it("should pass help as text", () => {
       expect(node.querySelector(".help-block").textContent)
         .eql("this is help");
     });

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -238,6 +238,15 @@ describe("uiSchema", () => {
     });
   });
 
+  it("should accept a react element as help", () => {
+    const schema = {type: "string"};
+    const uiSchema = {"ui:help": (<b>plop</b>)};
+
+    const {node} = createFormComponent({schema, uiSchema});
+
+    expect(node.querySelector("div.help-block").textContent).eql("plop");
+  });
+
   describe("ui:focus", () => {
     const shouldFocus = (schema, uiSchema, selector = "input", formData) => {
       const props = {schema, uiSchema};

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -236,15 +236,6 @@ describe("uiSchema", () => {
 
       expect(node.querySelector("p.help-block").textContent).eql("plop");
     });
-
-    it("should accept a react element as help", () => {
-      const schema = {type: "string"};
-      const uiSchema = {"ui:help": (<b>plop</b>)};
-
-      const {node} = createFormComponent({schema, uiSchema});
-
-      expect(node.querySelector("div.help-block").textContent).eql("plop");
-    });
   });
 
   describe("ui:focus", () => {


### PR DESCRIPTION
This adds flexibility.

An example use case would be when you want the help block to be a tooltip of the label. Then you don't want the help object to be a React component, but a string instead so you can render a tooltip for the label with the help string as the content.

I think this is also more consistent, since we are rendering the label already in TemplateField instead of passing it as a React component.

I exposed `Label`, `Help` and `ErrorList` components from SchemaField with `export`, because they are probably useful for writing a custom TemplateField - should we put these to a separate file?