### PR TITLE
Add ui:order wildcard feature and improve error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ This allows you to programmatically trigger the browser's file selector which ca
 
 ### Object fields ordering
 
-The `uiSchema` object spec also allows you to define in which order a given object field properties should be rendered using the `ui:order` property:
+Since the order of object properties in Javascript and JSON is not guaranteed, the `uiSchema` object spec allows you to define the order in which properties are rendered using the `ui:order` property:
 
 ```jsx
 const schema = {
@@ -409,7 +409,7 @@ render((
 ), document.getElementById("app"));
 ```
 
-For fields for which the order is OK already or a fixed order is not important, you can insert a wildcard `"*"` item in your `ui:oder` definition. All unreferenced fields will be rendered at that point:
+If a guarenteed fixed order is only important for some fields, you can insert a wildcard `"*"` item in your `ui:order` definition. All fields that are not referenced explicitly anywhere in the list will be rendered at that point:
 
 ```js
 const uiSchema = {

--- a/README.md
+++ b/README.md
@@ -408,6 +408,15 @@ render((
         uiSchema={uiSchema} />
 ), document.getElementById("app"));
 ```
+
+For fields for which the order is OK already or a fixed order is not important, you can insert a wildcard `"*"` item in your `ui:oder` definition. All unreferenced fields will be rendered at that point:
+
+```js
+const uiSchema = {
+  "ui:order": ["bar", "*"]
+};
+```
+
 ### Array items ordering
 
 Array items are orderable by default, and react-jsonschema-form renders move up/down buttons alongside them. The `uiSchema` object spec allows you to disable ordering:

--- a/playground/samples/ordering.js
+++ b/playground/samples/ordering.js
@@ -27,7 +27,7 @@ module.exports = {
     }
   },
   uiSchema: {
-    "ui:order": ["firstName", "lastName", "age", "bio", "password"],
+    "ui:order": ["firstName", "lastName", "*", "password"],
     age: {
       "ui:widget": "updown"
     },

--- a/src/utils.js
+++ b/src/utils.js
@@ -250,7 +250,10 @@ export function orderProperties(properties, order) {
     return properties;
   }
 
-  const arrayToHash = arr => arr.reduce((prev, curr) => ({...prev, [curr]: true}), {});
+  const arrayToHash = arr => arr.reduce((prev, curr) => {
+    prev[curr] = true;
+    return prev;
+  }, {});
   const errorPropList = arr => arr.length > 1 ?
     `properties '${arr.join("', '")}'` :
     `property '${arr[0]}'`;

--- a/src/utils.js
+++ b/src/utils.js
@@ -249,16 +249,32 @@ export function orderProperties(properties, order) {
   if (!Array.isArray(order)) {
     return properties;
   }
-  if (order.length !== properties.length) {
-    throw new Error(
-      "uiSchema order list length should match object properties length");
+
+  const arrayToHash = arr => arr.reduce((prev, curr) => {
+    prev[curr] = true;
+    return prev
+  }, {});
+  const propertyHash = arrayToHash(properties);
+  const orderHash = arrayToHash(order);
+  const extraneous = order.find(prop => prop !== '*' && !propertyHash[prop]);
+  if (extraneous) {
+    throw new Error(`uiSchema order list contains extraneous property "${extraneous}"`);
   }
-  const fingerprint = (arr) => [].slice.call(arr).sort().toString();
-  if (fingerprint(order) !== fingerprint(properties)) {
-    throw new Error(
-      "uiSchema order list does not match object properties list");
+  const rest = properties.filter(prop => !orderHash[prop]);
+  const restIndex = order.indexOf('*');
+  if (restIndex === -1) {
+    if (rest.length) {
+      throw new Error(`uiSchema order list does not contain property "${rest[0]}"`);
+    }
+    return order;
   }
-  return order;
+  if (restIndex !== order.lastIndexOf('*')) {
+    throw new Error('uiSchema order list contains more than one wildcard item');
+  }
+
+  const complete = [...order];
+  complete.splice(restIndex, 1, ...rest);
+  return complete;
 }
 
 export function isMultiSelect(schema) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -252,24 +252,24 @@ export function orderProperties(properties, order) {
 
   const arrayToHash = arr => arr.reduce((prev, curr) => {
     prev[curr] = true;
-    return prev
+    return prev;
   }, {});
   const propertyHash = arrayToHash(properties);
   const orderHash = arrayToHash(order);
-  const extraneous = order.find(prop => prop !== '*' && !propertyHash[prop]);
+  const extraneous = order.find(prop => prop !== "*" && !propertyHash[prop]);
   if (extraneous) {
     throw new Error(`uiSchema order list contains extraneous property "${extraneous}"`);
   }
   const rest = properties.filter(prop => !orderHash[prop]);
-  const restIndex = order.indexOf('*');
+  const restIndex = order.indexOf("*");
   if (restIndex === -1) {
     if (rest.length) {
       throw new Error(`uiSchema order list does not contain property "${rest[0]}"`);
     }
     return order;
   }
-  if (restIndex !== order.lastIndexOf('*')) {
-    throw new Error('uiSchema order list contains more than one wildcard item');
+  if (restIndex !== order.lastIndexOf("*")) {
+    throw new Error("uiSchema order list contains more than one wildcard item");
   }
 
   const complete = [...order];

--- a/src/utils.js
+++ b/src/utils.js
@@ -250,21 +250,21 @@ export function orderProperties(properties, order) {
     return properties;
   }
 
-  const arrayToHash = arr => arr.reduce((prev, curr) => {
-    prev[curr] = true;
-    return prev;
-  }, {});
+  const arrayToHash = arr => arr.reduce((prev, curr) => ({...prev, [curr]: true}), {});
+  const errorPropList = arr => arr.length > 1 ?
+    `properties '${arr.join("', '")}'` :
+    `property '${arr[0]}'`;
   const propertyHash = arrayToHash(properties);
   const orderHash = arrayToHash(order);
-  const extraneous = order.find(prop => prop !== "*" && !propertyHash[prop]);
-  if (extraneous) {
-    throw new Error(`uiSchema order list contains extraneous property "${extraneous}"`);
+  const extraneous = order.filter(prop => prop !== "*" && !propertyHash[prop]);
+  if (extraneous.length) {
+    throw new Error(`uiSchema order list contains extraneous ${errorPropList(extraneous)}`);
   }
   const rest = properties.filter(prop => !orderHash[prop]);
   const restIndex = order.indexOf("*");
   if (restIndex === -1) {
     if (rest.length) {
-      throw new Error(`uiSchema order list does not contain property "${rest[0]}"`);
+      throw new Error(`uiSchema order list does not contain ${errorPropList(rest)}`);
     }
     return order;
   }

--- a/test/FormContext_test.js
+++ b/test/FormContext_test.js
@@ -60,7 +60,7 @@ describe("FormContext", () => {
 
   it("should be passed to TemplateField", () => {
     function CustomTemplateField({formContext}) {
-      return <div id={formContext.foo} />;
+      return <div id={formContext.foo}/>;
     }
 
     const {node} = createFormComponent({

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -174,20 +174,20 @@ describe("ObjectField", () => {
 
     it("should throw when order list contains an extraneous property", () => {
       const {node} = createFormComponent({schema, uiSchema: {
-        "ui:order": ["baz", "qux", "bar", "wut?", "foo"]
+        "ui:order": ["baz", "qux", "bar", "wut?", "foo", "huh?"]
       }});
 
       expect(node.querySelector(".config-error").textContent)
-        .to.match(/contains extraneous property "wut\?"/);
+        .to.match(/contains extraneous properties 'wut\?', 'huh\?'/);
     });
 
     it("should throw when order list misses an existing property", () => {
       const {node} = createFormComponent({schema, uiSchema: {
-        "ui:order": ["baz", "qux", "bar"]
+        "ui:order": ["baz", "bar"]
       }});
 
       expect(node.querySelector(".config-error").textContent)
-        .to.match(/does not contain property "foo"/);
+        .to.match(/does not contain properties 'foo', 'qux'/);
     });
 
     it("should throw when more than one wildcard is present", () => {

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -146,36 +146,57 @@ describe("ObjectField", () => {
       type: "object",
       properties: {
         foo: {type: "string"},
-        bar: {type: "string"}
+        bar: {type: "string"},
+        baz: {type: "string"},
+        qux: {type: "string"}
       }
     };
 
     it("should use provided order", () => {
       const {node} = createFormComponent({schema, uiSchema: {
-        "ui:order": ["bar", "foo"]
+        "ui:order": ["baz", "qux", "bar", "foo"]
       }});
       const labels = [].map.call(
         node.querySelectorAll(".field > label"), l => l.textContent);
 
-      expect(labels).eql(["bar", "foo"]);
+      expect(labels).eql(["baz", "qux", "bar", "foo"]);
     });
 
-    it("should throw when order list length mismatches", () => {
+    it("should insert unordered properties at wildcard position", () => {
       const {node} = createFormComponent({schema, uiSchema: {
-        "ui:order": ["bar", "foo", "baz?"]
+        "ui:order": ["baz", "*", "foo"]
+      }});
+      const labels = [].map.call(
+        node.querySelectorAll(".field > label"), l => l.textContent);
+
+      expect(labels).eql(["baz", "bar", "qux", "foo"]);
+    });
+
+    it("should throw when order list contains an extraneous property", () => {
+      const {node} = createFormComponent({schema, uiSchema: {
+        "ui:order": ["baz", "qux", "bar", "wut?", "foo"]
       }});
 
       expect(node.querySelector(".config-error").textContent)
-        .to.match(/should match object properties length/);
+        .to.match(/contains extraneous property "wut\?"/);
     });
 
-    it("should throw when order and properties lists differs", () => {
+    it("should throw when order list misses an existing property", () => {
       const {node} = createFormComponent({schema, uiSchema: {
-        "ui:order": ["bar", "wut?"]
+        "ui:order": ["baz", "qux", "bar"]
       }});
 
       expect(node.querySelector(".config-error").textContent)
-        .to.match(/does not match object properties list/);
+        .to.match(/does not contain property "foo"/);
+    });
+
+    it("should throw when more than one wildcard is present", () => {
+      const {node} = createFormComponent({schema, uiSchema: {
+        "ui:order": ["baz", "*", "bar", "*"]
+      }});
+
+      expect(node.querySelector(".config-error").textContent)
+        .to.match(/contains more than one wildcard/);
     });
 
     it("should order referenced schema definitions", () => {
@@ -228,6 +249,14 @@ describe("ObjectField", () => {
     });
 
     it("should render the widget with the expected id", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {type: "string"},
+          bar: {type: "string"}
+        }
+      };
+
       const {node} = createFormComponent({schema, uiSchema: {
         "ui:order": ["bar", "foo"]
       }});


### PR DESCRIPTION
### Reasons for making this change

It can be tedious to maintain a `ui:order` list for large schemas if you only want to change the order of two or three fields. (I know that, strictly, the order of object properties is undefined, but in practice it always yields a constant order.) This feature lets you insert a wildcard (`"*"`) for all fields that you don't reference explicitly in `ui:order`, like this:

```js
const uiSchema = {
  "ui:order": ["bar", "*"]
};
```

This also helps during development so you don't have to always update your `uiSchema` when you update your `schema`. And it is useful when you dynamically insert properties in a schema and you want those dynamic properties to appear in a specific position.

While implementing this feature, I was able to improve the error messages for invalid `ui:order` values, specifying the exact field that causes the error. This really helps during debugging.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [x] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature