### PR TITLE
Add support for rows attribute of textarea widget.

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,15 +642,17 @@ const uiSchema = {
 }
 ```
 
-### Textarea rows
+### Textarea `rows` option
 
-You can set initial height of a textarea widget by specifying a `ui:rows` uiSchema directive.
+You can set initial height of a textarea widget by specifying `rows` option.
 
 ```js
 const schema = {type: "string"};
 const uiSchema = {
   "ui:widget": "textarea",
-  "ui:rows": 15
+  "ui:options": {
+    rows: 15
+  }
 }
 ```
 
@@ -1198,7 +1200,7 @@ render((
 
 ### Custom error messages
 
-Validation error messages are provided by the JSON Schema validation by default. If you need to change these messages or make any other modifications to the errors from the JSON Schema validation, you can define a transform function that receives the list of JSON Schema errors and returns a new list. 
+Validation error messages are provided by the JSON Schema validation by default. If you need to change these messages or make any other modifications to the errors from the JSON Schema validation, you can define a transform function that receives the list of JSON Schema errors and returns a new list.
 
 ```js
 function transformErrors(errors) {

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
      - [Form action buttons](#form-action-buttons)
      - [Help texts](#help-texts)
      - [Auto focus](#auto-focus)
-     - [Textarea rows](#textarea-rows)
+     - [Textarea rows option](#textarea-rows-option)
      - [Placeholders](#placeholders)
      - [Form attributes](#form-attributes)
   - [Advanced customization](#advanced-customization)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
      - [Form action buttons](#form-action-buttons)
      - [Help texts](#help-texts)
      - [Auto focus](#auto-focus)
+     - [Textarea rows](#textarea-rows)
      - [Placeholders](#placeholders)
      - [Form attributes](#form-attributes)
   - [Advanced customization](#advanced-customization)
@@ -638,6 +639,18 @@ const schema = {type: "string"};
 const uiSchema = {
   "ui:widget": "textarea",
   "ui:autofocus": true
+}
+```
+
+### Textarea rows
+
+You can set initial height of a textarea widget by specifying a `ui:rows` uiSchema directive.
+
+```js
+const schema = {type: "string"};
+const uiSchema = {
+  "ui:widget": "textarea",
+  "ui:rows": 15
 }
 ```
 

--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -95,7 +95,8 @@ module.exports = {
     },
     string: {
       textarea: {
-        "ui:widget": "textarea"
+        "ui:widget": "textarea",
+        "ui:rows": 5
       },
       color: {
         "ui:widget": "color"

--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -96,7 +96,9 @@ module.exports = {
     string: {
       textarea: {
         "ui:widget": "textarea",
-        "ui:rows": 5
+        "ui:options": {
+          rows: 5
+        }
       },
       color: {
         "ui:widget": "color"

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -4,6 +4,7 @@ import React, {PropTypes} from "react";
 function TextareaWidget({
   schema,
   id,
+  options,
   placeholder,
   value,
   required,
@@ -15,7 +16,7 @@ function TextareaWidget({
 }) {
   const _onChange = ({target: {value}}) => {
     return onChange(value === "" ? undefined : value);
-  };  
+  };
   return (
     <textarea
       id={id}
@@ -26,6 +27,7 @@ function TextareaWidget({
       disabled={disabled}
       readOnly={readonly}
       autoFocus={autofocus}
+      rows={options.rows}
       onBlur={onBlur && (event => onBlur(id, event.target.value))}
       onChange={_onChange} />
   );
@@ -40,6 +42,10 @@ if (process.env.NODE_ENV !== "production") {
     schema: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
+    options: PropTypes.shape({
+      enumOptions: PropTypes.bool,
+      rows: PropTypes.number
+    }).isRequired,
     value: PropTypes.string,
     required: PropTypes.bool,
     autofocus: PropTypes.bool,

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -29,12 +29,13 @@ function TextareaWidget({
       autoFocus={autofocus}
       rows={options.rows}
       onBlur={onBlur && (event => onBlur(id, event.target.value))}
-      onChange={_onChange} />
+      onChange={_onChange}/>
   );
 }
 
 TextareaWidget.defaultProps = {
-  autofocus: false
+  autofocus: false,
+  options: {}
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -43,9 +44,8 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     options: PropTypes.shape({
-      enumOptions: PropTypes.bool,
       rows: PropTypes.number
-    }).isRequired,
+    }),
     value: PropTypes.string,
     required: PropTypes.bool,
     autofocus: PropTypes.bool,

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -247,7 +247,10 @@ describe("StringField", () => {
     it("should render a textarea field with rows", () => {
       const {node} = createFormComponent({
         schema: {type: "string"},
-        uiSchema: {"ui:widget": "textarea", "ui:rows": 20},
+        uiSchema: {
+          "ui:widget": "textarea",
+          "ui:options": {rows: 20}
+        },
         formData: "x",
       });
 

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -89,7 +89,7 @@ describe("StringField", () => {
 
       expect(onBlur.calledWith(input.id, "yo")).to.be.true;
     });
-    
+
     it("should handle an empty string change event", () => {
       const {comp, node} = createFormComponent({
         schema: {type: "string"},
@@ -242,6 +242,16 @@ describe("StringField", () => {
       });
 
       expect(comp.state.formData).eql(undefined);
+    });
+
+    it("should render a textarea field with rows", () => {
+      const {node} = createFormComponent({
+        schema: {type: "string"},
+        uiSchema: {"ui:widget": "textarea", "ui:rows": 20},
+        formData: "x",
+      });
+
+      expect(node.querySelector("textarea").getAttribute("rows")).eql("20");
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

Add support for rows attribute of textarea widget.
Now users can specify initial height of it.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [x] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
