### PR TITLE
fix: deal with edage case in errorPropertyToPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "jsonschema": "^1.0.2",
+    "lodash.topath": "^4.5.2",
     "setimmediate": "^1.0.5"
   },
   "devDependencies": {
@@ -49,7 +50,6 @@
     "chai": "^3.3.0",
     "cross-env": "^2.0.1",
     "css-loader": "^0.23.1",
-    "eslint": "^2.9.0",
     "eslint-plugin-react": "^4.2.3",
     "estraverse": "^4.2.0",
     "estraverse-fb": "^1.3.1",

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,25 +1,7 @@
+import toPath from 'lodash.topath';
 import {validate as jsonValidate} from "jsonschema";
 
 import {isObject, mergeObjects} from "./utils";
-
-
-const reEscapeChar = /\\(\\)?/g;
-const reLeadingDot = /^\./;
-const rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
-
-function errorPropertyToPath(property) {
-  // Parse array indices, eg. "instance.level1.level2[2].level3"
-  // => ["instance", "level1", "level2", 2, "level3"]
-  // copied from lodash https://github.com/lodash/lodash/blob/4.17.1/lodash.js#L6744
-  const result = [];
-  if (reLeadingDot.test(property)) {
-    result.push('');
-  }
-  property.replace(rePropName, function(match, number, quote, string) {
-    result.push(quote ? string.replace(reEscapeChar, '$1') : (number || match));
-  });
-  return result;
-}
 
 function toErrorSchema(errors) {
   // Transforms a jsonschema validation errors list:
@@ -42,7 +24,7 @@ function toErrorSchema(errors) {
   }
   return errors.reduce((errorSchema, error) => {
     const {property, message} = error;
-    const path = errorPropertyToPath(property);
+    const path = toPath(property);
     let parent = errorSchema;
     for (const segment of path.slice(1)) {
       if (!(segment in parent)) {

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -9,29 +9,31 @@ import {createFormComponent} from "./test_utils";
 describe("Validation", () => {
   describe("validate.validateFormData()", () => {
     describe("No custom validate function", () => {
+      const illFormedKey = "bar.'\"[]()=+*&^%$#@!";
       const schema = {
         type: "object",
-        properties: {
-          foo: {type: "string"}
-        }
+        properties: { foo: {type: "string"}, [illFormedKey]: {type: "string"} }
       };
 
       let errors, errorSchema;
 
       beforeEach(() => {
-        const result = validateFormData({foo: 42}, schema);
+        const result = validateFormData({ foo: 42, [illFormedKey]: 41 }, schema);
         errors = result.errors;
         errorSchema = result.errorSchema;
       });
 
       it("should return an error list", () => {
-        expect(errors).to.have.length.of(1);
+        expect(errors).to.have.length.of(2);
         expect(errors[0].message).eql("is not of a type(s) string");
+        expect(errors[1].message).eql("is not of a type(s) string");
       });
 
       it("should return an errorSchema", () => {
         expect(errorSchema.foo.__errors).to.have.length.of(1);
         expect(errorSchema.foo.__errors[0]).eql("is not of a type(s) string");
+        expect(errorSchema[illFormedKey].__errors).to.have.length.of(1);
+        expect(errorSchema[illFormedKey].__errors[0]).eql("is not of a type(s) string");
       });
     });
 


### PR DESCRIPTION
### Reasons for making this change

When there is '.' in side a key of an object, the errorPropertyToPath function failed to parse the string into a path array.

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
