### PR TITLE
Show description for boolean fields

### DIFF
--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -26,15 +26,18 @@ module.exports = {
         properties: {
           default: {
             type: "boolean",
-            title: "checkbox (default)"
+            title: "checkbox (default)",
+            description: "This is the checkbox-description"
           },
           radio: {
             type: "boolean",
-            title: "radio buttons"
+            title: "radio buttons",
+            description: "This is the radio-description"
           },
           select: {
             type: "boolean",
-            title: "select box"
+            title: "select box",
+            description: "This is the select-description"
           }
         }
       },

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -1,5 +1,5 @@
 import React, {PropTypes} from "react";
-
+import DescriptionField from "../fields/DescriptionField.js";
 
 function CheckboxWidget({
   schema,
@@ -13,6 +13,10 @@ function CheckboxWidget({
 }) {
   return (
     <div className={`checkbox ${disabled ? "disabled" : ""}`}>
+      { schema.description
+        ? <DescriptionField description={ schema.description }/>
+        : null
+      }
       <label>
         <input type="checkbox"
           id={id}
@@ -20,6 +24,7 @@ function CheckboxWidget({
           required={required}
           disabled={disabled}
           autoFocus={autofocus}
+          title={schema.description}
           onChange={(event) => onChange(event.target.checked)}/>
         <span>{label}</span>
       </label>

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -13,10 +13,7 @@ function CheckboxWidget({
 }) {
   return (
     <div className={`checkbox ${disabled ? "disabled" : ""}`}>
-      { schema.description
-        ? <DescriptionField description={ schema.description }/>
-        : null
-      }
+      { schema.description && <DescriptionField description={ schema.description }/> }
       <label>
         <input type="checkbox"
           id={id}
@@ -24,7 +21,6 @@ function CheckboxWidget({
           required={required}
           disabled={disabled}
           autoFocus={autofocus}
-          title={schema.description}
           onChange={(event) => onChange(event.target.checked)}/>
         <span>{label}</span>
       </label>

--- a/test/BooleanField_test.js
+++ b/test/BooleanField_test.js
@@ -47,6 +47,16 @@ describe("BooleanField", () => {
       .to.have.length.of(1);
   });
 
+  it("should render a description", () => {
+    const {node} = createFormComponent({schema: {
+      type: "boolean",
+      description: "my description"
+    }});
+
+    const description = node.querySelector(".field-description");
+    expect(description.textContent).eql("my description");
+  });
+
   it("should assign a default value", () => {
     const {node} = createFormComponent({schema: {
       type: "boolean",


### PR DESCRIPTION
### Reasons for making this change

A fix for #435 . I chose to present the description in a similar way like the other fields, with an extra text above the input. The suggested `title` looked a bit "strange" since it was the only input with that kind of behavior and it would probably have issues in a mobile view. 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
