### PR TITLE
playground: add single field form example

### DIFF
--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -11,6 +11,7 @@ import large from "./large";
 import date from "./date";
 import validation from "./validation";
 import files from "./files";
+import single from "./single";
 
 export const samples = {
   Simple: simple,
@@ -26,4 +27,5 @@ export const samples = {
   "Date & time": date,
   Validation: validation,
   Files: files,
+  Single: single
 };

--- a/playground/samples/single.js
+++ b/playground/samples/single.js
@@ -1,0 +1,7 @@
+module.exports = {
+  schema: {
+    title: "A single-field form",
+    type: "string",
+  },
+  formData: "initial value"
+};


### PR DESCRIPTION
### Reasons for making this change

Add an playground example for single field form

Related : #376 

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [x] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

