### PR TITLE
Add onBlur event

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
         - [Form submission](#form-submission)
         - [Form error event handler](#form-error-event-handler)
         - [Form data changes](#form-data-changes)
+        - [Form field blur events](#form-field-blur-events)
   - [Form customization](#form-customization)
      - [The uiSchema object](#the-uischema-object)
      - [Alternative widgets](#alternative-widgets)
@@ -191,6 +192,10 @@ render((
 #### Form data changes
 
 If you plan on being notified everytime the form data are updated, you can pass an `onChange` handler, which will receive the same args as `onSubmit` any time a value is updated in the form.
+
+#### Form field blur events
+
+Sometimes you may want to trigger events or modify exteran state when a field has been touched, so you can pass an `onBlur` handler, which will receive the id of the input that was blurred and the field value.
 
 ## Form customization
 
@@ -741,12 +746,14 @@ render((
 
 The following props are passed to custom widget components:
 
+- `id`: The generated id for this field;
 - `schema`: The JSONSchema subschema object for this field;
 - `value`: The current value for this field;
 - `required`: The required status of this field;
 - `disabled`: `true` if the widget is disabled;
 - `readonly`: `true` if the widget is read-only;
 - `onChange`: The value change event handler; call it with the new value everytime it changes;
+- `onBlur`: The input blur event handler; call it with the the widget id and value;
 - `options`: A map of options passed as a prop to the component (see [Custom widget options](#custom-widget-options)).
 - `formContext`: The `formContext` object that you passed to Form.
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ If you plan on being notified everytime the form data are updated, you can pass 
 
 #### Form field blur events
 
-Sometimes you may want to trigger events or modify exteran state when a field has been touched, so you can pass an `onBlur` handler, which will receive the id of the input that was blurred and the field value.
+Sometimes you may want to trigger events or modify external state when a field has been touched, so you can pass an `onBlur` handler, which will receive the id of the input that was blurred and the field value.
 
 ## Form customization
 

--- a/playground/app.js
+++ b/playground/app.js
@@ -359,6 +359,7 @@ class App extends Component {
               onChange={this.onFormDataChange}
               fields={{geo: GeoPosition}}
               validate={validate}
+              onBlur={(id, value) => console.log(`Touched ${id} with value ${value}`)}
               onError={log("errors")} />}
         </div>
       </div>

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -88,6 +88,12 @@ export default class Form extends Component {
     });
   };
 
+  onBlur = (...args) => {
+    if (this.props.onBlur) {
+      this.props.onBlur(...args);
+    }
+  }
+
   onSubmit = (event) => {
     event.preventDefault();
     this.setState({status: "submitted"});
@@ -163,6 +169,7 @@ export default class Form extends Component {
           idSchema={idSchema}
           formData={formData}
           onChange={this.onChange}
+          onBlur={this.onBlur}
           registry={registry}
           safeRenderCompletion={safeRenderCompletion}/>
         { children ? children :

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -487,7 +487,7 @@ class ArrayField extends Component {
           idSchema={itemIdSchema}
           required={this.isItemRequired(itemSchema)}
           onChange={this.onChangeForIndex(index)}
-            onBlur={onBlur}
+          onBlur={onBlur}
           registry={this.props.registry}
           disabled={this.props.disabled}
           readonly={this.props.readonly}

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -173,6 +173,7 @@ class ArrayField extends Component {
       disabled,
       readonly,
       autofocus,
+      onBlur
     } = this.props;
     const title = (schema.title === undefined) ? name : schema.title;
     const {items} = this.state;
@@ -208,7 +209,8 @@ class ArrayField extends Component {
               itemErrorSchema,
               itemData: items[index],
               itemUiSchema: uiSchema.items,
-              autofocus: autofocus && index === 0
+              autofocus: autofocus && index === 0,
+              onBlur
             });
           })
         }</div>
@@ -220,7 +222,7 @@ class ArrayField extends Component {
   }
 
   renderMultiSelect() {
-    const {schema, idSchema, uiSchema, disabled, readonly, autofocus} = this.props;
+    const {schema, idSchema, uiSchema, disabled, readonly, autofocus, onBlur} = this.props;
     const {items} = this.state;
     const {widgets, definitions} = this.props.registry;
     const itemsSchema = retrieveSchema(schema.items, definitions);
@@ -232,6 +234,7 @@ class ArrayField extends Component {
         id={idSchema && idSchema.$id}
         multiple
         onChange={this.onSelectChange}
+        onBlur={onBlur}
         options={options}
         schema={schema}
         value={items}
@@ -242,7 +245,7 @@ class ArrayField extends Component {
   }
 
   renderFiles() {
-    const {schema, uiSchema, idSchema, name, disabled, readonly, autofocus} = this.props;
+    const {schema, uiSchema, idSchema, name, disabled, readonly, autofocus, onBlur} = this.props;
     const title = schema.title || name;
     const {items} = this.state;
     const {widgets} = this.props.registry;
@@ -254,6 +257,7 @@ class ArrayField extends Component {
         id={idSchema && idSchema.$id}
         multiple
         onChange={this.onSelectChange}
+        onBlur={onBlur}
         schema={schema}
         title={title}
         value={items}
@@ -274,6 +278,7 @@ class ArrayField extends Component {
       disabled,
       readonly,
       autofocus,
+      onBlur
     } = this.props;
     const title = schema.title || name;
     let {items} = this.state;
@@ -324,7 +329,8 @@ class ArrayField extends Component {
               itemUiSchema,
               itemIdSchema,
               itemErrorSchema,
-              autofocus: autofocus && index === 0
+              autofocus: autofocus && index === 0,
+              onBlur
             });
           })
         }</div>
@@ -347,7 +353,8 @@ class ArrayField extends Component {
     itemUiSchema,
     itemIdSchema,
     itemErrorSchema,
-    autofocus
+    autofocus,
+    onBlur
   }) {
     const {SchemaField} = this.props.registry.fields;
     const {disabled, readonly, uiSchema} = this.props;
@@ -375,6 +382,7 @@ class ArrayField extends Component {
             idSchema={itemIdSchema}
             required={this.isItemRequired(itemSchema)}
             onChange={this.onChangeForIndex(index)}
+            onBlur={onBlur}
             registry={this.props.registry}
             disabled={this.props.disabled}
             readonly={this.props.readonly}
@@ -439,6 +447,7 @@ if (process.env.NODE_ENV !== "production") {
     idSchema: PropTypes.object,
     errorSchema: PropTypes.object,
     onChange: PropTypes.func.isRequired,
+    onBlur: PropTypes.func.isRequired,
     formData: PropTypes.array,
     required: PropTypes.bool,
     disabled: PropTypes.bool,

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -532,7 +532,7 @@ if (process.env.NODE_ENV !== "production") {
     idSchema: PropTypes.object,
     errorSchema: PropTypes.object,
     onChange: PropTypes.func.isRequired,
-    onBlur: PropTypes.func.isRequired,
+    onBlur: PropTypes.func,
     formData: PropTypes.array,
     required: PropTypes.bool,
     disabled: PropTypes.bool,

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -91,7 +91,8 @@ class ObjectField extends Component {
       name,
       required,
       disabled,
-      readonly
+      readonly,
+      onBlur
     } = this.props;
     const {definitions, fields, formContext} = this.props.registry;
     const {SchemaField, TitleField, DescriptionField} = fields;
@@ -136,6 +137,7 @@ class ObjectField extends Component {
               idSchema={idSchema[name]}
               formData={this.state[name]}
               onChange={this.onPropertyChange(name)}
+              onBlur={onBlur}
               registry={this.props.registry}
               disabled={disabled}
               readonly={readonly}/>

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -21,7 +21,8 @@ function StringField(props) {
     readonly,
     autofocus,
     registry,
-    onChange
+    onChange,
+    onBlur
   } = props;
   const {title, format} = schema;
   const {widgets, formContext} = registry;
@@ -37,6 +38,7 @@ function StringField(props) {
     label={title === undefined ? name : title}
     value={defaultFieldValue(formData, schema)}
     onChange={onChange}
+    onBlur={onBlur}
     required={required}
     disabled={disabled}
     readonly={readonly}
@@ -52,6 +54,7 @@ if (process.env.NODE_ENV !== "production") {
     uiSchema: PropTypes.object.isRequired,
     idSchema: PropTypes.object,
     onChange: PropTypes.func.isRequired,
+    onBlur: PropTypes.func.isRequired,
     formData: PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number,

--- a/src/components/widgets/AltDateWidget.js
+++ b/src/components/widgets/AltDateWidget.js
@@ -16,7 +16,7 @@ function readyForChange(state) {
 }
 
 function DateElement(props) {
-  const {type, range, value, select, rootId, disabled, readonly, autofocus, registry} = props;
+  const {type, range, value, select, rootId, disabled, readonly, autofocus, registry, onBlur} = props;
   const id = rootId + "_" + type;
   const {SelectWidget} = registry.widgets;
   return (
@@ -29,7 +29,8 @@ function DateElement(props) {
       disabled={disabled}
       readonly={readonly}
       autofocus={autofocus}
-      onChange={(value) => select(type, value)}/>
+      onChange={(value) => select(type, value)}
+      onBlur={onBlur}/>
   );
 }
 
@@ -101,7 +102,7 @@ class AltDateWidget extends Component {
   }
 
   render() {
-    const {id, disabled, readonly, autofocus, registry} = this.props;
+    const {id, disabled, readonly, autofocus, registry, onBlur} = this.props;
     return (
       <ul className="list-inline">{
         this.dateElementProps.map((elemProps, i) => (
@@ -113,6 +114,7 @@ class AltDateWidget extends Component {
               disabled= {disabled}
               readonly={readonly}
               registry={registry}
+              onBlur={onBlur}
               autofocus={autofocus && i === 0}/>
           </li>
         ))
@@ -140,6 +142,7 @@ if (process.env.NODE_ENV !== "production") {
     readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
+    onBlur: PropTypes.func,
     time: PropTypes.bool,
   };
 }

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -26,7 +26,7 @@ function BaseInput(props) {
       autoFocus={autofocus}
       value={typeof value === "undefined" ? "" : value}
       onChange={_onChange}
-      onBlur={onBlur ? (event) => onBlur(inputProps.id, event.target.value) : undefined}/>
+      onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}/>
   );
 }
 

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -26,7 +26,7 @@ function BaseInput(props) {
       autoFocus={autofocus}
       value={typeof value === "undefined" ? "" : value}
       onChange={_onChange}
-      onBlur={(event) => onBlur(inputProps.id, event.target.value)}/>
+      onBlur={onBlur ? (event) => onBlur(inputProps.id, event.target.value) : undefined}/>
   );
 }
 

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -9,6 +9,7 @@ function BaseInput(props) {
     readonly,
     autofocus,
     onChange,
+    onBlur,
     options,  // eslint-disable-line
     schema,   // eslint-disable-line
     formContext,  // eslint-disable-line
@@ -22,7 +23,8 @@ function BaseInput(props) {
       readOnly={readonly}
       autoFocus={autofocus}
       value={typeof value === "undefined" ? "" : value}
-      onChange={(event) => onChange(event.target.value)}/>
+      onChange={(event) => onChange(event.target.value)}
+      onBlur={(event) => onBlur(inputProps.id, event.target.value)}/>
   );
 }
 
@@ -44,6 +46,7 @@ if (process.env.NODE_ENV !== "production") {
     readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
+    onBlur: PropTypes.func
   };
 }
 

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -53,10 +53,10 @@ function SelectWidget({
       disabled={disabled}
       readOnly={readonly}
       autoFocus={autofocus}
-      onBlur={(event) => {
+      onBlur={onBlur ? (event) => {
         const newValue = getValue(event, multiple);
         onBlur(id, processValue(schema, newValue));
-      }}
+      } : undefined}
       onChange={(event) => {
         const newValue = getValue(event, multiple);
         onChange(processValue(schema, newValue));

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -18,15 +18,13 @@ function processValue({type, items}, value) {
 }
 
 function getValue(event, multiple) {
-  let newValue;
   if (multiple) {
-    newValue = [].filter.call(
-      event.target.options, o => o.selected).map(o => o.value);
+    return [].slice.call(event.target.options)
+      .filter(o => o.selected)
+      .map(o => o.value);
   } else {
-    newValue = event.target.value;
+    return event.target.value;
   }
-
-  return newValue;
 }
 
 function SelectWidget({
@@ -53,10 +51,10 @@ function SelectWidget({
       disabled={disabled}
       readOnly={readonly}
       autoFocus={autofocus}
-      onBlur={onBlur ? (event) => {
+      onBlur={onBlur && (event => {
         const newValue = getValue(event, multiple);
         onBlur(id, processValue(schema, newValue));
-      } : undefined}
+      })}
       onChange={(event) => {
         const newValue = getValue(event, multiple);
         onChange(processValue(schema, newValue));

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -2,38 +2,6 @@ import React, {PropTypes} from "react";
 
 import {asNumber} from "../../utils";
 
-if (!Array.prototype.includes) {
-  Array.prototype.includes = function(searchElement /*, fromIndex*/) {
-    'use strict';
-    if (this == null) {
-      throw new TypeError('Array.prototype.includes called on null or undefined');
-    }
-
-    var O = Object(this);
-    var len = parseInt(O.length, 10) || 0;
-    if (len === 0) {
-      return false;
-    }
-    var n = parseInt(arguments[1], 10) || 0;
-    var k;
-    if (n >= 0) {
-      k = n;
-    } else {
-      k = len + n;
-      if (k < 0) {k = 0;}
-    }
-    var currentElement;
-    while (k < len) {
-      currentElement = O[k];
-      if (searchElement === currentElement ||
-         (searchElement !== searchElement && currentElement !== currentElement)) { // NaN !== NaN
-        return true;
-      }
-      k++;
-    }
-    return false;
-  };
-}
 /**
  * This is a silly limitation in the DOM where option change event values are
  * always retrieved as strings.

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -26,7 +26,7 @@ function TextareaWidget({
       disabled={disabled}
       readOnly={readonly}
       autoFocus={autofocus}
-      onBlur={(event) => onBlur(id, event.target.value)}
+      onBlur={onBlur ? (event) => onBlur(id, event.target.value) : undefined}
       onChange={_onChange} />
   );
 }

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -26,7 +26,7 @@ function TextareaWidget({
       disabled={disabled}
       readOnly={readonly}
       autoFocus={autofocus}
-      onBlur={onBlur ? (event) => onBlur(id, event.target.value) : undefined}
+      onBlur={onBlur && (event => onBlur(id, event.target.value))}
       onChange={_onChange} />
   );
 }

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -10,7 +10,8 @@ function TextareaWidget({
   disabled,
   readonly,
   autofocus,
-  onChange
+  onChange,
+  onBlur
 }) {
   return (
     <textarea
@@ -22,6 +23,7 @@ function TextareaWidget({
       disabled={disabled}
       readOnly={readonly}
       autoFocus={autofocus}
+      onBlur={(event) => onBlur(id, event.target.value)}
       onChange={(event) => onChange(event.target.value)}/>
   );
 }
@@ -39,6 +41,7 @@ if (process.env.NODE_ENV !== "production") {
     required: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
+    onBlur: PropTypes.func,
   };
 }
 

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -322,6 +322,22 @@ describe("ArrayField", () => {
         expect(comp.state.formData).eql(["foo", "bar"]);
       });
 
+      it("should handle a blur event", () => {
+        const onBlur = sandbox.spy();
+        const {comp, node} = createFormComponent({schema, onBlur});
+
+        const select = node.querySelector(".field select");
+        Simulate.blur(select, {
+          target: {options: [
+            {selected: true, value: "foo"},
+            {selected: true, value: "bar"},
+            {selected: false, value: "fuzz"},
+          ]}
+        });
+
+        expect(onBlur.calledWith(select.id, ["foo", "bar"])).to.be.true;
+      });
+
       it("should fill field with data", () => {
         const {node} = createFormComponent({schema, formData: ["foo", "bar"]});
 

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -324,7 +324,7 @@ describe("ArrayField", () => {
 
       it("should handle a blur event", () => {
         const onBlur = sandbox.spy();
-        const {comp, node} = createFormComponent({schema, onBlur});
+        const {node} = createFormComponent({schema, onBlur});
 
         const select = node.querySelector(".field select");
         Simulate.blur(select, {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -503,6 +503,30 @@ describe("Form", () => {
       });
     });
   });
+  describe("Blur handler", () => {
+    it("should call provided blur handler on form input blur event", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string",
+          },
+        }
+      };
+      const formData = {
+        foo: ""
+      };
+      const onBlur = sandbox.spy();
+      const {node} = createFormComponent({schema, formData, onBlur});
+
+      const input = node.querySelector("[type=text]");
+      Simulate.blur(input, {
+        target: {value: "new"}
+      });
+
+      sinon.assert.calledWithMatch(onBlur, input.id, "new");
+    });
+  });
 
   describe("Error handler", () => {
     it("should call provided error handler on validation errors", () => {

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -74,6 +74,19 @@ describe("NumberField", () => {
       expect(comp.state.formData).eql(2);
     });
 
+    it("should handle a blur event", () => {
+      const onBlur = sandbox.spy();
+      const {node} = createFormComponent({schema: {
+        type: "number",
+      }, onBlur});
+
+      const input = node.querySelector("input");
+      Simulate.blur(input, {
+        target: {value: "2"}
+      });
+
+      expect(onBlur.calledWith(input.id, 2));
+    });
     it("should fill field with data", () => {
       const {node} = createFormComponent({schema: {
         type: "number",

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -133,6 +133,18 @@ describe("ObjectField", () => {
       expect(comp.state.formData.foo).eql("changed");
     });
 
+    it("should handle object fields with blur events", () => {
+      const onBlur = sandbox.spy();
+      const {node} = createFormComponent({schema, onBlur});
+
+      const input = node.querySelector("input[type=text]");
+      Simulate.blur(input, {
+        target: {value: "changed"}
+      });
+
+      expect(onBlur.calledWith(input.id, "changed")).to.be.true;
+    });
+
     it("should render the widget with the expected id", () => {
       const {node} = createFormComponent({schema});
 

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -77,6 +77,19 @@ describe("StringField", () => {
       expect(comp.state.formData).eql("yo");
     });
 
+    it("should handle a blur event", () => {
+      const onBlur = sandbox.spy();
+      const {node} = createFormComponent({schema: {
+        type: "string",
+      }, onBlur});
+
+      const input = node.querySelector("input");
+      Simulate.blur(input, {
+        target: {value: "yo"}
+      });
+
+      expect(onBlur.calledWith(input.id, "yo")).to.be.true;
+    });
     it("should fill field with data", () => {
       const {node} = createFormComponent({schema: {
         type: "string",

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -90,6 +90,7 @@ describe("Rendering performance optimizations", () => {
 
   describe("ObjectField", () => {
     const onChange = () => {};
+    const onBlur = () => {};
     const registry = getDefaultRegistry();
     const uiSchema = {};
     const schema = {
@@ -107,6 +108,7 @@ describe("Rendering performance optimizations", () => {
         uiSchema,
         onChange,
         idSchema,
+        onBlur
       });
       sandbox.stub(comp, "render").returns(<div/>);
 
@@ -124,6 +126,7 @@ describe("Rendering performance optimizations", () => {
         formData,
         onChange,
         idSchema,
+        onBlur
       });
       sandbox.stub(comp, "render").returns(<div/>);
 

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -50,6 +50,7 @@ describe("Rendering performance optimizations", () => {
 
   describe("ArrayField", () => {
     const onChange = () => {};
+    const onBlur = () => {};
     const schema = {type: "array", items: {type: "string"}};
     const uiSchema = {};
     const registry = getDefaultRegistry();
@@ -60,6 +61,7 @@ describe("Rendering performance optimizations", () => {
         schema,
         uiSchema,
         onChange,
+        onBlur
       });
       sandbox.stub(comp, "render").returns(<div/>);
 

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -78,6 +78,7 @@ describe("Rendering performance optimizations", () => {
         schema,
         formData,
         onChange,
+        onBlur
       });
       sandbox.stub(comp, "render").returns(<div/>);
 


### PR DESCRIPTION
### Reasons for making this change

We want to be able to show validation errors only after a user has touched a field or tried to submit. We can do the submit part easily through the onError hook and formContext, but we need a way to track blur events. This adds that, similar to the onChange hook.

Should close #364 

### Checklist

* [X] **I'm updating documentation**
  - [X] I've checked the rendering of the Markdown text I've added
  - [X] If I'm adding a new section, I've updated the Table of Content
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [X] I've updated docs if needed
* [X] **I'm adding a new feature**
  - [X] I've updated the playground with an example use of the feature
