### PR TITLE
Issue 412:  Readonly fixes to checkboxes, radion buttons, dropdowns, …

### DIFF
--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -7,6 +7,7 @@ function BaseInput(props) {
   const {
     value,
     readonly,
+    disabled,
     autofocus,
     onBlur,
     options,  // eslint-disable-line
@@ -23,6 +24,7 @@ function BaseInput(props) {
       {...inputProps}
       className="form-control"
       readOnly={readonly}
+      disabled={disabled}
       autoFocus={autofocus}
       value={typeof value === "undefined" ? "" : value}
       onChange={_onChange}

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -7,18 +7,19 @@ function CheckboxWidget({
   value,
   required,
   disabled,
+  readonly,
   label,
   autofocus,
   onChange,
 }) {
   return (
-    <div className={`checkbox ${disabled ? "disabled" : ""}`}>
+    <div className={`checkbox ${disabled || readonly ? "disabled" : ""}`}>
       <label>
         <input type="checkbox"
           id={id}
           checked={typeof value === "undefined" ? false : value}
           required={required}
-          disabled={disabled}
+          disabled={disabled || readonly}
           autoFocus={autofocus}
           onChange={(event) => onChange(event.target.checked)}/>
         <span>{label}</span>
@@ -37,6 +38,8 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     value: PropTypes.bool,
     required: PropTypes.bool,
+    disabled: PropTypes.bool,
+    readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
   };

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -14,19 +14,19 @@ function deselectValue(value, selected) {
 }
 
 function CheckboxesWidget(props) {
-  const {id, disabled, options, value, autofocus, onChange} = props;
+  const {id, disabled, options, value, autofocus, readonly, onChange} = props;
   const {enumOptions, inline} = options;
   return (
     <div className="checkboxes" id={id}>{
       enumOptions.map((option, index) => {
         const checked = value.indexOf(option.value) !== -1;
-        const disabledCls = disabled ? "disabled" : "";
+        const disabledCls = disabled || readonly ? "disabled" : "";
         const checkbox = (
           <span>
             <input type="checkbox"
               id={`${id}_${index}`}
               checked={checked}
-              disabled={disabled}
+              disabled={disabled || readonly}
               autoFocus={autofocus && index === 0}
               onChange={(event) => {
                 const all = enumOptions.map(({value}) => value);
@@ -72,6 +72,7 @@ if (process.env.NODE_ENV !== "production") {
     }).isRequired,
     value: PropTypes.any,
     required: PropTypes.bool,
+    readonly: PropTypes.bool,
     disabled: PropTypes.bool,
     multiple: PropTypes.bool,
     autofocus: PropTypes.bool,

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -4,7 +4,14 @@ import BaseInput from "./BaseInput";
 
 
 function ColorWidget(props) {
-  return <BaseInput type="color" {...props}/>;
+  if (props.readonly) {
+    let {disabled, ...colorProps} = props;
+    colorProps.disabled = true;
+    return <BaseInput type="color" {...colorProps}/>;
+  } else {
+    return <BaseInput type="color" {...props}/>;
+  }
+  
 }
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -5,7 +5,7 @@ import BaseInput from "./BaseInput";
 
 function ColorWidget(props) {
   if (props.readonly) {
-    let {disabled, ...colorProps} = props;
+    let {...colorProps} = props;
     colorProps.disabled = true;
     return <BaseInput type="color" {...colorProps}/>;
   } else {

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -6,6 +6,7 @@ function RadioWidget({
   options,
   value,
   required,
+  readonly,
   disabled,
   autofocus,
   onChange
@@ -19,14 +20,14 @@ function RadioWidget({
     <div className="field-radio-group">{
       enumOptions.map((option, i) => {
         const checked = option.value === value;
-        const disabledCls = disabled ? "disabled" : "";
+        const disabledCls = disabled || readonly ? "disabled" : "";
         const radio = (
           <span>
             <input type="radio"
               checked={checked}
               name={name}
               value={option.value}
-              disabled={disabled}
+              disabled={disabled || readonly}
               autoFocus={autofocus && i === 0}
               onChange={_ => onChange(option.value)}/>
             <span>{option.label}</span>
@@ -63,6 +64,7 @@ if (process.env.NODE_ENV !== "production") {
     }).isRequired,
     value: PropTypes.any,
     required: PropTypes.bool,
+    readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
   };

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -52,8 +52,7 @@ function SelectWidget({
       className="form-control"
       value={typeof value === "undefined" ? emptyValue : value}
       required={required}
-      disabled={disabled}
-      readOnly={readonly}
+      disabled={disabled || readonly}
       autoFocus={autofocus}
       onBlur={onBlur && (event => {
         const newValue = getValue(event, multiple);
@@ -84,6 +83,8 @@ if (process.env.NODE_ENV !== "production") {
     }).isRequired,
     value: PropTypes.any,
     required: PropTypes.bool,
+    disabled: PropTypes.bool,
+    readonly: PropTypes.bool,
     multiple: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -1525,6 +1525,10 @@ describe("uiSchema", () => {
         expect(node.querySelector(selector).hasAttribute("readonly"))
           .eql(true);
       }
+      function shouldBeDisabled(selector, schema, uiSchema) {
+        const {node} = createFormComponent({schema, uiSchema});
+        expect(node.querySelector(selector).disabled).eql(true);
+      }
 
       it("should mark as readonly a text widget", () => {
         shouldBeReadonly("input[type=text]",
@@ -1565,8 +1569,8 @@ describe("uiSchema", () => {
                          {"ui:readonly": true, "ui:widget": "range"});
       });
 
-      it("should mark as readonly a select widget", () => {
-        shouldBeReadonly("select",
+      it("should mark readonly as disabled on a select widget", () => {
+        shouldBeDisabled("select",
                          {type: "string", enum: ["a", "b"]},
                          {"ui:readonly": true});
       });
@@ -1607,25 +1611,25 @@ describe("uiSchema", () => {
                          {"ui:readonly": true});
       });
 
-      it("should mark as readonly an alternative date widget", () => {
+      it("should mark readonly as disabled on an alternative date widget", () => {
         const {node} = createFormComponent({
           schema: {type: "string", format: "date"},
           uiSchema: {"ui:readonly": true, "ui:widget": "alt-date"}
         });
 
         const readonly = [].map.call(node.querySelectorAll("select"),
-                                     node => node.hasAttribute("readonly"));
+                                     node => node.hasAttribute("disabled"));
         expect(readonly).eql([true, true, true]);
       });
 
-      it("should mark as readonly an alternative datetime widget", () => {
+      it("should mark readonly as disabled on an alternative datetime widget", () => {
         const {node} = createFormComponent({
           schema: {type: "string", format: "date-time"},
           uiSchema: {"ui:readonly": true, "ui:widget": "alt-datetime"}
         });
 
         const readonly = [].map.call(node.querySelectorAll("select"),
-                                     node => node.hasAttribute("readonly"));
+                                     node => node.hasAttribute("disabled"));
         expect(readonly).eql([true, true, true, true, true, true]);
       });
     });


### PR DESCRIPTION
Issue #412:  Readonly fixes to checkboxes, radio buttons, dropdowns and color widget.

### Reasons for making this change

Many controls are still editable in the form when the schema is set to readonly.  Even though these controls may not explicitly support the readonly keyword, it is anticipated that disabled in a closer match to than ignoring the directive,

Initially this was just checkboxes and radio buttons, but in the course of testing in the playground I also encountered similar problems with the dropdowns and color select control.

Please review the `ColorWidget` in particular, not sure what styling you'd prefer.  I went for two "returns" and only unpacked the props if needed, but it obviously can be done differently if you'd prefer.

If this is related to existing tickets, include links to them as well.

Tested in playground on by setting

```js
        "ui:readonly": true
```

Many controls affected on many tabs:

- Nested Tab:  "tasks"."items"."done"
- Arrays Tab:  "multipleChoicesList", "fixedItemsList"."a boolean value", "fixedNoToolbar"."a boolean"
- Numbers Tab: "numberEnum", "numberEnumRadio"
- Widgets Tab: "boolean"."default", "boolean"."radio", "boolean"."select", "strings"."color", "selectWidgetOptions"
- Errors Tab: "active", "multipleChoicesList"
- Large:  everything
- Date & Time: all alt-datetime dropdowns

**NOTE:**  The following items still do NOT respond to setting readonly in the playground:

In the custom tab the "geo" component.  As this is a custom component rather than a core component that is possibly acceptable.

In the "Custom Array" tab, the buttons still work ... but I'm not sure I'm the best person to tackle that fix.  I'd happily accept and include the change, or it can just go in another PR.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
