### PR TITLE
Fix array items order example

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ Array items are orderable by default, and react-jsonschema-form renders move up/
 ```jsx
 const schema = {
   type: "array",
-  properties: {
+  items: {
     type: "string"
   }
 };


### PR DESCRIPTION
Arrays have `items`, not `properties`. The example json schema is not valid and doesn't work with react-jsonschema-forms.
