### PR TITLE
Centralized handling shouldComponentUpdate into SchemaField

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -11,7 +11,6 @@ import {
   optionsList,
   retrieveSchema,
   toIdSchema,
-  shouldRender,
   getDefaultRegistry
 } from "../../utils";
 
@@ -158,10 +157,6 @@ class ArrayField extends Component {
     readonly: false,
     autofocus: false,
   };
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shouldRender(this, nextProps, nextState);
-  }
 
   get itemTitle() {
     const {schema} = this.props;

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -3,7 +3,6 @@ import React, {Component, PropTypes} from "react";
 import {
   orderProperties,
   retrieveSchema,
-  shouldRender,
   getDefaultRegistry
 } from "../../utils";
 
@@ -17,10 +16,6 @@ class ObjectField extends Component {
     required: false,
     disabled: false,
     readonly: false,
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shouldRender(this, nextProps, nextState);
   }
 
   isRequired(name) {

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -1,4 +1,4 @@
-import React, {PropTypes, Component} from "react";
+import React, {PropTypes} from "react";
 
 import {
   isMultiSelect,
@@ -129,49 +129,38 @@ DefaultTemplate.defaultProps = {
   displayLabel: true,
 };
 
-class SchemaField extends Component {
-  shouldComponentUpdate(nextProps, nextState) {
-    // if schemas are equal idSchemas will be equal as well,
-    // so it is not necessary to compare
-    return !deepEquals(
-      {...this.props, idSchema: undefined},
-      {...nextProps,  idSchema: undefined}
-    );
+function SchemaFieldRender(props) {
+  const {uiSchema, errorSchema, idSchema, name, required, registry} = props;
+  const {definitions, fields, formContext, FieldTemplate = DefaultTemplate} = registry;
+  const schema = retrieveSchema(props.schema, definitions);
+  const FieldComponent = getFieldComponent(schema, uiSchema, fields);
+  const {DescriptionField} = fields;
+  const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);
+  const readonly = Boolean(props.readonly || uiSchema["ui:readonly"]);
+  const autofocus = Boolean(props.autofocus || uiSchema["ui:autofocus"]);
+
+  if (Object.keys(schema).length === 0) {
+    // See #312: Ensure compatibility with old versions of React.
+    return <div/>;
   }
 
-  render() {
-    const props = this.props;
-    const {uiSchema, errorSchema, idSchema, name, required, registry} = props;
-    const {definitions, fields, formContext, FieldTemplate = DefaultTemplate} = registry;
-    const schema = retrieveSchema(props.schema, definitions);
-    const FieldComponent = getFieldComponent(schema, uiSchema, fields);
-    const {DescriptionField} = fields;
-    const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);
-    const readonly = Boolean(props.readonly || uiSchema["ui:readonly"]);
-    const autofocus = Boolean(props.autofocus || uiSchema["ui:autofocus"]);
+  let displayLabel = true;
+  if (schema.type === "array") {
+    displayLabel = isMultiSelect(schema) || isFilesArray(schema, uiSchema);
+  }
+  if (schema.type === "object") {
+    displayLabel = false;
+  }
+  if (schema.type === "boolean" && !uiSchema["ui:widget"]) {
+    displayLabel = false;
+  }
+  if (uiSchema["ui:field"]) {
+    displayLabel = false;
+  }
 
-    if (Object.keys(schema).length === 0) {
-    // See #312: Ensure compatibility with old versions of React.
-      return <div/>;
-    }
+  const {__errors, ...fieldErrorSchema} = errorSchema;
 
-    let displayLabel = true;
-    if (schema.type === "array") {
-      displayLabel = isMultiSelect(schema) || isFilesArray(schema, uiSchema);
-    }
-    if (schema.type === "object") {
-      displayLabel = false;
-    }
-    if (schema.type === "boolean" && !uiSchema["ui:widget"]) {
-      displayLabel = false;
-    }
-    if (uiSchema["ui:field"]) {
-      displayLabel = false;
-    }
-
-    const {__errors, ...fieldErrorSchema} = errorSchema;
-
-    const field = (
+  const field = (
     <FieldComponent {...props}
       schema={schema}
       // See #439: Don't pass consumed class names to child components
@@ -183,44 +172,58 @@ class SchemaField extends Component {
       formContext={formContext}/>
   );
 
-    const {type} = schema;
-    const id = idSchema.$id;
-    const label = props.schema.title || schema.title || name;
-    const description = props.schema.description || schema.description;
-    const errors = __errors;
-    const help = uiSchema["ui:help"];
-    const hidden = uiSchema["ui:widget"] === "hidden";
-    const classNames = [
-      "form-group",
-      "field",
-      `field-${type}`,
-      errors && errors.length > 0 ? "field-error has-error" : "",
-      uiSchema.classNames,
-    ].join(" ").trim();
+  const {type} = schema;
+  const id = idSchema.$id;
+  const label = props.schema.title || schema.title || name;
+  const description = props.schema.description || schema.description;
+  const errors = __errors;
+  const help = uiSchema["ui:help"];
+  const hidden = uiSchema["ui:widget"] === "hidden";
+  const classNames = [
+    "form-group",
+    "field",
+    `field-${type}`,
+    errors && errors.length > 0 ? "field-error has-error" : "",
+    uiSchema.classNames,
+  ].join(" ").trim();
 
-    const fieldProps = {
-      description: <DescriptionField id={id + "__description"}
+  const fieldProps = {
+    description: <DescriptionField id={id + "__description"}
                                    description={description}
                                    formContext={formContext}/>,
-      rawDescription: description,
-      help: <Help help={help}/>,
-      rawHelp: typeof help === "string" ? help : undefined,
-      errors: <ErrorList errors={errors}/>,
-      rawErrors: errors,
-      id,
-      label,
-      hidden,
-      required,
-      readonly,
-      displayLabel,
-      classNames,
-      formContext,
-      fields,
-      schema,
-      uiSchema,
-    };
+    rawDescription: description,
+    help: <Help help={help}/>,
+    rawHelp: typeof help === "string" ? help : undefined,
+    errors: <ErrorList errors={errors}/>,
+    rawErrors: errors,
+    id,
+    label,
+    hidden,
+    required,
+    readonly,
+    displayLabel,
+    classNames,
+    formContext,
+    fields,
+    schema,
+    uiSchema,
+  };
 
-    return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
+  return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
+}
+
+class SchemaField extends React.Component{
+  shouldComponentUpdate(nextProps, nextState) {
+    // if schemas are equal idSchemas will be equal as well,
+    // so it is not necessary to compare
+    return !deepEquals(
+      {...this.props, idSchema: undefined},
+      {...nextProps,  idSchema: undefined}
+    );
+  }
+
+  render(){
+    return SchemaFieldRender(this.props);
   }
 }
 

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -212,7 +212,7 @@ function SchemaFieldRender(props) {
   return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
 }
 
-class SchemaField extends React.Component{
+class SchemaField extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     // if schemas are equal idSchemas will be equal as well,
     // so it is not necessary to compare
@@ -222,7 +222,7 @@ class SchemaField extends React.Component{
     );
   }
 
-  render(){
+  render() {
     return SchemaFieldRender(this.props);
   }
 }

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -131,13 +131,12 @@ DefaultTemplate.defaultProps = {
 
 class SchemaField extends Component {
   shouldComponentUpdate(nextProps, nextState) {
-    let _props = {...this.props};
-    let _nextProps = {...nextProps};
-    // if schema and formData are the equal
-    // idSchema and errorSchema will be equal
-    delete _props.idSchema;
-    delete _nextProps.idSchema;
-    return !deepEquals(_props, _nextProps);
+    // if schemas are equal idSchemas will be equal as well,
+    // so it is not necessary to compare
+    return !deepEquals(
+      {...this.props, idSchema: undefined},
+      {...nextProps,  idSchema: undefined}
+    );
   }
 
   render() {

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -62,11 +62,11 @@ describe("Rendering performance optimizations", () => {
       });
 
       const fields = scryRenderedComponentsWithType(comp, SchemaField)
-              .reduce( (fields, fieldComp) => {
-                sandbox.stub(fieldComp, "render").returns(<div/>);
-                fields[fieldComp.props.idSchema.$id] = fieldComp;
-                return fields;
-              });
+        .reduce( (fields, fieldComp) => {
+          sandbox.stub(fieldComp, "render").returns(<div/>);
+          fields[fieldComp.props.idSchema.$id] = fieldComp;
+          return fields;
+        });
 
       setProps(comp, {schema, formData: {const: "0", var: "1"}});
 
@@ -86,11 +86,11 @@ describe("Rendering performance optimizations", () => {
       });
 
       const fields = scryRenderedComponentsWithType(comp, SchemaField)
-              .reduce( (fields, fieldComp) => {
-                sandbox.stub(fieldComp, "render").returns(<div/>);
-                fields[fieldComp.props.idSchema.$id] = fieldComp;
-                return fields;
-              });
+        .reduce( (fields, fieldComp) => {
+          sandbox.stub(fieldComp, "render").returns(<div/>);
+          fields[fieldComp.props.idSchema.$id] = fieldComp;
+          return fields;
+        });
 
       setProps(comp, {schema, formData: ["const", "var1"]});
 

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -2,8 +2,7 @@ import sinon from "sinon";
 import React from "react";
 
 import {getDefaultRegistry} from "../src/utils";
-import ArrayField from "../src/components/fields/ArrayField";
-import ObjectField from "../src/components/fields/ObjectField";
+import SchemaField from "../src/components/fields/SchemaField";
 import {
   createComponent,
   createFormComponent,
@@ -49,49 +48,7 @@ describe("Rendering performance optimizations", () => {
     });
   });
 
-  describe("ArrayField", () => {
-    const onChange = () => {};
-    const onBlur = () => {};
-    const schema = {type: "array", items: {type: "string"}};
-    const uiSchema = {};
-    const registry = getDefaultRegistry();
-
-    it("should not render if next props are equivalent", () => {
-      const props = {
-        registry,
-        schema,
-        uiSchema,
-        onChange,
-        onBlur
-      };
-
-      const {comp} = createComponent(ArrayField, props);
-      sandbox.stub(comp, "render").returns(<div/>);
-
-      setProps(comp, props);
-
-      sinon.assert.notCalled(comp.render);
-    });
-
-    it("should not render if next formData are equivalent", () => {
-      const props = {
-        registry,
-        schema,
-        formData: ["a", "b"],
-        onChange,
-        onBlur
-      };
-
-      const {comp} = createComponent(ArrayField, props);
-      sandbox.stub(comp, "render").returns(<div/>);
-
-      setProps(comp, {...props, formData: ["a", "b"]});
-
-      sinon.assert.notCalled(comp.render);
-    });
-  });
-
-  describe("ObjectField", () => {
+  describe("SchemaField", () => {
     const onChange = () => {};
     const onBlur = () => {};
     const registry = getDefaultRegistry();
@@ -114,7 +71,7 @@ describe("Rendering performance optimizations", () => {
         onBlur
       };
 
-      const {comp} = createComponent(ObjectField, props);
+      const {comp} = createComponent(SchemaField, props);
       sandbox.stub(comp, "render").returns(<div/>);
 
       setProps(comp, props);
@@ -132,7 +89,7 @@ describe("Rendering performance optimizations", () => {
         onBlur
       };
 
-      const {comp} = createComponent(ObjectField, props);
+      const {comp} = createComponent(SchemaField, props);
       sandbox.stub(comp, "render").returns(<div/>);
 
       setProps(comp, {...props, formData: {foo: "blah"}});


### PR DESCRIPTION
### Reasons for making this change

When one property is updated, the rest of the properties will be unnecessarily rendered.
This will cause a significant performance issue in a large object schema such as the demo of 'Large' in the playground.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
