### PR TITLE
ui:options everywhere (fix #370)

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,7 +820,7 @@ render((
 
 > Note: This also applies to [registered custom components](#custom-component-registration).
 
-> Note: The `ui:widget` object API, where a widget and options were specified with `"ui:widget: {component, options}` shape, is deprecated. It will be removed in a future release.
+> Note: Since v0.40.0, the `ui:widget` object API, where a widget and options were specified with `"ui:widget": {component, options}` shape, is deprecated. It will be removed in a future release.
 
 ### Custom field components
 

--- a/README.md
+++ b/README.md
@@ -783,6 +783,8 @@ render((
 
 This is useful if you expose the `uiSchema` as pure JSON, which can't carry functions.
 
+> Note: Until 0.40.0 it was possible to register a widget as object with shape `{ component: MyCustomWidget, options: {...} }`. This undocumented API has been removed. Instead, you can register a custom widget with a React `defaultProps` property. `defaultProps.options` can be an object containing your custom options.
+
 #### Custom widget options
 
 If you need to pass options to your custom widget, you can add a `ui:options` object containing those properties. If the widget has `defaultProps`, the options will be merged with the (optional) options object from `defaultProps`:
@@ -820,7 +822,7 @@ render((
 
 > Note: This also applies to [registered custom components](#custom-component-registration).
 
-> Note: Since v0.40.0, the `ui:widget` object API, where a widget and options were specified with `"ui:widget": {component, options}` shape, is deprecated. It will be removed in a future release.
+> Note: Since v0.41.0, the `ui:widget` object API, where a widget and options were specified with `"ui:widget": {component, options}` shape, is deprecated. It will be removed in a future release.
 
 ### Custom field components
 

--- a/README.md
+++ b/README.md
@@ -550,11 +550,9 @@ By default, checkboxes are stacked but if you prefer them inline:
 
 ```js
 const uiSchema = {
-  "ui:widget": {
-    component: "checkboxes",
-    options: {
-      inline: true
-    }
+  "ui:widget": "checkboxes",
+  "ui:options": {
+    inline: true
   }
 };
 ```
@@ -787,7 +785,7 @@ This is useful if you expose the `uiSchema` as pure JSON, which can't carry func
 
 #### Custom widget options
 
-If you need to pass options to your custom widget, change your `ui:widget` value to be an object having the following structure:
+If you need to pass options to your custom widget, you can add a `ui:options` object containing those properties:
 
 ```jsx
 const schema = {
@@ -800,11 +798,9 @@ function MyCustomWidget(props) {
 }
 
 const uiSchema = {
-  "ui:widget": {
-    options: {
-      backgroundColor: "yellow",
-    },
-    component: MyCustomWidget
+  "ui:widget": MyCustomWidget,
+  "ui:options": {
+    backgroundColor: "yellow"
   }
 };
 
@@ -815,6 +811,8 @@ render((
 ```
 
 > Note: This also applies to [registered custom components](#custom-component-registration).
+
+> Note: The `ui:widget` object API, where a widget and options were specified with `"ui:widget: {component, options}` shape, is deprecated. It will be removed in a future release.
 
 ### Custom field components
 

--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ This is useful if you expose the `uiSchema` as pure JSON, which can't carry func
 
 #### Custom widget options
 
-If you need to pass options to your custom widget, you can add a `ui:options` object containing those properties:
+If you need to pass options to your custom widget, you can add a `ui:options` object containing those properties. If the widget has `defaultProps`, the options will be merged with the (optional) options object from `defaultProps`:
 
 ```jsx
 const schema = {
@@ -794,8 +794,15 @@ const schema = {
 
 function MyCustomWidget(props) {
   const {options} = props;
-  return <input style={{options.backgroundColor}} />;
+  const {color, backgroundColor} = options;
+  return <input style={{color, backgroundColor}} />;
 }
+
+MyCustomWidget.defaultProps = {
+  options: {
+    color: "red"
+  }
+};
 
 const uiSchema = {
   "ui:widget": MyCustomWidget,
@@ -804,6 +811,7 @@ const uiSchema = {
   }
 };
 
+// renders red on yellow input
 render((
   <Form schema={schema}
         uiSchema={uiSchema} />

--- a/playground/samples/numbers.js
+++ b/playground/samples/numbers.js
@@ -41,11 +41,9 @@ module.exports = {
       "ui:widget": "updown"
     },
     numberEnumRadio: {
-      "ui:widget": {
-        component: "radio",
-        options: {
-          inline: true
-        }
+      "ui:widget": "radio",
+      "ui:options": {
+        inline: true
       }
     },
     integerRange: {

--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -111,39 +111,35 @@ module.exports = {
       "ui:readonly": true
     },
     widgetOptions: {
-      "ui:widget": {
-        component: ({value, onChange, options}) => {
-          const {backgroundColor} = options;
-          return (
-            <input className="form-control"
-              onChange={(event) => onChange(event.target.value)}
-              style={{backgroundColor}}
-              value={value} />
-          );
-        },
-        options: {
-          backgroundColor: "yellow",
-        }
+      "ui:widget": ({value, onChange, options}) => {
+        const {backgroundColor} = options;
+        return (
+          <input className="form-control"
+            onChange={(event) => onChange(event.target.value)}
+            style={{backgroundColor}}
+            value={value} />
+        );
+      },
+      "ui:options": {
+        backgroundColor: "yellow"
       }
     },
     selectWidgetOptions: {
-      "ui:widget": {
-        component: ({value, onChange, options}) => {
-          const {enumOptions, backgroundColor} = options;
-          return (
-            <select className="form-control"
-              style={{backgroundColor}}
-              value={value}
-              onChange={(event) => onChange(event.target.value)}>{
-              enumOptions.map(({label, value}, i) => {
-                return <option key={i} value={value}>{label}</option>;
-              })
-            }</select>
-          );
-        },
-        options: {
-          backgroundColor: "pink",
-        }
+      "ui:widget": ({value, onChange, options}) => {
+        const {enumOptions, backgroundColor} = options;
+        return (
+          <select className="form-control"
+            style={{backgroundColor}}
+            value={value}
+            onChange={(event) => onChange(event.target.value)}>{
+            enumOptions.map(({label, value}, i) => {
+              return <option key={i} value={value}>{label}</option>;
+            })
+          }</select>
+        );
+      },
+      "ui:options": {
+        backgroundColor: "pink"
       }
     },
   },

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -179,7 +179,7 @@ class ArrayField extends Component {
     const {definitions, fields} = this.props.registry;
     const {TitleField, DescriptionField} = fields;
     const itemsSchema = retrieveSchema(schema.items, definitions);
-    const {addable} = {addable: true, ...getUiOptions(uiSchema)};
+    const {addable=true} = getUiOptions(uiSchema);
 
     return (
       <fieldset
@@ -225,7 +225,7 @@ class ArrayField extends Component {
     const {widgets, definitions} = this.props.registry;
     const itemsSchema = retrieveSchema(schema.items, definitions);
     const enumOptions = optionsList(itemsSchema);
-    const {widget, ...options} = {widget: "select", ...getUiOptions(uiSchema), enumOptions};
+    const {widget="select", ...options} = {...getUiOptions(uiSchema), enumOptions};
     const Widget = getWidget(schema, widget, widgets);
     return (
       <Widget
@@ -246,7 +246,7 @@ class ArrayField extends Component {
     const title = schema.title || name;
     const {items} = this.state;
     const {widgets} = this.props.registry;
-    const {widget, ...options} = {widget: "files", ...getUiOptions(uiSchema)};
+    const {widget="files", ...options} = getUiOptions(uiSchema);
     const Widget = getWidget(schema, widget, widgets);
     return (
       <Widget
@@ -283,7 +283,7 @@ class ArrayField extends Component {
       retrieveSchema(item, definitions));
     const additionalSchema = allowAdditionalItems(schema) ?
       retrieveSchema(schema.additionalItems, definitions) : null;
-    const {addable} = {addable: true, ...getUiOptions(uiSchema)};
+    const {addable=true} = getUiOptions(uiSchema);
     const canAdd = addable && additionalSchema;
 
     if (!items || items.length < itemSchemas.length) {

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from "react";
 
 import {
-  getAlternativeWidget,
+  getWidget,
   getDefaultFormState,
   getUiOptions,
   isMultiSelect,
@@ -226,7 +226,7 @@ class ArrayField extends Component {
     const itemsSchema = retrieveSchema(schema.items, definitions);
     const enumOptions = optionsList(itemsSchema);
     const {widget, ...options} = {widget: "select", ...getUiOptions(uiSchema), enumOptions};
-    const Widget = getAlternativeWidget(schema, widget, widgets);
+    const Widget = getWidget(schema, widget, widgets);
     return (
       <Widget
         id={idSchema && idSchema.$id}
@@ -242,12 +242,15 @@ class ArrayField extends Component {
   }
 
   renderFiles() {
-    const {schema, idSchema, name, disabled, readonly, autofocus} = this.props;
+    const {schema, uiSchema, idSchema, name, disabled, readonly, autofocus} = this.props;
     const title = schema.title || name;
     const {items} = this.state;
-    const {FileWidget} = this.props.registry.widgets;
+    const {widgets} = this.props.registry;
+    const {widget, ...options} = {widget: "files", ...getUiOptions(uiSchema)};
+    const Widget = getWidget(schema, widget, widgets);
     return (
-      <FileWidget
+      <Widget
+        options={options}
         id={idSchema && idSchema.$id}
         multiple
         onChange={this.onSelectChange}

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -3,6 +3,7 @@ import React, {Component, PropTypes} from "react";
 import {
   getAlternativeWidget,
   getDefaultFormState,
+  getUiOptions,
   isMultiSelect,
   isFilesArray,
   isFixedItems,
@@ -178,10 +179,7 @@ class ArrayField extends Component {
     const {definitions, fields} = this.props.registry;
     const {TitleField, DescriptionField} = fields;
     const itemsSchema = retrieveSchema(schema.items, definitions);
-    const {addable} = {
-      addable: true,
-      ...uiSchema["ui:options"]
-    };
+    const {addable} = {addable: true, ...getUiOptions(uiSchema)};
 
     return (
       <fieldset
@@ -226,17 +224,15 @@ class ArrayField extends Component {
     const {items} = this.state;
     const {widgets, definitions} = this.props.registry;
     const itemsSchema = retrieveSchema(schema.items, definitions);
-
-    const Widget = getAlternativeWidget(schema, uiSchema["ui:widget"] || "select", widgets);
+    const enumOptions = optionsList(itemsSchema);
+    const {widget, ...options} = {widget: "select", ...getUiOptions(uiSchema), enumOptions};
+    const Widget = getAlternativeWidget(schema, widget, widgets);
     return (
       <Widget
         id={idSchema && idSchema.$id}
         multiple
         onChange={this.onSelectChange}
-        options={{
-          ...Widget.defaultProps.options,
-          enumOptions: optionsList(itemsSchema),
-        }}
+        options={options}
         schema={schema}
         value={items}
         disabled={disabled}
@@ -284,10 +280,7 @@ class ArrayField extends Component {
       retrieveSchema(item, definitions));
     const additionalSchema = allowAdditionalItems(schema) ?
       retrieveSchema(schema.additionalItems, definitions) : null;
-    const {addable} = {
-      addable: true,
-      ...uiSchema["ui:options"]
-    };
+    const {addable} = {addable: true, ...getUiOptions(uiSchema)};
     const canAdd = addable && additionalSchema;
 
     if (!items || items.length < itemSchemas.length) {
@@ -435,7 +428,9 @@ if (process.env.NODE_ENV !== "production") {
     schema: PropTypes.object.isRequired,
     uiSchema: PropTypes.shape({
       "ui:options": PropTypes.shape({
-        orderable: PropTypes.bool
+        addable: PropTypes.bool,
+        orderable: PropTypes.bool,
+        removable: PropTypes.bool
       })
     }),
     idSchema: PropTypes.object,

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -24,7 +24,7 @@ function BooleanField(props) {
   } = props;
   const {title} = schema;
   const {widgets, formContext} = registry;
-  const {widget, ...options} = {widget: "checkbox", ...getUiOptions(uiSchema)};
+  const {widget="checkbox", ...options} = getUiOptions(uiSchema);
   const Widget = getWidget(schema, widget, widgets);
   const enumOptions = optionsList({
     enum: [true, false],

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -2,7 +2,7 @@ import React, {PropTypes} from "react";
 
 import {
   defaultFieldValue,
-  getAlternativeWidget,
+  getWidget,
   getUiOptions,
   optionsList,
   getDefaultRegistry
@@ -24,27 +24,25 @@ function BooleanField(props) {
   } = props;
   const {title} = schema;
   const {widgets, formContext} = registry;
-  const {widget, ...options} = getUiOptions(uiSchema);
-  const commonProps = {
-    schema,
-    id: idSchema && idSchema.$id,
-    onChange,
-    label: (title === undefined) ? name : title,
-    value: defaultFieldValue(formData, schema),
-    required,
-    disabled,
-    readonly,
-    registry,
-    formContext,
-    autofocus,
-  };
-  if (widget) {
-    const Widget = getAlternativeWidget(schema, widget, widgets);
-    const enumOptions = optionsList({enum: [true, false], enumNames: schema.enumNames});
-    return <Widget options={{...options, enumOptions}} {...commonProps}/>;
-  }
-  const {CheckboxWidget} = registry.widgets;
-  return <CheckboxWidget {...commonProps}/>;
+  const {widget, ...options} = {widget: "checkbox", ...getUiOptions(uiSchema)};
+  const Widget = getWidget(schema, widget, widgets);
+  const enumOptions = optionsList({
+    enum: [true, false],
+    enumNames: schema.enumNames || ["yes", "no"]
+  });
+  return <Widget
+    options={{...options, enumOptions}}
+    schema={schema}
+    id={idSchema && idSchema.$id}
+    onChange={onChange}
+    label={title === undefined ? name : title}
+    value={defaultFieldValue(formData, schema)}
+    required={required}
+    disabled={disabled}
+    readonly={readonly}
+    registry={registry}
+    formContext={formContext}
+    autofocus={autofocus}/>;
 }
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -3,25 +3,10 @@ import React, {PropTypes} from "react";
 import {
   defaultFieldValue,
   getAlternativeWidget,
+  getUiOptions,
   optionsList,
-  getDefaultRegistry,
-  isObject,
+  getDefaultRegistry
 } from "../../utils";
-
-
-function buildOptions(schema, uiWidget) {
-  // Note: uiWidget can be undefined, a string or an object; we only deal with
-  // the inline option when we're provided a definition object.
-  return {
-    inline: isObject(uiWidget) &&
-            isObject(uiWidget.options) &&
-            uiWidget.options.inline,
-    enumOptions: optionsList(Object.assign({
-      enumNames: ["true", "false"],
-      enum: [true, false]
-    }, {enumNames: schema.enumNames}))
-  };
-}
 
 function BooleanField(props) {
   const {
@@ -39,7 +24,7 @@ function BooleanField(props) {
   } = props;
   const {title} = schema;
   const {widgets, formContext} = registry;
-  const widget = uiSchema["ui:widget"];
+  const {widget, ...options} = getUiOptions(uiSchema);
   const commonProps = {
     schema,
     id: idSchema && idSchema.$id,
@@ -55,7 +40,8 @@ function BooleanField(props) {
   };
   if (widget) {
     const Widget = getAlternativeWidget(schema, widget, widgets);
-    return <Widget options={buildOptions(schema, uiSchema["ui:widget"])} {...commonProps}/>;
+    const enumOptions = optionsList({enum: [true, false], enumNames: schema.enumNames});
+    return <Widget options={{...options, enumOptions}} {...commonProps}/>;
   }
   const {CheckboxWidget} = registry.widgets;
   return <CheckboxWidget {...commonProps}/>;

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -2,7 +2,7 @@ import React, {PropTypes} from "react";
 
 import {
   defaultFieldValue,
-  getAlternativeWidget,
+  getWidget as getWidget,
   getUiOptions,
   optionsList,
   getDefaultRegistry
@@ -16,49 +16,37 @@ function StringField(props) {
     uiSchema,
     idSchema,
     formData,
-    registry,
     required,
     disabled,
     readonly,
     autofocus,
+    registry,
     onChange
   } = props;
   const {title, format} = schema;
   const {widgets, formContext} = registry;
+  const enumOptions = Array.isArray(schema.enum) && optionsList(schema);
   const {widget, placeholder, ...options} = {
-    widget: format,
+    widget: format || (enumOptions ? "select" : "text"),
     placeholder: "",
     ...getUiOptions(uiSchema)
   };
-  const commonProps = {
-    schema,
-    id: idSchema && idSchema.$id,
-    label: (title === undefined) ? name : title,
-    value: defaultFieldValue(formData, schema),
-    onChange,
-    required,
-    disabled,
-    readonly,
-    formContext,
-    autofocus,
-    registry,
-  };
+  const Widget = getWidget(schema, widget, widgets);
 
-  const {TextWidget, SelectWidget} = widgets;
-
-  if (Array.isArray(schema.enum)) {
-    const enumOptions = optionsList(schema);
-    if (widget) {
-      const Widget = getAlternativeWidget(schema, widget, widgets);
-      return <Widget options={{...options, enumOptions}} {...commonProps}/>;
-    }
-    return <SelectWidget options={{enumOptions}} {...commonProps}/>;
-  }
-  if (widget) {
-    const Widget = getAlternativeWidget(schema, widget, widgets);
-    return <Widget options={options} {...commonProps} placeholder={placeholder}/>;
-  }
-  return <TextWidget {...commonProps} placeholder={placeholder}/>;
+  return <Widget
+    options={{...options, enumOptions}}
+    schema={schema}
+    id={idSchema && idSchema.$id}
+    label={title === undefined ? name : title}
+    value={defaultFieldValue(formData, schema)}
+    onChange={onChange}
+    required={required}
+    disabled={disabled}
+    readonly={readonly}
+    formContext={formContext}
+    autofocus={autofocus}
+    registry={registry}
+    placeholder={placeholder}/>;
 }
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -2,7 +2,7 @@ import React, {PropTypes} from "react";
 
 import {
   defaultFieldValue,
-  getWidget as getWidget,
+  getWidget,
   getUiOptions,
   optionsList,
   getDefaultRegistry

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -26,11 +26,8 @@ function StringField(props) {
   const {title, format} = schema;
   const {widgets, formContext} = registry;
   const enumOptions = Array.isArray(schema.enum) && optionsList(schema);
-  const {widget, placeholder, ...options} = {
-    widget: format || (enumOptions ? "select" : "text"),
-    placeholder: "",
-    ...getUiOptions(uiSchema)
-  };
+  const defaultWidget = format || (enumOptions ? "select" : "text");
+  const {widget=defaultWidget, placeholder="", ...options} = getUiOptions(uiSchema);
   const Widget = getWidget(schema, widget, widgets);
 
   return <Widget

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -3,6 +3,7 @@ import React, {PropTypes} from "react";
 import {
   defaultFieldValue,
   getAlternativeWidget,
+  getUiOptions,
   optionsList,
   getDefaultRegistry
 } from "../../utils";
@@ -22,10 +23,13 @@ function StringField(props) {
     autofocus,
     onChange
   } = props;
-  const {title} = schema;
+  const {title, format} = schema;
   const {widgets, formContext} = registry;
-  const widget = uiSchema["ui:widget"] || schema.format;
-  const placeholder = uiSchema["ui:placeholder"] || "";
+  const {widget, placeholder, ...options} = {
+    widget: format,
+    placeholder: "",
+    ...getUiOptions(uiSchema)
+  };
   const commonProps = {
     schema,
     id: idSchema && idSchema.$id,
@@ -45,14 +49,14 @@ function StringField(props) {
   if (Array.isArray(schema.enum)) {
     const enumOptions = optionsList(schema);
     if (widget) {
-      const Widget = getAlternativeWidget(schema, widget, widgets, {enumOptions});
-      return <Widget {...commonProps}/>;
+      const Widget = getAlternativeWidget(schema, widget, widgets);
+      return <Widget options={{...options, enumOptions}} {...commonProps}/>;
     }
     return <SelectWidget options={{enumOptions}} {...commonProps}/>;
   }
   if (widget) {
     const Widget = getAlternativeWidget(schema, widget, widgets);
-    return <Widget {...commonProps} placeholder={placeholder}/>;
+    return <Widget options={options} {...commonProps} placeholder={placeholder}/>;
   }
   return <TextWidget {...commonProps} placeholder={placeholder}/>;
 }

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -37,7 +37,7 @@ function RadioWidget({
 }
 
 RadioWidget.defaultProps = {
-  autofocus: false,
+  autofocus: false
 };
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -37,7 +37,7 @@ function RadioWidget({
 }
 
 RadioWidget.defaultProps = {
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/utils.js
+++ b/src/utils.js
@@ -196,7 +196,7 @@ export function getDefaultFormState(_schema, formData, definitions={}) {
 
 export function getUiOptions(uiSchema) {
   // get all passed options from ui:widget, ui:options, and ui:<optionName>
-  return Object.keys(uiSchema).filter(key => /^ui:/.test(key)).reduce((options, key) => {
+  return Object.keys(uiSchema).filter(key => key.indexOf("ui:") === 0).reduce((options, key) => {
     const value = uiSchema[key];
 
     if (key === "ui:widget" && isObject(value)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,32 +3,45 @@ import React from "react";
 import "setimmediate";
 
 
-const altWidgetMap = {
+const widgetMap = {
   boolean: {
+    checkbox: "CheckboxWidget",
     radio: "RadioWidget",
     select: "SelectWidget",
     hidden: "HiddenWidget",
   },
   string: {
+    text: "TextWidget",
     password: "PasswordWidget",
+    email: "EmailWidget",
+    hostname: "TextWidget",
+    ipv4: "TextWidget",
+    ipv6: "TextWidget",
+    uri: "URLWidget",
+    "data-url": "FileWidget",
     radio: "RadioWidget",
     select: "SelectWidget",
     textarea: "TextareaWidget",
     hidden: "HiddenWidget",
     date: "DateWidget",
     datetime: "DateTimeWidget",
+    "date-time": "DateTimeWidget",
     "alt-date": "AltDateWidget",
     "alt-datetime": "AltDateTimeWidget",
     color: "ColorWidget",
     file: "FileWidget",
   },
   number: {
+    text: "TextWidget",
+    select: "SelectWidget",
     updown: "UpDownWidget",
     range: "RangeWidget",
     radio: "RadioWidget",
     hidden: "HiddenWidget",
   },
   integer: {
+    text: "TextWidget",
+    select: "SelectWidget",
     updown: "UpDownWidget",
     range: "RangeWidget",
     radio: "RadioWidget",
@@ -37,18 +50,8 @@ const altWidgetMap = {
   array: {
     select: "SelectWidget",
     checkboxes: "CheckboxesWidget",
+    files: "FileWidget"
   }
-};
-
-const stringFormatWidgets = {
-  "date-time": "DateTimeWidget",
-  "date": "DateWidget",
-  "email": "EmailWidget",
-  "hostname": "TextWidget",
-  "ipv4": "TextWidget",
-  "ipv6": "TextWidget",
-  "uri": "URLWidget",
-  "data-url": "FileWidget",
 };
 
 export function getDefaultRegistry() {
@@ -101,8 +104,8 @@ export function defaultFieldValue(formData, schema) {
   return typeof formData === "undefined" ? schema.default : formData;
 }
 
-export function getAlternativeWidget(schema, widget, registeredWidgets={}) {
-  const {type, format} = schema;
+export function getWidget(schema, widget, registeredWidgets={}) {
+  const {type} = schema;
 
   function mergeOptions(Widget) {
     // cache return value as property of widget for proper react reconciliation
@@ -124,25 +127,19 @@ export function getAlternativeWidget(schema, widget, registeredWidgets={}) {
 
   if (registeredWidgets.hasOwnProperty(widget)) {
     const registeredWidget = registeredWidgets[widget];
-    return getAlternativeWidget(schema, registeredWidget, registeredWidgets);
+    return getWidget(schema, registeredWidget, registeredWidgets);
   }
 
-  if (!altWidgetMap.hasOwnProperty(type)) {
-    throw new Error(`No alternative widget for type ${type}`);
+  if (!widgetMap.hasOwnProperty(type)) {
+    throw new Error(`No widget for type "${type}"`);
   }
 
-  if (altWidgetMap[type].hasOwnProperty(widget)) {
-    const altWidget = registeredWidgets[altWidgetMap[type][widget]];
-    return getAlternativeWidget(schema, altWidget, registeredWidgets);
+  if (widgetMap[type].hasOwnProperty(widget)) {
+    const registeredWidget = registeredWidgets[widgetMap[type][widget]];
+    return getWidget(schema, registeredWidget, registeredWidgets);
   }
 
-  if (type === "string" && stringFormatWidgets.hasOwnProperty(format)) {
-    const stringFormatWidget = registeredWidgets[stringFormatWidgets[format]];
-    return getAlternativeWidget(schema, stringFormatWidget, registeredWidgets);
-  }
-
-  const info = type === "string" && format ? `/${format}` : "";
-  throw new Error(`No alternative widget "${widget}" for type ${type}${info}`);
+  throw new Error(`No widget "${widget}" for type "${type}"`);
 }
 
 function computeDefaults(schema, parentDefaults, definitions={}) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -109,12 +109,12 @@ export function getWidget(schema, widget, registeredWidgets={}) {
 
   function mergeOptions(Widget) {
     // cache return value as property of widget for proper react reconciliation
-    if (!widget.mergedOptions) {
+    if (!Widget.MergedWidget) {
       const defaultOptions = Widget.defaultProps && Widget.defaultProps.options || {};
-      Widget.mergedOptions = ({options={}, ...props}) =>
+      Widget.MergedWidget = ({options={}, ...props}) =>
         <Widget options={{...defaultOptions, ...options}} {...props}/>;
     }
-    return widget.mergedOptions;
+    return Widget.MergedWidget;
   }
 
   if (typeof widget === "function") {

--- a/src/utils.js
+++ b/src/utils.js
@@ -195,26 +195,19 @@ export function getDefaultFormState(_schema, formData, definitions={}) {
 }
 
 export function getUiOptions(uiSchema) {
-  let options = {};
-
   // get all passed options from ui:widget, ui:options, and ui:<optionName>
-  Object.keys(uiSchema).filter(key => /^ui:/.test(key)).forEach(key => {
+  return Object.keys(uiSchema).filter(key => /^ui:/.test(key)).reduce((options, key) => {
     const value = uiSchema[key];
 
     if (key === "ui:widget" && isObject(value)) {
       console.warn("Setting options via ui:widget object is deprecated, use ui:options instead");
-      options.widget = value.component;
-      if (isObject(value.options)) {
-        options = {...options, ...value.options};
-      }
-    } else if (key === "ui:options" && isObject(value)) {
-      options = {...options, ...value};
-    } else {
-      options[key.substring(3)] = value;
+      return {...options, ...(value.options || {}), widget: value.component};
     }
-  });
-
-  return options;
+    if (key === "ui:options" && isObject(value)) {
+      return {...options, ...value};
+    }
+    return {...options, [key.substring(3)]: value};
+  }, {});
 }
 
 export function isObject(thing) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -195,28 +195,26 @@ export function getDefaultFormState(_schema, formData, definitions={}) {
 }
 
 export function getUiOptions(uiSchema) {
+  let options = {};
+
   // get all passed options from ui:widget, ui:options, and ui:<optionName>
-  return Object.keys(uiSchema).filter(key => /^ui:/.test(key)).reduce((options, key) => {
+  Object.keys(uiSchema).filter(key => /^ui:/.test(key)).forEach(key => {
     const value = uiSchema[key];
 
     if (key === "ui:widget" && isObject(value)) {
       console.warn("Setting options via ui:widget object is deprecated, use ui:options instead");
-      options["widget"] = value.component;
+      options.widget = value.component;
       if (isObject(value.options)) {
-        setOptions(options, value.options);
+        options = {...options, ...value.options};
       }
     } else if (key === "ui:options" && isObject(value)) {
-      setOptions(options, value);
+      options = {...options, ...value};
     } else {
       options[key.substring(3)] = value;
     }
+  });
 
-    return options;
-  }, {});
-
-  function setOptions(dest, src) {
-    Object.keys(src).forEach(option => dest[option] = src[option]);
-  }
+  return options;
 }
 
 export function isObject(thing) {

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -67,7 +67,7 @@ describe("uiSchema", () => {
       });
     });
 
-    describe.only("custom options", () => {
+    describe("custom options", () => {
       let widget, widgets, schema, uiSchema;
 
       beforeEach(() => {

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -67,6 +67,73 @@ describe("uiSchema", () => {
       });
     });
 
+    describe.only("custom options", () => {
+      const widget = ({label, options}) => <div className="custom" id={label} style={options}></div>;
+      widget.defaultProps = {options: {background: "yellow", color: "green"}};
+      const widgets = {widget};
+      const schema = {
+        type: "object",
+        properties: {
+          prop1: {type: "string"},
+          prop2: {type: "string"},
+          prop3: {type: "string"},
+          prop4: {type: "string"}
+        }
+      };
+      const uiSchema = {
+        prop1: {
+          "ui:widget": {
+            "component": widget, // as function
+            "options": {
+              "background": "red"
+            }
+          }
+        },
+        prop2: {
+          "ui:widget": widget // as function
+        },
+        prop3: {
+          "ui:widget": {
+            "component": "widget", // as string
+            "options": {
+              "background": "blue"
+            }
+          }
+        },
+        prop4: {
+          "ui:widget": "widget" // as string
+        }
+      };
+
+      it("should render merged ui:widget options for widget referenced as function", () => {
+        const {node} = createFormComponent({schema, uiSchema, widgets});
+        const widget = node.querySelector('#prop1');
+        expect(widget.style.background).to.equal("red");
+        expect(widget.style.color).to.equal("green");
+      });
+
+      it("should render ui:widget default options for widget referenced as function", () => {
+        const {node} = createFormComponent({schema, uiSchema, widgets});
+        const widget = node.querySelector('#prop2');
+        expect(widget.style.background).to.equal("yellow");
+        expect(widget.style.color).to.equal("green");
+      });
+
+      it("should render merged ui:widget options for widget referenced as string", () => {
+        const {node} = createFormComponent({schema, uiSchema, widgets});
+        const widget = node.querySelector('#prop3');
+        expect(widget.style.background).to.equal("blue");
+        expect(widget.style.color).to.equal("green");
+      });
+
+      it("should render ui:widget default options for widget referenced as string", () => {
+        const {node} = createFormComponent({schema, uiSchema, widgets});
+        const widget = node.querySelector('#prop4');
+        expect(widget.style.background).to.equal("yellow");
+        expect(widget.style.color).to.equal("green");
+      });
+    });
+
     describe("nested widget", () => {
       const schema = {
         "type": "object",

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -271,29 +271,6 @@ describe("uiSchema", () => {
           expect(node.querySelectorAll(".custom")).to.have.length.of(1);
         });
       });
-
-      describe("referenced descriptor", () => {
-        const uiSchema = {
-          "field": {
-            "ui:widget": "custom"
-          }
-        };
-
-        const widgets = {
-          custom: {
-            component: CustomWidget,
-            options: {
-              className: "custom"
-            }
-          }
-        };
-
-        it("should render a custom widget with options", () => {
-          const {node} = createFormComponent({schema, uiSchema, widgets});
-
-          expect(node.querySelectorAll(".custom")).to.have.length.of(1);
-        });
-      });
     });
 
     describe("enum fields native options", () => {
@@ -1128,7 +1105,7 @@ describe("uiSchema", () => {
           node => node.textContent);
 
         expect(labels)
-          .eql(["true", "false"]);
+          .eql(["yes", "no"]);
       });
 
       it("should support formData", () => {
@@ -1183,9 +1160,9 @@ describe("uiSchema", () => {
         const {node} = createFormComponent({schema, uiSchema});
 
         expect(node.querySelectorAll("option")[0].textContent)
-          .eql("true");
+          .eql("yes");
         expect(node.querySelectorAll("option")[1].textContent)
-          .eql("false");
+          .eql("no");
       });
 
       it("should update state when true is selected", () => {

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -67,62 +67,64 @@ describe("uiSchema", () => {
       });
     });
 
-    describe("custom options", () => {
-      const widget = ({label, options}) => <div id={label} style={options}></div>;
-      widget.defaultProps = {options: {background: "yellow", color: "green"}};
-
-      const widgets = {widget};
-
-      // all fields in one schema to catch errors where options passed to one
-      // instance of a widget are persistent across all instances
-      const schema = {
-        type: "object",
-        properties: {
-          funcAll: {type: "string"},
-          funcNone: {type: "string"},
-          stringAll: {type: "string"},
-          stringNone: {type: "string"}
-        }
-      };
-
-      const uiSchema = {
-        // pass widget as function
-        funcAll: {
-          "ui:widget": {
-            component: widget,
-            options: {
-              background: "purple"
-            }
-          },
-          "ui:options": {
-            margin: "7px"
-          },
-          "ui:padding": "42px"
-        },
-        funcNone: {
-          "ui:widget": widget
-        },
-
-        // pass widget as string
-        stringAll: {
-          "ui:widget": {
-            component: "widget",
-            options: {
-              background: "blue"
-            }
-          },
-          "ui:options": {
-            margin: "19px"
-          },
-          "ui:padding": "41px"
-        },
-        stringNone: {
-          "ui:widget": "widget"
-        }
-      };
+    describe.only("custom options", () => {
+      let widget, widgets, schema, uiSchema;
 
       beforeEach(() => {
         sandbox.stub(console, "warn");
+
+        widget = ({label, options}) => <div id={label} style={options}></div>;
+        widget.defaultProps = {options: {background: "yellow", color: "green"}};
+
+        widgets = {widget};
+
+        // all fields in one schema to catch errors where options passed to one
+        // instance of a widget are persistent across all instances
+        schema = {
+          type: "object",
+          properties: {
+            funcAll: {type: "string"},
+            funcNone: {type: "string"},
+            stringAll: {type: "string"},
+            stringNone: {type: "string"}
+          }
+        };
+
+        uiSchema = {
+          // pass widget as function
+          funcAll: {
+            "ui:widget": {
+              component: widget,
+              options: {
+                background: "purple"
+              }
+            },
+            "ui:options": {
+              margin: "7px"
+            },
+            "ui:padding": "42px"
+          },
+          funcNone: {
+            "ui:widget": widget
+          },
+
+          // pass widget as string
+          stringAll: {
+            "ui:widget": {
+              component: "widget",
+              options: {
+                background: "blue"
+              }
+            },
+            "ui:options": {
+              margin: "19px"
+            },
+            "ui:padding": "41px"
+          },
+          stringNone: {
+            "ui:widget": "widget"
+          }
+        };
       });
 
       it("should log warning when deprecated ui:widget: {component, options} api is used", () => {
@@ -132,6 +134,15 @@ describe("uiSchema", () => {
           widgets
         });
         expect(console.warn.calledWithMatch(/ui:widget object is deprecated/)).to.be.true;
+      });
+
+      it("should cache MergedWidget instance", () => {
+        expect(widget.MergedWidget).not.to.be.ok;
+        createFormComponent({schema: {type:"string"}, uiSchema: {"ui:widget": "widget"}, widgets});
+        const cached = widget.MergedWidget;
+        expect(cached).to.be.ok;
+        createFormComponent({schema: {type:"string"}, uiSchema: {"ui:widget": "widget"}, widgets});
+        expect(widget.MergedWidget).to.equal(cached);
       });
 
       it("should render merged ui:widget options for widget referenced as function", () => {


### PR DESCRIPTION
### Reasons for making this change

See #370.

Issues:

- (Error) One test does not work any more: "referenced descriptor". This is inherent to the change as proposed by me in #370, but maybe we can still make it working? It is undocumented behaviour though, and I doubt if the functionality is really useful. I think a referenced descriptor with `{component, options}` as widget definition is always easily replaceable with a custom widget with some `defaultProps`.

- (Question) I don't like the fact that `ui:options` from `uiSchema` and processed `enum` and `enumNames` data from `schema` are merged into one property for widgets in every field that accepts `enum`. (E.g. in `StringField`: `options={{...options, enumOptions}}`.) These 2 things don't 'naturally' belong together in one property. Could we split out the enum information to a different property called `choices`? (I took 'choices' from the corresponding Django widget but another name would also do.)

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [x] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
