### PR TITLE
Tab stop for Add button +

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -419,7 +419,7 @@ function AddButton({onClick, disabled}) {
     <div className="row">
       <p className="col-xs-3 col-xs-offset-9 array-item-add text-right">
         <IconBtn type="info" icon="plus" className="btn-add col-xs-12"
-                 tabIndex="-1" onClick={onClick}
+                 tabIndex="0" onClick={onClick}
                  disabled={disabled}/>
       </p>
     </div>


### PR DESCRIPTION
### Reasons for making this change

This makes it possible to add an array item while tabbing through a form.

https://github.com/mozilla-services/react-jsonschema-form/issues/365