### PR TITLE
Migrate SchemaField to being an extensible React component

### DIFF
--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -134,6 +134,39 @@ class SchemaField extends Component {
     return this.COMPONENT_TYPES[schema.type] || UnsupportedField;
   }
 
+  shouldDisplayLabel(schema, uiSchema) {
+    let displayLabel = true;
+    if (schema.type === "array") {
+      displayLabel = isMultiSelect(schema) || isFilesArray(schema, uiSchema);
+    }
+    if (schema.type === "object") {
+      displayLabel = false;
+    }
+    if (schema.type === "boolean" && !uiSchema["ui:widget"]) {
+      displayLabel = false;
+    }
+    if (uiSchema["ui:field"]) {
+      displayLabel = false;
+    }
+
+    return displayLabel;
+  }
+
+  buildFieldComponent(FieldComponent, props, schema, disabled, readonly, autofocus, formContext) {
+    return (
+      <FieldComponent {...this.props}
+        schema={schema}
+        disabled={disabled}
+        readonly={readonly}
+        autofocus={autofocus}
+        formContext={formContext}/>
+    );
+  }
+
+  buildFieldTemplate(FieldTemplate, fieldProps, field) {
+    return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
+  }
+
   render() {
     const {uiSchema, errorSchema, idSchema, name, required, registry} = this.props;
     const {definitions, fields, formContext, FieldTemplate = DefaultTemplate} = registry;
@@ -149,28 +182,9 @@ class SchemaField extends Component {
       return <div/>;
     }
 
-    let displayLabel = true;
-    if (schema.type === "array") {
-      displayLabel = isMultiSelect(schema) || isFilesArray(schema, uiSchema);
-    }
-    if (schema.type === "object") {
-      displayLabel = false;
-    }
-    if (schema.type === "boolean" && !uiSchema["ui:widget"]) {
-      displayLabel = false;
-    }
-    if (uiSchema["ui:field"]) {
-      displayLabel = false;
-    }
+    let displayLabel = this.shouldDisplayLabel(schema, uiSchema);
 
-    const field = (
-      <FieldComponent {...this.props}
-        schema={schema}
-        disabled={disabled}
-        readonly={readonly}
-        autofocus={autofocus}
-        formContext={formContext}/>
-    );
+    const field = this.buildFieldComponent(FieldComponent, this.props, schema, disabled, readonly, autofocus, formContext);
 
     const {type} = schema;
     const id = idSchema.$id;
@@ -207,8 +221,10 @@ class SchemaField extends Component {
       fields,
     };
 
-    return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
+    return this.buildFieldTemplate(FieldTemplate, fieldProps, field);
   }
+
+
 }
 
 SchemaField.defaultProps = {

--- a/test/FormContext_test.js
+++ b/test/FormContext_test.js
@@ -60,7 +60,7 @@ describe("FormContext", () => {
 
   it("should be passed to TemplateField", () => {
     function CustomTemplateField({formContext}) {
-      return <div id={formContext.foo} />;
+      return <div id={formContext.foo}/>;
     }
 
     const {node} = createFormComponent({


### PR DESCRIPTION
### Motivation

Currently it's necessary to either completely rewrite or clone SchemaField to make a custom object type.  This allows one to add custom property types or override the default components in a much less heavy-handed way.  

Ideally, for the react-bootstrap example this could be implemented while maintaining compatibility with upstream updates.  Adding a new property would consist of something like this:

``` javascript
import SchemaField from 'react-jsonschema-form';
import specialField from 'components/specialField';

class myCustomSchemaField extends SchemaField {
   constructor() {
      super();
      this.OBJECT_FIELD_COMPONENTS['specialField'] = specialField;
   }
}

...

let registry = { 'SchemaField': myCustomSchemaField }
<Form registry={registry} ... />
```
### Note

This is just code I've ported over from an internal project and from the looks of #358 it may be useful to others to improve pluggability/replacement of the default types.
### Checklist
- [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
- [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
