### PR TITLE
Pass your object structure into the schema as an enum via enumOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Please note that while standardized, `datetime-local` and `date` input elements 
 
   * `updown`: an `input[type=number]` updown selector;
   * `range`: an `input[type=range]` slider;
-  * `radio`: a radio button group with enum values. **can only be used when `enum` values are specified for this input**
+  * `radio`: a radio button group with enum values. **can only be used when `enum` values or `enumOptions` are specified for this input**
   * by default, a regular `input[type=text]` element is used.
 
 > Note: for numbers, `min`, `max` and `step` input attributes values will be handled according to JSONSchema's `minimum`, `maximium` and `multipleOf` values when they're defined.
@@ -515,6 +515,20 @@ This will be rendered using a select box that way:
 </select>
 ```
 
+Alternatively you can pass your own objects in and reference them directly as follows:
+
+    enumOptions: [{myvalue: 1, , mylabel: "one"}, {myvalue: 2, mylabel: "two"}, {myvalue: 3, mylabel: "three"}],
+    enumLabel: "mylabel",
+    enumValue: "myvalue"
+
+This will render indentically to the above.
+
+As a result it means you can use an existing array of objects and use "id" and "name" for example as the value and label.
+e.g.
+    enumOptions: myarray,
+    enumLabel: "name",
+    enumValue: "id"
+
 Note that string representations of numbers will be cast back and reflected as actual numbers into form state.
 
 ### Multiple choices list
@@ -523,6 +537,7 @@ The default behavior for array fields is a list of text inputs with add/remove b
 
 - an `enum` list for the `items` property of an `array` field
 - with the `uniqueItems` property set to `true`
+- again you can pass in your own structure through `enumOptions`, and reference it's label and value with `enumLabel` and `enumValue`
 
 Example:
 

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -25,7 +25,7 @@ function StringField(props) {
   } = props;
   const {title, format} = schema;
   const {widgets, formContext} = registry;
-  const enumOptions = Array.isArray(schema.enum) && optionsList(schema);
+  var enumOptions = (schema.enumOptions || Array.isArray(schema.enum)) && optionsList(schema);
   const defaultWidget = format || (enumOptions ? "select" : "text");
   const {widget=defaultWidget, placeholder="", ...options} = getUiOptions(uiSchema);
   const Widget = getWidget(schema, widget, widgets);

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -14,12 +14,32 @@ function deselectValue(value, selected) {
 }
 
 function CheckboxesWidget(props) {
-  const {id, disabled, options, value, autofocus, onChange} = props;
-  const {enumOptions, inline} = options;
+  const {id, disabled, options, value, autofocus, multiple, onChange} = props;
+  const {inline} = options;
+  var {enumOptions} = options;
+  var schema = props.schema;
+  var { enumLabel,enumValue } = schema;
+  if (multiple && schema.items) {
+    if (schema.items.enumLabel) {
+      enumLabel = schema.items.enumLabel;
+    }
+    if (schema.items.enumValue) {
+      enumValue = schema.items.enumValue;
+    }
+  }
+  if (!enumValue) {
+    enumValue = "value";
+  }
+  if (!enumLabel) {
+    enumLabel = "label";
+  }
+  if (!enumOptions) {
+    enumOptions = [];
+  }
   return (
     <div className="checkboxes" id={id}>{
       enumOptions.map((option, index) => {
-        const checked = value.indexOf(option.value) !== -1;
+        const checked = value.indexOf(option[enumValue]) !== -1;
         const disabledCls = disabled ? "disabled" : "";
         const checkbox = (
           <span>
@@ -31,12 +51,12 @@ function CheckboxesWidget(props) {
               onChange={(event) => {
                 const all = enumOptions.map(({value}) => value);
                 if (event.target.checked) {
-                  onChange(selectValue(option.value, value, all));
+                  onChange(selectValue(option[enumValue], value, all));
                 } else {
-                  onChange(deselectValue(option.value, value));
+                  onChange(deselectValue(option[enumValue], value));
                 }
               }}/>
-            {option.label}
+            {option[enumLabel]}
           </span>
         );
         return inline ? (

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -18,7 +18,7 @@ function CheckboxesWidget(props) {
   const {inline} = options;
   var {enumOptions} = options;
   var schema = props.schema;
-  var { enumLabel,enumValue } = schema;
+  var {enumLabel,enumValue} = schema;
   if (multiple && schema.items) {
     if (schema.items.enumLabel) {
       enumLabel = schema.items.enumLabel;

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -14,7 +14,7 @@ function RadioWidget({
   const name = Math.random().toString();
   const {inline} = options;
   var {enumOptions} = options;
-  var { enumLabel,enumValue } = schema;
+  var {enumLabel,enumValue} = schema;
   if (!enumValue) {
     enumValue = "value";
   }

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -12,22 +12,33 @@ function RadioWidget({
 }) {
   // Generating a unique field name to identify this set of radio buttons
   const name = Math.random().toString();
-  const {enumOptions, inline} = options;
+  const {inline} = options;
+  var {enumOptions} = options;
+  var { enumLabel,enumValue } = schema;
+  if (!enumValue) {
+    enumValue = "value";
+  }
+  if (!enumLabel) {
+    enumLabel = "label";
+  }  
+  if (!enumOptions) {
+    enumOptions = [];
+  }
   return (
     <div className="field-radio-group">{
       enumOptions.map((option, i) => {
-        const checked = option.value === value;
+        const checked = option[enumValue] === value;
         const disabledCls = disabled ? "disabled" : "";
         const radio = (
           <span>
             <input type="radio"
               name={name}
-              value={option.value}
+              value={option[enumValue]}
               checked={checked}
               disabled={disabled}
               autoFocus={autofocus && i === 0}
-              onChange={_ => onChange(option.value)}/>
-            {option.label}
+              onChange={_ => onChange(option[enumValue])}/>
+            {option[enumLabel]}
           </span>
         );
 

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -31,7 +31,7 @@ function SelectWidget({
   onChange
 }) {
   var {enumOptions} = options;
-  var { enumLabel,enumValue } = schema;
+  var {enumLabel,enumValue} = schema;
   if (multiple && schema.items) {
     if (schema.items.enumLabel) {
       enumLabel = schema.items.enumLabel;

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -30,7 +30,25 @@ function SelectWidget({
   autofocus,
   onChange
 }) {
-  const {enumOptions} = options;
+  var {enumOptions} = options;
+  var { enumLabel,enumValue } = schema;
+  if (multiple && schema.items) {
+    if (schema.items.enumLabel) {
+      enumLabel = schema.items.enumLabel;
+    }
+    if (schema.items.enumValue) {
+      enumValue = schema.items.enumValue;
+    }
+  }
+  if (!enumValue) {
+    enumValue = "value";
+  }
+  if (!enumLabel) {
+    enumLabel = "label";
+  }  
+  if (!enumOptions) {
+    enumOptions = [];
+  }
   return (
     <select
       id={id}
@@ -51,8 +69,8 @@ function SelectWidget({
         }
         onChange(processValue(schema, newValue));
       }}>{
-      enumOptions.map(({value, label}, i) => {
-        return <option key={i} value={value}>{label}</option>;
+      enumOptions.map((option, i) => {
+        return <option key={i} value={option[enumValue]}>{option[enumLabel]}</option>;
       })
     }</select>
   );

--- a/src/utils.js
+++ b/src/utils.js
@@ -284,7 +284,7 @@ export function optionsList(schema) {
   } else {
     return schema.enum.map(function (value, i) {
       var label = schema.enumNames && schema.enumNames[i] || String(value);
-      return { label: label, value: value };
+      return {label: label, value: value};
     });
   }  
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -256,7 +256,7 @@ export function orderProperties(properties, order) {
 }
 
 export function isMultiSelect(schema) {
-  return Array.isArray(schema.items.enum) && schema.uniqueItems;
+  return (schema.items.enumOptions && schema.uniqueItems) || (Array.isArray(schema.items.enum) && schema.uniqueItems);  
 }
 
 export function isFilesArray(schema, uiSchema) {
@@ -279,10 +279,14 @@ export function allowAdditionalItems(schema) {
 }
 
 export function optionsList(schema) {
-  return schema.enum.map((value, i) => {
-    const label = schema.enumNames && schema.enumNames[i] || String(value);
-    return {label, value};
-  });
+  if (schema.enumOptions){
+    return schema.enumOptions;
+  } else {
+    return schema.enum.map(function (value, i) {
+      var label = schema.enumNames && schema.enumNames[i] || String(value);
+      return { label: label, value: value };
+    });
+  }  
 }
 
 function findSchemaDefinition($ref, definitions={}) {


### PR DESCRIPTION
### Reasons for making this change

To allow easier and more flexible integration into an existing product with a existing object structure.
I coopted the existing variable `enumOptions` and exposed it in the schema.  I figured if it was a good enough name internally it's my best bet externally too!  But I'm terrible at naming we can call it whatever you want if you like the fix.

For example:

```js
  enum: [1, 2, 3],
  enumNames: ["one", "two", "three"]
```

Will render the same as:
```js
    enumOptions: [{myvalue: 1, , mylabel: "one"}, {myvalue: 2, mylabel: "two"}, {myvalue: 3, mylabel: "three"}],
    enumLabel: "mylabel",
    enumValue: "myvalue"
```

Hopefully the advantages are obvious. Instead of having to copy another array I can reference directly into an existing schema.  In my case a GraphQL schema.

e.g.

```js
    enumOptions: this.props.myarray,
    enumLabel: "name",
    enumValue: "id"
```

Which brings me to the second part of this fix.  In my case, `this.props.myarray` is actually a graph returning asynchronously via a promise.

When the form is initially rendered the `this.props.myarray` is not set.  This will in fact lead to `enumOptions` being passed into the Select, Radio or Checkboxes widget as a boolean `false`.

I had hoped to move the fix higher, however doing so seemed to break string fields in the playground, so I've put the check:

```js
  if (!enumOptions) {
    enumOptions = [];
  }
```

In all three of those classes.

Before someone asks I had considered considered using the data and populating a new "translated" `enumOptions` with just two fields `value` and `label`.  It would have been a slightly easier change (not that this is big).

However I decided against it for the following reasons.  There is no reason why another custom control might not wish to access other data in your structure ... why limit it to two fields?

I can envisage (and will probably implement) a custom array class based on ag-grid.  I could then display the entire data in the grid and have checkboxes down the left hand side still for selection.  But I could only do that if the data structure is passed completely into the control.  Perhaps another case could be another field for a hover tooltip over a selection.

It just seems more flexible.  Very interested in general feedback.  I understand this is a feature change/request rather than a bugfix and it should be considered carefully before giving green light or it may need rework.  I hope though that people like the idea in general.

This (in part) addresses:
https://github.com/mozilla-services/react-jsonschema-form/issues/415

### Checklist

* [x ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [x ] **I'm adding a new feature**
  - [x ] I've updated the playground with an example use of the feature

I've tried every enum I could find in the playground to try and break it.

Variations of:

```js
          enum: ["foo", "bar", "fuzz", "qux"],
          enumOptions: [{value: "foo", label: "foo"}, {value: "bar", label: "bar"}, {value: "fuz", label: "fuz"}, , {value: "qux", label: "qux"}],
          enumOptions: [{value: "foo", label: "foo", altlabel: "foo2"}, {value: "bar", label: "bar", altlabel: "bar2"}, {value: "fuz", label: "fuz", altlabel: "fuz2"}, , {value: "qux", label: "qux", altlabel: "qux2"}],
          enumLabel: "altlabel"
          enumValue: "value"
```

And:

```js
          enumOptions: [{value2: "foo", label: "foo", altlabel: "foo2"}, {value2: "bar", label: "bar", altlabel: "bar2"}, {value2: "fuz2", label: "fuz", altlabel: "fuz2"}, , {value2: "qux2", label: "qux", altlabel: "qux2"}],
          enumLabel: "altlabel",
          enumValue: "value2"
```

And:

```js
        enumOptions: [{value: 1, value2: 11, label: "111", label2: "1112"}, {value: 2, value2: 2, label: "222", label2: "2223"}, {value: 3, value2: 33, label: "333", label2: "3334"}],
        enumLabel: "label2",
        enumValue: "value2"
```

And:

```js
        enumOptions: [{value: 1, value2: 11, label: "111", label2: "1112"}, {value: 2, value2: 22, label: "222", label2: "2223"}, {value: 3, value2: 33, label: "333", label2: "3334"}],
        enumLabel: "label2",
        enumValue: "value2"
```