### PR TITLE
fix undefined value in formData for fileInput that cause incorrect error display

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -115,6 +115,8 @@ function unwrapErrorHandler(errorHandler) {
  * will be used to add custom validation errors for each field.
  */
 export default function validateFormData(formData, schema, customValidate) {
+  formData = undefinedToNullRecursively(formData);
+  
   const {errors} = jsonValidate(formData, schema);
   const errorSchema = toErrorSchema(errors);
 
@@ -131,4 +133,18 @@ export default function validateFormData(formData, schema, customValidate) {
   const newErrors = toErrorList(newErrorSchema);
 
   return {errors: newErrors, errorSchema: newErrorSchema};
+}
+
+function undefinedToNullRecursively(obj) {
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      if(obj[key] === undefined) {
+        obj[key] = null;
+      }
+      else if(typeof obj[key] === 'object') {
+        obj[key] = undefinedToNullRecursively(obj[key]);
+      }
+    }
+  }
+  return obj;
 }


### PR DESCRIPTION
I noticed that in the function `validateFormData()` in `validate.js` will receive `formData` objects that contains an undefined value, which will occur if the form consists of FileInput field that have no file selected.

`jsonValidate` will not map the error to the field instance correctly if the value is `undefined`, result in it mapping the error to the form itself.

My changes should change all `undefined` value to `null` value in the formData, allowing `jsonValidate` to do its job correctly.