### PR TITLE
Readonly on radio and checkboxes #412

### DIFF
--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -20,7 +20,7 @@ function CheckboxesWidget(props) {
     <div className="checkboxes" id={id}>{
       enumOptions.map((option, index) => {
         const checked = value.indexOf(option.value) !== -1;
-        const disabledCls = disabled ? "disabled" : "";
+        const disabledCls = disabled || readonly ? "disabled" : "";
         const checkbox = (
           <span>
             <input type="checkbox"

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -14,7 +14,7 @@ function deselectValue(value, selected) {
 }
 
 function CheckboxesWidget(props) {
-  const {id, disabled, options, value, autofocus, onChange} = props;
+  const {id, disabled, options, value, autofocus, readonly, onChange} = props;
   const {enumOptions, inline} = options;
   return (
     <div className="checkboxes" id={id}>{
@@ -26,7 +26,7 @@ function CheckboxesWidget(props) {
             <input type="checkbox"
               id={`${id}_${index}`}
               checked={checked}
-              disabled={disabled}
+              disabled={disabled || readonly}
               autoFocus={autofocus && index === 0}
               onChange={(event) => {
                 const all = enumOptions.map(({value}) => value);
@@ -73,6 +73,7 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.any,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
+    readonly: PropTypes.bool,
     multiple: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -18,7 +18,7 @@ function RadioWidget({
     <div className="field-radio-group">{
       enumOptions.map((option, i) => {
         const checked = option.value === value;
-        const disabledCls = disabled ? "disabled" : "";
+        const disabledCls = disabled || readonly ? "disabled" : "";
         const radio = (
           <span>
             <input type="radio"

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -6,6 +6,7 @@ function RadioWidget({
   options,
   value,
   required,
+  readonly,
   disabled,
   autofocus,
   onChange
@@ -24,7 +25,7 @@ function RadioWidget({
               name={name}
               value={option.value}
               checked={checked}
-              disabled={disabled}
+              disabled={disabled || readonly}
               autoFocus={autofocus && i === 0}
               onChange={_ => onChange(option.value)}/>
             {option.label}
@@ -61,6 +62,7 @@ if (process.env.NODE_ENV !== "production") {
     }).isRequired,
     value: PropTypes.any,
     required: PropTypes.bool,
+    readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
   };


### PR DESCRIPTION
### Reasons for making this change

While the controls themselves may not support the property directly it seemed to me that that "disabled" was closer than nothing at all. At least the user could update the data.

While disabled and readonly are subtly different, my suggestion is that using disabled is possibly better than doing nothing.

Reference:
Readonly on radio and checkboxes #412

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

