### PR TITLE
Enable the required field on the radio buttons

### DIFF
--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -22,6 +22,7 @@ function RadioWidget({
           <span>
             <input type="radio"
               name={name}
+              required={required}
               value={option.value}
               checked={checked}
               disabled={disabled}


### PR DESCRIPTION
### Reasons for making this change

I'd like to suggest enabling the "required" field on radio buttons.

Since the RadioWidget input supports the "required" tag, I think it's a nicer prompt for the user is also consistent with it's usage elsewhere in the module.

Relates to Issue:
https://github.com/mozilla-services/react-jsonschema-form/issues/411
### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

