### PR TITLE
Wrap radio and checkbox labels into span to enable styling.

### DIFF
--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -21,7 +21,7 @@ function CheckboxWidget({
           disabled={disabled}
           autoFocus={autofocus}
           onChange={(event) => onChange(event.target.checked)}/>
-        <strong>{label}</strong>
+        <span>{label}</span>
       </label>
     </div>
   );

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -36,7 +36,7 @@ function CheckboxesWidget(props) {
                   onChange(deselectValue(option.value, value));
                 }
               }}/>
-            {option.label}
+            <span>{option.label}</span>
           </span>
         );
         return inline ? (

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -29,7 +29,7 @@ function RadioWidget({
               disabled={disabled}
               autoFocus={autofocus && i === 0}
               onChange={_ => onChange(option.value)}/>
-            {option.label}
+            <span>{option.label}</span>
           </span>
         );
 

--- a/test/BooleanField_test.js
+++ b/test/BooleanField_test.js
@@ -33,7 +33,7 @@ describe("BooleanField", () => {
       title: "foo"
     }});
 
-    expect(node.querySelector(".field label strong").textContent)
+    expect(node.querySelector(".field label span").textContent)
       .eql("foo");
   });
 


### PR DESCRIPTION
### Reasons for making this change

This allows labels to be styled using:
input + span
input:checked + span

Also changed `strong` to `span` to be consistent.

Some conversation:
https://github.com/mozilla-services/react-jsonschema-form/pull/403

### Checklist
* [x] **I'm adding or updating code**
* [x] **I'm updated test**

No docs are needed.