### PR TITLE
Improved documentation on form initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ render((
 ), document.getElementById("app"));
 ```
 
-WARNING: The `formData` field is **not** used only for initialization but it sets the data of the form if your wrapping component rerenders. Therefore make sure you listen to the `onChange` event and update the data you pass to the `formData` field.
+Therefore, if you have situations where your parent component can re-render, make sure you listen to the `onChange` event and update the data you pass to the `formData` field.
 
 ### Form event handlers
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ render((
 ), document.getElementById("app"));
 ```
 
+WARNING: The `formData` field is **not** used only for initialization but it sets the data of the form if your wrapping component rerenders. Therefore make sure you listen to the `onChange` event and update the data you pass to the `formData` field.
+
 ### Form event handlers
 
 #### Form submission


### PR DESCRIPTION
### Reasons for making this change

Through the docs I got the impression that `formData` prop is used for initialization only, which led to a hard-to-detect bug that was happening when the parent element was re-rendering. So I decided to update the documentation so it's more clear. Please feel free to modify the texts that I wrote so they fit well with the rest of the documentation

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
