### PR TITLE
readme: Add a note about formData

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ render((
 ), document.getElementById("app"));
 ```
 
+NOTE: If your form have a single field, pass a single value to `formData`. ex: `formData='Charlie'`
+
 WARNING: If you have situations where your parent component can re-render, make sure you listen to the `onChange` event and update the data you pass to the `formData` attribute.
 
 ### Form event handlers


### PR DESCRIPTION
### Reasons for making this change

Hi, not sure this is a feature or a bug, so i try to document the current behaviour.

In the case fo a single-field form, looks like we must pass `formData` as the field value instead of an object containing that field value.

I find this counter-intuitive at first sight, so i could dig deeper and add some tests if you want to change this in the future and make formData shape consistent whatever the destination form. (always as an object).

Thanks for this great tool 👍 

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [x] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

