### PR TITLE
Added ref to FileWidget.

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ const schema = {
 
 ##### File widget input ref
 
-The included `FileWidget` exposes its `<input type="file"></input>` via `inputRef`.
+The included `FileWidget` exposes a reference to the `<input type="file" />` element node as an `inputRef` component property.
 
 This allows you to programmatically trigger the browser's file selector which can be used in a custom file widget.
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,12 @@ const schema = {
 
 > Note that storing large dataURIs into form state might slow rendering.
 
+##### File widget input ref
+
+The included `FileWidget` exposes its `<input type="file"></input>` via `inputRef`.
+
+This allows you to programmatically trigger the browser's file selector which can be used in a custom file widget.
+
 ### Object fields ordering
 
 The `uiSchema` object spec also allows you to define in which order a given object field properties should be rendered using the `ui:order` property:

--- a/src/components/widgets/FileWidget.js
+++ b/src/components/widgets/FileWidget.js
@@ -100,6 +100,7 @@ class FileWidget extends Component {
       <div>
         <p>
           <input
+            ref={ref => this.inputRef = ref}
             id={id}
             type="file"
             disabled={readonly || disabled}


### PR DESCRIPTION
### Reasons for making this change

With this change, I've added a reference to the `input` element in `FileWidget`. The reason I did this is because I've created a custom widget which is composed of a hidden `FileWidget` and a nice looking button (that way you don't need to have the browser styled file button).

By exposing `inputRef`, I can progammatiacally call the `input`'s choose file by calling: `fileWidgetRef.inputRef.click()` whenever the fancy button is clicked.

I can add documentation and a playground if you'd like.

Also this library is great, thanks! 😄 

### Checklist

* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [x] I've updated docs if needed
* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
