### PR TITLE
Fix #221 Manually reorder array erros insteading of using validate when live validation is off

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -8,7 +8,7 @@ import {
   setState,
   getDefaultRegistry,
 } from "../utils";
-import validateFormData from "../validate";
+import validateFormData, {toErrorList} from "../validate";
 
 
 export default class Form extends Component {
@@ -75,12 +75,15 @@ export default class Form extends Component {
     return null;
   }
 
-  onChange = (formData, options={validate: false}) => {
-    const mustValidate = !this.props.noValidate && (this.props.liveValidate || options.validate);
+  onChange = (formData, errorSchemaUpdater) => {
+    const mustValidate = !this.props.noValidate && this.props.liveValidate;
     let state = {status: "editing", formData};
     if (mustValidate) {
       const {errors, errorSchema} = this.validate(formData);
       state = {...state, errors, errorSchema};
+    } else if (!this.props.noValidate && errorSchemaUpdater) {
+      const errorSchema = errorSchemaUpdater(this.state.errorSchema);
+      state = {...state, errorSchema, errors: toErrorList(errorSchema)};
     }
     setState(this, state, () => {
       if (this.props.onChange) {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -75,15 +75,18 @@ export default class Form extends Component {
     return null;
   }
 
-  onChange = (formData, errorSchemaUpdater) => {
+  onChange = (formData, newErrorSchema) => {
     const mustValidate = !this.props.noValidate && this.props.liveValidate;
     let state = {status: "editing", formData};
     if (mustValidate) {
       const {errors, errorSchema} = this.validate(formData);
       state = {...state, errors, errorSchema};
-    } else if (!this.props.noValidate && errorSchemaUpdater) {
-      const errorSchema = errorSchemaUpdater(this.state.errorSchema);
-      state = {...state, errorSchema, errors: toErrorList(errorSchema)};
+    } else if (!this.props.noValidate && newErrorSchema) {
+      state = {
+        ...state,
+        errorSchema: newErrorSchema,
+        errors: toErrorList(newErrorSchema)
+      };
     }
     setState(this, state, () => {
       if (this.props.onChange) {

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -223,9 +223,11 @@ class ArrayField extends Component {
       }
       const {formData, onChange} = this.props;
       onChange(formData.map((item, i) => {
-        if (i === newIndex) {
+        // i is string, index and newIndex are numbers,
+        // so using "==" to compare
+        if (i == newIndex) {
           return formData[index];
-        } else if (i === index) {
+        } else if (i == index) {
           return formData[newIndex];
         } else {
           return item;

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -25,9 +25,17 @@ class ObjectField extends Component {
   }
 
   onPropertyChange = (name) => {
-    return (value, options) => {
+    return (value, errorSchemaUpdater) => {
       const newFormData = {...this.props.formData, [name]: value};
-      this.props.onChange(newFormData, options);
+      this.props.onChange(
+        newFormData,
+        errorSchemaUpdater && (
+          errorSchema => (errorSchema && {
+            ...errorSchema,
+            [name]: errorSchemaUpdater(errorSchema[name])
+          })
+        )
+      );
     };
   };
 

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -25,16 +25,14 @@ class ObjectField extends Component {
   }
 
   onPropertyChange = (name) => {
-    return (value, errorSchemaUpdater) => {
+    return (value, errorSchema) => {
       const newFormData = {...this.props.formData, [name]: value};
       this.props.onChange(
         newFormData,
-        errorSchemaUpdater && (
-          errorSchema => (errorSchema && {
-            ...errorSchema,
-            [name]: errorSchemaUpdater(errorSchema[name])
-          })
-        )
+        errorSchema && this.props.errorSchema && {
+          ...this.props.errorSchema,
+          [name]: errorSchema
+        }
       );
     };
   };


### PR DESCRIPTION
No validating but updating errorSchema base on array operation when live validation is off.

{validate: true/false} in the onChange function has been replaced by a updated errorSchema when live validation was setted to fail and array was reorder or related item was deleted. This can prevent validating the whole form when justing updating the array.

Limitation: Unexpected behaviours may occur if user forget to pass the update function to parent in their custom field.

This patch fix #221.

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
