### PR TITLE
Fix CheckboxesWidget and RadioWidget style

### DIFF
--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -20,23 +20,33 @@ function CheckboxesWidget(props) {
     <div className="checkboxes" id={id}>{
       enumOptions.map((option, index) => {
         const checked = value.indexOf(option.value) !== -1;
-        return (
-          <div key={index} className={`checkbox${inline ? "-inline" : ""}`}>
+        const disabledCls = disabled ? "disabled" : "";
+        const checkbox = (
+          <span>
+            <input type="checkbox"
+              id={`${id}_${index}`}
+              checked={checked}
+              disabled={disabled}
+              autoFocus={autofocus && index === 0}
+              onChange={(event) => {
+                const all = enumOptions.map(({value}) => value);
+                if (event.target.checked) {
+                  onChange(selectValue(option.value, value, all));
+                } else {
+                  onChange(deselectValue(option.value, value));
+                }
+              }}/>
+            {option.label}
+          </span>
+        );
+        return inline ? (
+          <label key={index} className={`checkbox-inline ${disabledCls}`}>
+            {checkbox}
+          </label>
+        ) : (
+          <div key={index} className={`checkbox ${disabledCls}`}>
             <label>
-              <input type="checkbox"
-                id={`${id}_${index}`}
-                checked={checked}
-                disabled={disabled}
-                autoFocus={autofocus && index === 0}
-                onChange={(event) => {
-                  const all = enumOptions.map(({value}) => value);
-                  if (event.target.checked) {
-                    onChange(selectValue(option.value, value, all));
-                  } else {
-                    onChange(deselectValue(option.value, value));
-                  }
-                }}/>
-              {option.label}
+              {checkbox}
             </label>
           </div>
         );

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -36,7 +36,7 @@ function CheckboxesWidget(props) {
                     onChange(deselectValue(option.value, value));
                   }
                 }}/>
-              <strong>{option.label}</strong>
+              {option.label}
             </label>
           </div>
         );

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -17,17 +17,28 @@ function RadioWidget({
     <div className="field-radio-group">{
       enumOptions.map((option, i) => {
         const checked = option.value === value;
-        return (
-          <div key={i} className={`radio${inline ? "-inline" : ""} ${disabled ? "disabled" : ""}`}>
+        const disabledCls = disabled ? "disabled" : "";
+        const radio = (
+          <span>
+            <input type="radio"
+              name={name}
+              value={option.value}
+              checked={checked}
+              disabled={disabled}
+              autoFocus={autofocus && i === 0}
+              onChange={_ => onChange(option.value)}/>
+            {option.label}
+          </span>
+        );
+
+        return inline ? (
+          <label key={i} className={`radio-inline ${disabledCls}`}>
+            {radio}
+          </label>
+        ) : (
+          <div key={i} className={`radio ${disabledCls}`}>
             <label>
-              <input type="radio"
-                name={name}
-                value={option.value}
-                checked={checked}
-                disabled={disabled}
-                autoFocus={autofocus && i === 0}
-                onChange={_ => onChange(option.value)}/>
-              {option.label}
+              {radio}
             </label>
           </div>
         );


### PR DESCRIPTION
### Reasons for making this change

Unfortunately I currently don't have time for the 'bigger' issues, but this is a simple style fix I think will make many forms look better.

Some context:
The label in a `CheckboxWidget` is bold, and rightly so, because the label of a `CheckboxWidget` is the field title and all field titles are bold. The labels in a `RadioWidget` are not bold, unless the option `inline: true` is set.

Issue 1:
The labels in the `CheckboxesWidget` are bold too. I think this is done for consistency with `CheckboxWidget`, but I think consistency with `RadioWidget` would be better, because the labels of a `CheckboxesWidget` are not titles but `enumNames`. Now it could lead to an enormous wall of bold text for large `enum`s, and the real field title does not stand out any more. I changed this in this pull request.

Issue 2:
The labels in `RadioWidget` and `CheckboxesWidget` were bold when `inline: true` was set. This was due to a styling issue with Bootstrap, which needs another DOM structure for inline widgets (class `radio-inline` or `checkbox-inline` must be set on `<label>` itself instead of on a wrapper `<div>`). I fixed this too.

Issue 3:
While I was working on it, I saw that in `CheckboxesWidget` the `disabled` class was not set for disabled inputs. I fixed this like it was done for `CheckboxWidget` and `RadioWidget`.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

