### PR TITLE
Refs #471: Introducing field clearing button.

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>react-jsonschema-form playground</title>
-  <link rel="stylesheet" id="theme" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  <link rel="stylesheet" id="theme" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   <script src="//cdn.polyfill.io/v2/polyfill.min.js"></script>
 </head>
 <body>

--- a/playground/index.prod.html
+++ b/playground/index.prod.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>react-jsonschema-form playground</title>
-  <link rel="stylesheet" id="theme" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  <link rel="stylesheet" id="theme" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   <link rel="stylesheet" href="./styles.css">
   <script src="//cdn.polyfill.io/v2/polyfill.min.js"></script>
 </head>

--- a/playground/samples/errors.js
+++ b/playground/samples/errors.js
@@ -7,7 +7,8 @@ module.exports = {
         type: "string",
         title: "First name",
         minLength: 8,
-        pattern: "\\d+"
+        pattern: "\\d+",
+        "description": "Note: this field isn't required, but will be validated for length and pattern as soon as a value is entered.",
       },
       active: {
         type: "boolean",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -154,7 +154,7 @@ export default class Form extends Component {
     const _SchemaField = registry.fields.SchemaField;
 
     return (
-      <form className={className ? className : "rjsf"}
+      <form className={`${className ? className : "rjsf"} has-feedback`}
         id={id}
         name={name}
         method={method}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -154,7 +154,7 @@ export default class Form extends Component {
     const _SchemaField = registry.fields.SchemaField;
 
     return (
-      <form className={`${className ? className : "rjsf"} has-feedback`}
+      <form className={className ? className : "rjsf"}
         id={id}
         name={name}
         method={method}

--- a/src/components/widgets/AltDateWidget.js
+++ b/src/components/widgets/AltDateWidget.js
@@ -21,6 +21,7 @@ function DateElement(props) {
   const {SelectWidget} = registry.widgets;
   return (
     <SelectWidget
+      clearable={false}
       schema={{type: "integer"}}
       id={id}
       className="form-control"

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -32,7 +32,7 @@ function BaseInput(props) {
         value={typeof value === "undefined" ? "" : value}
         onChange={_onChange}
         onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}/>
-      <a href="#" className="input-group-addon input-clear-btn" title="Clear field"
+      <a href="#" className="input-group-addon clear-btn" title="Clear field"
         onClick={_onClear}>
         <i className="glyphicon glyphicon-remove"/>
       </a>

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -15,21 +15,22 @@ function BaseInput(props) {
     schema,   // eslint-disable-line
     formContext,  // eslint-disable-line
     registry, // eslint-disable-line
+    onChange,
     ...inputProps
   } = props;
   const _onChange = ({target: {value}}) => {
-    return props.onChange(value);
+    return onChange(value);
   };
   return (
-    <ClearableWidget onChange={props.onChange}>
+    <ClearableWidget onChange={onChange} value={value}>
       <input
-      {...inputProps}
-      className="form-control"
-      readOnly={readonly}
-      autoFocus={autofocus}
-      value={typeof value === "undefined" ? "" : value}
-      onChange={_onChange}
-      onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}/>
+        {...inputProps}
+        className="form-control"
+        readOnly={readonly}
+        autoFocus={autofocus}
+        value={typeof value === "undefined" ? "" : value}
+        onChange={_onChange}
+        onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}/>
     </ClearableWidget>
   );
 }

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -1,5 +1,7 @@
 import React, {PropTypes} from "react";
 
+import ClearableWidget from "./ClearableWidget";
+
 
 function BaseInput(props) {
   // Note: since React 15.2.0 we can't forward unknown element attributes, so we
@@ -18,25 +20,17 @@ function BaseInput(props) {
   const _onChange = ({target: {value}}) => {
     return props.onChange(value);
   };
-  const _onClear = (event) => {
-    event.preventDefault();
-    return props.onChange(undefined);
-  };
   return (
-    <div className="input-group">
+    <ClearableWidget onChange={props.onChange}>
       <input
-        {...inputProps}
-        className="form-control"
-        readOnly={readonly}
-        autoFocus={autofocus}
-        value={typeof value === "undefined" ? "" : value}
-        onChange={_onChange}
-        onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}/>
-      <a href="#" className="input-group-addon clear-btn" title="Clear field"
-        onClick={_onClear}>
-        <i className="glyphicon glyphicon-remove"/>
-      </a>
-    </div>
+      {...inputProps}
+      className="form-control"
+      readOnly={readonly}
+      autoFocus={autofocus}
+      value={typeof value === "undefined" ? "" : value}
+      onChange={_onChange}
+      onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}/>
+    </ClearableWidget>
   );
 }
 

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -8,6 +8,7 @@ function BaseInput(props) {
   // exclude the "options" and "schema" ones here.
   const {
     value,
+    disabled,
     readonly,
     autofocus,
     onBlur,
@@ -22,7 +23,11 @@ function BaseInput(props) {
     return onChange(value);
   };
   return (
-    <ClearableWidget onChange={onChange} value={value}>
+    <ClearableWidget
+      onChange={onChange}
+      disabled={disabled}
+      readonly={readonly}
+      value={value}>
       <input
         {...inputProps}
         className="form-control"

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -16,17 +16,27 @@ function BaseInput(props) {
     ...inputProps
   } = props;
   const _onChange = ({target: {value}}) => {
-    return props.onChange(value === "" ? undefined : value);
+    return props.onChange(value);
+  };
+  const _onClear = (event) => {
+    event.preventDefault();
+    return props.onChange(undefined);
   };
   return (
-    <input
-      {...inputProps}
-      className="form-control"
-      readOnly={readonly}
-      autoFocus={autofocus}
-      value={typeof value === "undefined" ? "" : value}
-      onChange={_onChange}
-      onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}/>
+    <div className="input-group">
+      <input
+        {...inputProps}
+        className="form-control"
+        readOnly={readonly}
+        autoFocus={autofocus}
+        value={typeof value === "undefined" ? "" : value}
+        onChange={_onChange}
+        onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}/>
+      <a href="#" className="input-group-addon input-clear-btn" title="Clear field"
+        onClick={_onClear}>
+        <i className="glyphicon glyphicon-remove"/>
+      </a>
+    </div>
   );
 }
 

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -5,37 +5,42 @@ import ClearableWidget from "./ClearableWidget";
 
 function BaseInput(props) {
   // Note: since React 15.2.0 we can't forward unknown element attributes, so we
-  // exclude the "options" and "schema" ones here.
+  // exclude some props like "options" and "schema" here.
   const {
     value,
+    clearable,
     disabled,
     readonly,
     autofocus,
     onBlur,
-    options,  // eslint-disable-line
-    schema,   // eslint-disable-line
-    formContext,  // eslint-disable-line
-    registry, // eslint-disable-line
+    options,     // eslint-disable-line
+    schema,      // eslint-disable-line
+    formContext, // eslint-disable-line
+    registry,    // eslint-disable-line
     onChange,
     ...inputProps
   } = props;
   const _onChange = ({target: {value}}) => {
     return onChange(value);
   };
-  return (
+  const input = (
+    <input
+      {...inputProps}
+      className="form-control"
+      readOnly={readonly}
+      disabled={disabled}
+      autoFocus={autofocus}
+      value={typeof value === "undefined" ? "" : value}
+      onChange={_onChange}
+      onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}/>
+  );
+  return !clearable ? input : (
     <ClearableWidget
       onChange={onChange}
       disabled={disabled}
       readonly={readonly}
       value={value}>
-      <input
-        {...inputProps}
-        className="form-control"
-        readOnly={readonly}
-        autoFocus={autofocus}
-        value={typeof value === "undefined" ? "" : value}
-        onChange={_onChange}
-        onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}/>
+      {input}
     </ClearableWidget>
   );
 }
@@ -43,6 +48,7 @@ function BaseInput(props) {
 BaseInput.defaultProps = {
   type: "text",
   required: false,
+  clearable: true,
   disabled: false,
   readonly: false,
   autofocus: false,
@@ -54,6 +60,7 @@ if (process.env.NODE_ENV !== "production") {
     placeholder: PropTypes.string,
     value: PropTypes.any,
     required: PropTypes.bool,
+    clearable: PropTypes.bool,
     disabled: PropTypes.bool,
     readonly: PropTypes.bool,
     autofocus: PropTypes.bool,

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -1,29 +1,40 @@
 import React, {PropTypes} from "react";
 
+import ClearableWidget from "./ClearableWidget";
+
 
 function CheckboxWidget({
   schema,
   id,
   value,
   required,
+  readonly,
   disabled,
   label,
   autofocus,
   onChange,
 }) {
   return (
-    <div className={`checkbox ${disabled ? "disabled" : ""}`}>
-      <label>
-        <input type="checkbox"
-          id={id}
-          checked={typeof value === "undefined" ? false : value}
-          required={required}
-          disabled={disabled}
-          autoFocus={autofocus}
-          onChange={(event) => onChange(event.target.checked)}/>
-        <span>{label}</span>
-      </label>
-    </div>
+    <ClearableWidget
+      onChange={onChange}
+      disabled={disabled}
+      readonly={readonly}
+      value={value}>
+      <div className="form-control">
+        <div className={`checkbox ${disabled ? "disabled" : ""}`} style={{margin: "inherit"}}>
+          <label>
+            <input type="checkbox"
+              id={id}
+              checked={typeof value === "undefined" ? false : value}
+              required={required}
+              disabled={disabled}
+              autoFocus={autofocus}
+              onChange={(event) => onChange(event.target.checked)}/>
+            <span>{label}</span>
+          </label>
+        </div>
+      </div>
+    </ClearableWidget>
   );
 }
 

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -1,5 +1,7 @@
 import React, {PropTypes} from "react";
 
+import ClearableWidget from "./ClearableWidget";
+
 
 function selectValue(value, selected, all) {
   const at = all.indexOf(value);
@@ -14,44 +16,51 @@ function deselectValue(value, selected) {
 }
 
 function CheckboxesWidget(props) {
-  const {id, disabled, options, value, autofocus, onChange} = props;
+  const {id, disabled, readonly, options, value, autofocus, onChange} = props;
   const {enumOptions, inline} = options;
   return (
-    <div className="checkboxes" id={id}>{
-      enumOptions.map((option, index) => {
-        const checked = value.indexOf(option.value) !== -1;
-        const disabledCls = disabled ? "disabled" : "";
-        const checkbox = (
-          <span>
-            <input type="checkbox"
-              id={`${id}_${index}`}
-              checked={checked}
-              disabled={disabled}
-              autoFocus={autofocus && index === 0}
-              onChange={(event) => {
-                const all = enumOptions.map(({value}) => value);
-                if (event.target.checked) {
-                  onChange(selectValue(option.value, value, all));
-                } else {
-                  onChange(deselectValue(option.value, value));
-                }
-              }}/>
-            <span>{option.label}</span>
-          </span>
-        );
-        return inline ? (
-          <label key={index} className={`checkbox-inline ${disabledCls}`}>
-            {checkbox}
-          </label>
-        ) : (
-          <div key={index} className={`checkbox ${disabledCls}`}>
-            <label>
+    <ClearableWidget
+      onChange={onChange}
+      disabled={disabled}
+      readonly={readonly}
+      value={value}>
+      <div id={id} className="checkboxes form-control"
+        style={{paddingTop: 0, paddingBottom: 0, float: "none"}}>{
+        enumOptions.map((option, index) => {
+          const checked = value.indexOf(option.value) !== -1;
+          const disabledCls = disabled ? "disabled" : "";
+          const checkbox = (
+            <span>
+              <input type="checkbox"
+                id={`${id}_${index}`}
+                checked={checked}
+                disabled={disabled}
+                autoFocus={autofocus && index === 0}
+                onChange={(event) => {
+                  const all = enumOptions.map(({value}) => value);
+                  if (event.target.checked) {
+                    onChange(selectValue(option.value, value, all));
+                  } else {
+                    onChange(deselectValue(option.value, value));
+                  }
+                }}/>
+              <span>{option.label}</span>
+            </span>
+          );
+          return inline ? (
+            <label key={index} className={`checkbox-inline ${disabledCls}`}>
               {checkbox}
             </label>
-          </div>
-        );
-      })
-    }</div>
+          ) : (
+            <div key={index} className={`checkbox ${disabledCls}`}>
+              <label>
+                {checkbox}
+              </label>
+            </div>
+          );
+        })
+      }</div>
+    </ClearableWidget>
   );
 }
 

--- a/src/components/widgets/ClearableWidget.js
+++ b/src/components/widgets/ClearableWidget.js
@@ -1,18 +1,28 @@
 import React, {PropTypes} from "react";
 
 
-function ClearableWidget({onChange, children}) {
+function ClearableWidget({onChange, value, children}) {
   const _onClear = (event) => {
     event.preventDefault();
-    return onChange(undefined);
+    if (typeof value !== "undefined") {
+      return onChange(undefined);
+    }
+  };
+  const cleared = value === "" || value === undefined;
+  const clearBtnCls = "glyphicon glyphicon-remove-sign clear-btn";
+  const clearBtnStyles = {
+    pointerEvents: "auto",
+    textDecoration: "none",
+    cursor: cleared ? "no-drop" : "pointer",
+    color: cleared ? "#aaa" : "#888",
   };
   return (
     <div className="input-group">
-    {children}
-      <a href="#" className="input-group-addon clear-btn" title="Clear field"
-        onClick={_onClear}>
-        <i className="glyphicon glyphicon-remove"/>
-      </a>
+      {children}
+      <div className="input-group-addon">
+        <a className={clearBtnCls} onClick={_onClear} style={clearBtnStyles}
+          title="Reset field value"/>
+      </div>
     </div>
   );
 }

--- a/src/components/widgets/ClearableWidget.js
+++ b/src/components/widgets/ClearableWidget.js
@@ -1,0 +1,29 @@
+import React, {PropTypes} from "react";
+
+
+function ClearableWidget({onChange, children}) {
+  const _onClear = (event) => {
+    event.preventDefault();
+    return onChange(undefined);
+  };
+  return (
+    <div className="input-group">
+    {children}
+      <a href="#" className="input-group-addon clear-btn" title="Clear field"
+        onClick={_onClear}>
+        <i className="glyphicon glyphicon-remove"/>
+      </a>
+    </div>
+  );
+}
+
+ClearableWidget.defaultProps = {
+};
+
+if (process.env.NODE_ENV !== "production") {
+  ClearableWidget.propTypes = {
+    onChange: PropTypes.func,
+  };
+}
+
+export default ClearableWidget;

--- a/src/components/widgets/ClearableWidget.js
+++ b/src/components/widgets/ClearableWidget.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from "react";
 
 
-function ClearableWidget({onChange, value, children}) {
+function ClearableWidget({onChange, disabled, readonly, value, children}) {
   const _onClear = (event) => {
     event.preventDefault();
     if (typeof value !== "undefined") {
@@ -16,7 +16,7 @@ function ClearableWidget({onChange, value, children}) {
     cursor: cleared ? "no-drop" : "pointer",
     color: cleared ? "#aaa" : "#888",
   };
-  return (
+  return disabled || readonly ? children : (
     <div className="input-group">
       {children}
       <div className="input-group-addon">
@@ -28,11 +28,17 @@ function ClearableWidget({onChange, value, children}) {
 }
 
 ClearableWidget.defaultProps = {
+  disabled: false,
+  readonly: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
   ClearableWidget.propTypes = {
+    children: React.PropTypes.element.isRequired,
     onChange: PropTypes.func,
+    value: PropTypes.any,
+    disabled: PropTypes.bool,
+    readonly: PropTypes.bool,
   };
 }
 

--- a/src/components/widgets/ClearableWidget.js
+++ b/src/components/widgets/ClearableWidget.js
@@ -8,7 +8,7 @@ function ClearableWidget({onChange, disabled, readonly, value, children}) {
       return onChange(undefined);
     }
   };
-  const cleared = value === "" || value === undefined;
+  const cleared = typeof value === "undefined";
   const clearBtnCls = "glyphicon glyphicon-remove-sign clear-btn";
   const clearBtnStyles = {
     pointerEvents: "auto",

--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -15,10 +15,12 @@ function toJSONDate(dateString) {
 
 function DateTimeWidget(props) {
   const {value, onChange} = props;
+  // Note: native HTML date widgets are already clearable.
   return (
     <BaseInput
       type="datetime-local"
       {...props}
+      clearable={false}
       value={fromJSONDate(value)}
       onChange={(value) => onChange(toJSONDate(value))}/>
   );

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -5,10 +5,12 @@ import BaseInput from "./BaseInput";
 
 function DateWidget(props) {
   const {onChange} = props;
+  // Note: native HTML date widgets are already clearable.
   return (
     <BaseInput
       type="date"
       {...props}
+      clearable={false}
       onChange={(value) => onChange(value || undefined)}/>
   );
 }

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -1,5 +1,7 @@
 import React, {PropTypes} from "react";
 
+import ClearableWidget from "./ClearableWidget";
+
 
 function RadioWidget({
   schema,
@@ -7,6 +9,7 @@ function RadioWidget({
   value,
   required,
   disabled,
+  readonly,
   autofocus,
   onChange
 }) {
@@ -16,37 +19,43 @@ function RadioWidget({
   // checked={checked} has been moved above name={name}, As mentioned in #349;
   // this is a temporary fix for radio button rendering bug in React, facebook/react#7630.
   return (
-    <div className="field-radio-group">{
-      enumOptions.map((option, i) => {
-        const checked = option.value === value;
-        const disabledCls = disabled ? "disabled" : "";
-        const radio = (
-          <span>
-            <input type="radio"
-              checked={checked}
-              name={name}
-              required={required}
-              value={option.value}
-              disabled={disabled}
-              autoFocus={autofocus && i === 0}
-              onChange={_ => onChange(option.value)}/>
-            <span>{option.label}</span>
-          </span>
-        );
+    <ClearableWidget
+      onChange={onChange}
+      disabled={disabled}
+      readonly={readonly}
+      value={value}>
+      <div className="field-radio-group form-control" style={{float: "none"}}>{
+        enumOptions.map((option, i) => {
+          const checked = option.value === value;
+          const disabledCls = disabled ? "disabled" : "";
+          const radio = (
+            <span>
+              <input type="radio"
+                checked={checked}
+                name={name}
+                required={required}
+                value={option.value}
+                disabled={disabled}
+                autoFocus={autofocus && i === 0}
+                onChange={_ => onChange(option.value)}/>
+              <span>{option.label}</span>
+            </span>
+          );
 
-        return inline ? (
-          <label key={i} className={`radio-inline ${disabledCls}`}>
-            {radio}
-          </label>
-        ) : (
-          <div key={i} className={`radio ${disabledCls}`}>
-            <label>
+          return inline ? (
+            <label key={i} className={`radio-inline ${disabledCls}`}>
               {radio}
             </label>
-          </div>
-        );
-      })
-    }</div>
+          ) : (
+            <div key={i} className={`radio ${disabledCls}`} style={{margin: "inherit"}}>
+              <label>
+                {radio}
+              </label>
+            </div>
+          );
+        })
+      }</div>
+    </ClearableWidget>
   );
 }
 

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -1,6 +1,8 @@
 import React, {PropTypes} from "react";
 
+import ClearableWidget from "./ClearableWidget";
 import {asNumber} from "../../utils";
+
 
 /**
  * This is a silly limitation in the DOM where option change event values are
@@ -49,12 +51,8 @@ function SelectWidget({
     const newValue = getValue(event, multiple);
     onChange(processValue(schema, newValue));
   };
-  const _onClear = (event) => {
-    event.preventDefault();
-    return onChange(undefined);
-  };
   return (
-    <div className="input-group">
+    <ClearableWidget onChange={onChange}>
       <select
         id={id}
         multiple={multiple}
@@ -74,11 +72,7 @@ function SelectWidget({
           return <option key={i} value={value}>{label}</option>;
         })}
       </select>
-      <a href="#" className="input-group-addon clear-btn" title="Clear field"
-        onClick={_onClear}>
-        <i className="glyphicon glyphicon-remove"/>
-      </a>
-    </div>
+    </ClearableWidget>
   );
 }
 

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -45,29 +45,40 @@ function SelectWidget({
 }) {
   const {enumOptions} = options;
   const emptyValue = multiple ? [] : "";
+  const _onChange = (event) => {
+    const newValue = getValue(event, multiple);
+    onChange(processValue(schema, newValue));
+  };
+  const _onClear = (event) => {
+    event.preventDefault();
+    return onChange(undefined);
+  };
   return (
-    <select
-      id={id}
-      multiple={multiple}
-      className="form-control"
-      value={typeof value === "undefined" ? emptyValue : value}
-      required={required}
-      disabled={disabled}
-      readOnly={readonly}
-      autoFocus={autofocus}
-      onBlur={onBlur && (event => {
-        const newValue = getValue(event, multiple);
-        onBlur(id, processValue(schema, newValue));
-      })}
-      onChange={(event) => {
-        const newValue = getValue(event, multiple);
-        onChange(processValue(schema, newValue));
-      }}>
-      {!multiple && !schema.default && <option value="">{placeholder}</option>}
-      {enumOptions.map(({value, label}, i) => {
-        return <option key={i} value={value}>{label}</option>;
-      })}
-    </select>
+    <div className="input-group">
+      <select
+        id={id}
+        multiple={multiple}
+        className="form-control"
+        value={typeof value === "undefined" ? emptyValue : value}
+        required={required}
+        disabled={disabled}
+        readOnly={readonly}
+        autoFocus={autofocus}
+        onBlur={onBlur && (event => {
+          const newValue = getValue(event, multiple);
+          onBlur(id, processValue(schema, newValue));
+        })}
+        onChange={_onChange}>
+        {!multiple && !schema.default && <option value="">{placeholder}</option>}
+        {enumOptions.map(({value, label}, i) => {
+          return <option key={i} value={value}>{label}</option>;
+        })}
+      </select>
+      <a href="#" className="input-group-addon clear-btn" title="Clear field"
+        onClick={_onClear}>
+        <i className="glyphicon glyphicon-remove"/>
+      </a>
+    </div>
   );
 }
 

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -52,7 +52,7 @@ function SelectWidget({
     onChange(processValue(schema, newValue));
   };
   return (
-    <ClearableWidget onChange={onChange}>
+    <ClearableWidget onChange={onChange} value={value}>
       <select
         id={id}
         multiple={multiple}

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -52,7 +52,11 @@ function SelectWidget({
     onChange(processValue(schema, newValue));
   };
   return (
-    <ClearableWidget onChange={onChange} value={value}>
+    <ClearableWidget
+      onChange={onChange}
+      disabled={disabled}
+      readonly={readonly}
+      value={value}>
       <select
         id={id}
         multiple={multiple}

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -36,6 +36,7 @@ function SelectWidget({
   id,
   options,
   value,
+  clearable,
   required,
   disabled,
   readonly,
@@ -51,37 +52,41 @@ function SelectWidget({
     const newValue = getValue(event, multiple);
     onChange(processValue(schema, newValue));
   };
-  return (
+  const select = (
+    <select
+      id={id}
+      multiple={multiple}
+      className="form-control"
+      value={typeof value === "undefined" ? emptyValue : value}
+      required={required}
+      disabled={disabled}
+      readOnly={readonly}
+      autoFocus={autofocus}
+      onBlur={onBlur && (event => {
+        const newValue = getValue(event, multiple);
+        onBlur(id, processValue(schema, newValue));
+      })}
+      onChange={_onChange}>
+      {!multiple && !schema.default && <option value="">{placeholder}</option>}
+      {enumOptions.map(({value, label}, i) => {
+        return <option key={i} value={value}>{label}</option>;
+      })}
+    </select>
+  );
+  return !clearable ? select : (
     <ClearableWidget
       onChange={onChange}
       disabled={disabled}
       readonly={readonly}
       value={value}>
-      <select
-        id={id}
-        multiple={multiple}
-        className="form-control"
-        value={typeof value === "undefined" ? emptyValue : value}
-        required={required}
-        disabled={disabled}
-        readOnly={readonly}
-        autoFocus={autofocus}
-        onBlur={onBlur && (event => {
-          const newValue = getValue(event, multiple);
-          onBlur(id, processValue(schema, newValue));
-        })}
-        onChange={_onChange}>
-        {!multiple && !schema.default && <option value="">{placeholder}</option>}
-        {enumOptions.map(({value, label}, i) => {
-          return <option key={i} value={value}>{label}</option>;
-        })}
-      </select>
+      {select}
     </ClearableWidget>
   );
 }
 
 SelectWidget.defaultProps = {
   autofocus: false,
+  clearable: true,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -92,6 +97,7 @@ if (process.env.NODE_ENV !== "production") {
       enumOptions: PropTypes.array,
     }).isRequired,
     value: PropTypes.any,
+    clearable: PropTypes.bool,
     required: PropTypes.bool,
     multiple: PropTypes.bool,
     autofocus: PropTypes.bool,

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -1,5 +1,7 @@
 import React, {PropTypes} from "react";
 
+import ClearableWidget from "./ClearableWidget";
+
 
 function TextareaWidget({
   schema,
@@ -16,12 +18,8 @@ function TextareaWidget({
   const _onChange = ({target: {value}}) => {
     return onChange(value);
   };
-  const _onClear = (event) => {
-    event.preventDefault();
-    return onChange(undefined);
-  };
   return (
-    <div className="input-group">
+    <ClearableWidget onChange={onChange}>
       <textarea
         id={id}
         className="form-control"
@@ -33,11 +31,7 @@ function TextareaWidget({
         autoFocus={autofocus}
         onBlur={onBlur && (event => onBlur(id, event.target.value))}
         onChange={_onChange}/>
-      <a href="#" className="input-group-addon clear-btn" title="Clear field"
-        onClick={_onClear}>
-        <i className="glyphicon glyphicon-remove"/>
-      </a>
-    </div>
+    </ClearableWidget>
   );
 }
 

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -18,6 +18,7 @@ function TextareaWidget({
   const _onChange = ({target: {value}}) => {
     return onChange(value);
   };
+  // Note: Textareas are always clearable.
   return (
     <ClearableWidget
       onChange={onChange}

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -19,7 +19,11 @@ function TextareaWidget({
     return onChange(value);
   };
   return (
-    <ClearableWidget onChange={onChange} value={value}>
+    <ClearableWidget
+      onChange={onChange}
+      disabled={disabled}
+      readonly={readonly}
+      value={value}>
       <textarea
         id={id}
         className="form-control"

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -14,20 +14,30 @@ function TextareaWidget({
   onBlur
 }) {
   const _onChange = ({target: {value}}) => {
-    return onChange(value === "" ? undefined : value);
+    return onChange(value);
+  };
+  const _onClear = (event) => {
+    event.preventDefault();
+    return onChange(undefined);
   };
   return (
-    <textarea
-      id={id}
-      className="form-control"
-      value={typeof value === "undefined" ? "" : value}
-      placeholder={placeholder}
-      required={required}
-      disabled={disabled}
-      readOnly={readonly}
-      autoFocus={autofocus}
-      onBlur={onBlur && (event => onBlur(id, event.target.value))}
-      onChange={_onChange}/>
+    <div className="input-group">
+      <textarea
+        id={id}
+        className="form-control"
+        value={typeof value === "undefined" ? "" : value}
+        placeholder={placeholder}
+        required={required}
+        disabled={disabled}
+        readOnly={readonly}
+        autoFocus={autofocus}
+        onBlur={onBlur && (event => onBlur(id, event.target.value))}
+        onChange={_onChange}/>
+      <a href="#" className="input-group-addon input-clear-btn" title="Clear field"
+        onClick={_onClear}>
+        <i className="glyphicon glyphicon-remove"/>
+      </a>
+    </div>
   );
 }
 

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -33,7 +33,7 @@ function TextareaWidget({
         autoFocus={autofocus}
         onBlur={onBlur && (event => onBlur(id, event.target.value))}
         onChange={_onChange}/>
-      <a href="#" className="input-group-addon input-clear-btn" title="Clear field"
+      <a href="#" className="input-group-addon clear-btn" title="Clear field"
         onClick={_onClear}>
         <i className="glyphicon glyphicon-remove"/>
       </a>

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -19,7 +19,7 @@ function TextareaWidget({
     return onChange(value);
   };
   return (
-    <ClearableWidget onChange={onChange}>
+    <ClearableWidget onChange={onChange} value={value}>
       <textarea
         id={id}
         className="form-control"

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -415,6 +415,23 @@ describe("Form", () => {
     });
   });
 
+  describe("Default value handling when clearing fields", () => {
+    const schema = {
+      type: "string",
+      default: "foo",
+    };
+
+    it("should not set default when a text field is cleared", () => {
+      const {node} = createFormComponent({schema, formData: "bar"});
+
+      Simulate.change(node.querySelector("input"), {
+        target: {value: ""}
+      });
+
+      expect(node.querySelector("input").value).eql("");
+    });
+  });
+
   describe("Defaults array items default propagation", () => {
     const schema = {
       type: "object",

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -89,7 +89,7 @@ describe("StringField", () => {
 
       expect(onBlur.calledWith(input.id, "yo")).to.be.true;
     });
-    
+
     it("should handle an empty string change event", () => {
       const {comp, node} = createFormComponent({
         schema: {type: "string"},
@@ -100,7 +100,7 @@ describe("StringField", () => {
         target: {value: ""}
       });
 
-      expect(comp.state.formData).eql(undefined);
+      expect(comp.state.formData).eql("");
     });
 
     it("should fill field with data", () => {

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -103,6 +103,17 @@ describe("StringField", () => {
       expect(comp.state.formData).eql("");
     });
 
+    it("should allow clearing the field", () => {
+      const {comp, node} = createFormComponent({
+        schema: {type: "string"},
+        formData: "x",
+      });
+
+      Simulate.click(node.querySelector(".clear-btn"));
+
+      expect(comp.state.formData).eql(undefined);
+    });
+
     it("should fill field with data", () => {
       const {node} = createFormComponent({schema: {
         type: "string",
@@ -281,16 +292,28 @@ describe("StringField", () => {
   });
 
   describe("TextareaWidget", () => {
-    it("should handle an empty string change event", () => {
-      const {comp, node} = createFormComponent({
+    let comp, node;
+
+    beforeEach(() => {
+      const res = createFormComponent({
         schema: {type: "string"},
         uiSchema: {"ui:widget": "textarea"},
         formData: "x",
       });
+      node = res.node;
+      comp = res.comp;
+    });
 
+    it("should handle an empty string change event", () => {
       Simulate.change(node.querySelector("textarea"), {
         target: {value: ""}
       });
+
+      expect(comp.state.formData).eql("");
+    });
+
+    it("should allow clearing the field", () => {
+      Simulate.click(node.querySelector(".clear-btn"));
 
       expect(comp.state.formData).eql(undefined);
     });

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -289,6 +289,20 @@ describe("StringField", () => {
       expect(node.querySelector("#custom"))
         .to.exist;
     });
+
+    it("should allow clearing the field", () => {
+      const {comp, node} = createFormComponent({
+        schema: {
+          type: "string",
+          enum: ["a", "b"],
+        },
+        formData: "a",
+      });
+
+      Simulate.click(node.querySelector(".clear-btn"));
+
+      expect(comp.state.formData).eql(undefined);
+    });
   });
 
   describe("TextareaWidget", () => {


### PR DESCRIPTION
WiP, introducing clear buttons for fields. The blank-string-as-undefined strategy introduced by #442 brings too much trouble, eg. #471. So I'm finally working on adding clear buttons, as initially intended.

![](http://i.imgur.com/12NVwqu.png)

### Todo

- [x] Text inputs (including numbers, textareas)
- [x] Boolean fields
- [x] Enums (select)
- [x] Handling `disabled` and `readonly`
- [x] Disabling the button for already cleared fields  