### PR TITLE
Issue #473: Fix uiSchema in playground "Single" tab.

### DIFF
--- a/playground/samples/single.js
+++ b/playground/samples/single.js
@@ -3,5 +3,6 @@ module.exports = {
     title: "A single-field form",
     type: "string",
   },
-  formData: "initial value"
+  formData: "initial value",
+  uiSchema: {}
 };


### PR DESCRIPTION
### Reasons for making this change

Missing uiSchema export for "Single" tab in playground.

If this is related to existing tickets, include links to them as well.

[Playground] Error in "Single" after having loaded the "Validation" example #473

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
