### PR TITLE
Removable and addable options for array items

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
            - [Multiple files](#multiple-files)
            - [File widget input ref](#file-widget-input-ref)
      - [Object fields ordering](#object-fields-ordering)
-     - [Array items ordering](#array-items-ordering)
+     - [Array item options](#array-items-options)
+        - [Orderable option](#orderable-option)
+        - [Addable option](#addable-option)
+        - [Removable option](#deletable-option)
      - [Custom CSS class names](#custom-css-class-names)
      - [Custom labels for enum fields](#custom-labels-for-enum-fields)
      - [Multiple choices list](#multiple-choices-list)
@@ -419,7 +422,9 @@ const uiSchema = {
 };
 ```
 
-### Array items ordering
+### Array item options
+
+#### `orderable` option
 
 Array items are orderable by default, and react-jsonschema-form renders move up/down buttons alongside them. The `uiSchema` object spec allows you to disable ordering:
 
@@ -434,6 +439,32 @@ const schema = {
 const uiSchema = {
   "ui:options":  {
     orderable: false
+  }
+};
+```
+
+#### `addable` option
+
+If either `items` or `additionalItems` contains a schema object, an add button for new items is shown by default. You can turn this off with the `addable` option:
+
+```jsx
+const schema = {
+const uiSchema = {
+  "ui:options":  {
+    addable: false
+  }
+};
+```
+
+#### `removable` option
+
+A remove button is shown by default for an item if `items` contains a schema object, or the item is an `additionalItems` instance. You can turn this off with the `removable` option:
+
+```jsx
+const schema = {
+const uiSchema = {
+  "ui:options":  {
+    removable: false
   }
 };
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
      - [Array item options](#array-item-options)
         - [Orderable option](#orderable-option)
         - [Addable option](#addable-option)
-        - [Removable option](#removale-option)
+        - [Removable option](#removable-option)
      - [Custom CSS class names](#custom-css-class-names)
      - [Custom labels for enum fields](#custom-labels-for-enum-fields)
      - [Multiple choices list](#multiple-choices-list)

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
            - [Multiple files](#multiple-files)
            - [File widget input ref](#file-widget-input-ref)
      - [Object fields ordering](#object-fields-ordering)
-     - [Array item options](#array-items-options)
+     - [Array item options](#array-item-options)
         - [Orderable option](#orderable-option)
         - [Addable option](#addable-option)
-        - [Removable option](#deletable-option)
+        - [Removable option](#removale-option)
      - [Custom CSS class names](#custom-css-class-names)
      - [Custom labels for enum fields](#custom-labels-for-enum-fields)
      - [Multiple choices list](#multiple-choices-list)
@@ -445,10 +445,9 @@ const uiSchema = {
 
 #### `addable` option
 
-If either `items` or `additionalItems` contains a schema object, an add button for new items is shown by default. You can turn this off with the `addable` option:
+If either `items` or `additionalItems` contains a schema object, an add button for new items is shown by default. You can turn this off with the `addable` option in `uiSchema`:
 
 ```jsx
-const schema = {
 const uiSchema = {
   "ui:options":  {
     addable: false
@@ -458,10 +457,9 @@ const uiSchema = {
 
 #### `removable` option
 
-A remove button is shown by default for an item if `items` contains a schema object, or the item is an `additionalItems` instance. You can turn this off with the `removable` option:
+A remove button is shown by default for an item if `items` contains a schema object, or the item is an `additionalItems` instance. You can turn this off with the `removable` option in `uiSchema`:
 
 ```jsx
-const schema = {
 const uiSchema = {
   "ui:options":  {
     removable: false

--- a/playground/samples/arrays.js
+++ b/playground/samples/arrays.js
@@ -49,6 +49,51 @@ module.exports = {
             default: "lorem ipsum"
           }
         }
+      },
+      unorderable: {
+        title: "Unorderable items",
+        type: "array",
+        items: {
+          type: "string",
+          default: "lorem ipsum"
+        }
+      },
+      unremovable: {
+        title: "Unremovable items",
+        type: "array",
+        items: {
+          type: "string",
+          default: "lorem ipsum"
+        }
+      },
+      noToolbar: {
+        title: "No add, remove and order buttons",
+        type: "array",
+        items: {
+          type: "string",
+          default: "lorem ipsum"
+        }
+      },
+      fixedNoToolbar: {
+        title: "Fixed array without buttons",
+        type: "array",
+        items: [
+          {
+            title: "A number",
+            type: "number",
+            default: 42
+          },
+          {
+            title: "A boolean",
+            type: "boolean",
+            default: false
+          }
+        ],
+        additionalItems: {
+          title: "A string",
+          type: "string",
+          default: "lorem ipsum"
+        }
       }
     }
   },
@@ -64,12 +109,40 @@ module.exports = {
       additionalItems: {
         "ui:widget": "updown"
       }
+    },
+    unorderable: {
+      "ui:options": {
+        orderable: false
+      }
+    },
+    unremovable: {
+      "ui:options": {
+        removable: false
+      }
+    },
+    noToolbar: {
+      "ui:options": {
+        addable: false,
+        orderable: false,
+        removable: false
+      }
+    },
+    fixedNoToolbar: {
+      "ui:options": {
+        addable: false,
+        orderable: false,
+        removable: false
+      }
     }
   },
   formData: {
     listOfStrings: ["foo", "bar"],
     multipleChoicesList: ["foo", "bar"],
     fixedItemsList: ["Some text", true, 123],
-    nestedList: [["lorem", "ipsum"], ["dolor"]]
+    nestedList: [["lorem", "ipsum"], ["dolor"]],
+    unorderable: ["one", "two"],
+    unremovable: ["one", "two"],
+    noToolbar: ["one", "two"],
+    fixedNoToolbar: [42, true, "additional item one", "additional item two"]
   }
 };

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -217,8 +217,8 @@ class ArrayField extends Component {
           })
         }</div>
         {addable ? <AddButton
-                   onClick={this.onAddClick}
-                   disabled={disabled || readonly}/> : null}
+                     onClick={this.onAddClick}
+                     disabled={disabled || readonly}/> : null}
       </fieldset>
     );
   }
@@ -289,7 +289,7 @@ class ArrayField extends Component {
       addable: true,
       ...uiSchema["ui:options"]
     };
-    const hasAdd = addable && additionalSchema;
+    const canAdd = addable && additionalSchema;
 
     if (!items || items.length < itemSchemas.length) {
       // to make sure at least all fixed items are generated
@@ -334,7 +334,7 @@ class ArrayField extends Component {
           })
         }</div>
         {
-          hasAdd ? <AddButton
+          canAdd ? <AddButton
                                onClick={this.onAddClick}
                                disabled={disabled || readonly}/> : null
         }
@@ -366,7 +366,7 @@ class ArrayField extends Component {
       moveDown: orderable && canMoveDown,
       remove: removable && canRemove
     };
-    has.toolbar = Object.keys(has).map(key => has[key]).includes(true);
+    has.toolbar = Object.keys(has).some(key => has[key]);
     const btnStyle = {flex: 1, paddingLeft: 6, paddingRight: 6, fontWeight: "bold"};
 
     return (

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -84,6 +84,12 @@ describe("ArrayField", () => {
         .not.eql(null);
     });
 
+    it("should not have an add button if addable is false", () => {
+      const {node} = createFormComponent({schema, uiSchema: {"ui:options": {addable: false}}});
+
+      expect(node.querySelector(".array-item-add button")).to.be.null;
+    });
+
     it("should add a new field when clicking the add button", () => {
       const {node} = createFormComponent({schema});
 
@@ -157,7 +163,7 @@ describe("ArrayField", () => {
       expect(moveDownBtns[1].disabled).eql(true);
     });
 
-    it("should not show move up/down buttons is orderable is false", () => {
+    it("should not show move up/down buttons if orderable is false", () => {
       const {node} = createFormComponent({schema, formData: ["foo", "bar"], uiSchema: {"ui:options": {orderable: false}}});
       const moveUpBtns = node.querySelector(".array-item-move-up");
       const moveDownBtns = node.querySelector(".array-item-move-down");
@@ -175,6 +181,13 @@ describe("ArrayField", () => {
       const inputs = node.querySelectorAll(".field-string input[type=text]");
       expect(inputs).to.have.length.of(1);
       expect(inputs[0].value).eql("bar");
+    });
+
+    it("should not show remove button if removable is false", () => {
+      const {node} = createFormComponent({schema, formData: ["foo", "bar"], uiSchema: {"ui:options": {removable: false}}});
+      const dropBtn = node.querySelector(".array-item-remove");
+
+      expect(dropBtn).to.be.null;
     });
 
     it("should force revalidation when a field is removed", () => {
@@ -583,6 +596,21 @@ describe("ArrayField", () => {
           node.querySelector("fieldset .field-string input[type=text]");
       expect(addInput.id).eql("root_2");
       expect(addInput.value).eql("bar");
+    });
+
+    it("should have an add button if additionalItems is an object", () => {
+      const {node} = createFormComponent({schema: schemaAdditional});
+      expect(node.querySelector(".array-item-add button")).not.to.be.null;
+    });
+
+    it("should not have an add button if additionalItems is not set", () => {
+      const {node} = createFormComponent({schema});
+      expect(node.querySelector(".array-item-add button")).to.be.null;
+    });
+
+    it("should not have an add button if addable is false", () => {
+      const {node} = createFormComponent({schema, uiSchema: {"ui:options": {addable: false}}});
+      expect(node.querySelector(".array-item-add button")).to.be.null;
     });
 
     describe("operations for additional items", () => {


### PR DESCRIPTION
### Reasons for making this change

There are cases where you don't want an add button or a remove button for array items, even though the schema allows it. Just like with the recent `orderable` option. The array items in my current case come from another resource and I fill the array in the background on initial form load; the user should not be able to reorder, add or remove the items via the form. I think this is a common use case.

I refactored the code a little bit to align all variable names (`orderable`, `addable` and `removable` for `uiSchema` settings, and `canMoveUp`, `canMoveDown`, `canDelete` for application logic).

![options](https://cloud.githubusercontent.com/assets/298893/19972421/4d022146-a1e2-11e6-91f9-8c63cf6b6b4c.png)

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [x] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
