### PR TITLE
Issue #411.  Enable required field on radio options.

### DIFF
--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -25,6 +25,7 @@ function RadioWidget({
             <input type="radio"
               checked={checked}
               name={name}
+              required={required}
               value={option.value}
               disabled={disabled}
               autoFocus={autofocus && i === 0}


### PR DESCRIPTION
### Reasons for making this change

Enabled the required field on radio options so we can utilise HTML5 validation, as raised in Issue 411.

Tested on:
 numberEnumRadio on the "Numbers" tab in the playground 
 "boolean"."radio" in th "Widgets" tab in the playground

with noHtml5Validate both on and off

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
