### PR TITLE
Update "form action buttons" example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,7 @@ render((
   <Form schema={schema}>
     <div>
       <button type="submit">Submit</button>
-      <button>Cancel</button>
+      <button type="button">Cancel</button>
     </div>
   </Form>
 ), document.getElementById("app"));


### PR DESCRIPTION
I tried this and noticed weird behaviors:
```jsx
<Form schema={schema} onSubmit={this.handleFormSubmit.bind(this)}>
  <div>
    <button onClick={this.handleFormCancel.bind(this)}>Cancel</button>
    <button type="submit">Submit</button>
  </div>
</Form>
```
The clicks on `Cancel` and `Submit` buttons worked as expected. However, when I submitted the form via the keyboard (hit <kbd>Enter</kbd>), the form was submitted but not catched by `Form.onSubmit` and triggered a page reload - consequence of the browser's default form submission handling.

It [looks like](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) that, when not specified the `type` of the `button` element defaults to `submit`. Therefore, in my example, _very probably_ the `Cancel` button receives the keyboard form submission that is not catched by `Form.onSubmit` (kinda weird though, no?).

Nevertheless, adding the appropriate `type` to cancel button prevents it to be considered as a submit button and avoid the weird behaviors I noticed:

```diff
-      <button onClick={this.handleFormCancel.bind(this)}>Cancel</button>
+      <button type="button" onClick={this.handleFormCancel.bind(this)}>Cancel</button>
```

This PR fixes the example given in the README.