### PR TITLE
Issue 488

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
   - [Advanced customization](#advanced-customization)
      - [Field template](#field-template)
      - [Array Field Template](#array-field-template)
+     - [Error list Template](#error-list-template)
      - [Custom widgets and fields](#custom-widgets-and-fields)
      - [Custom widget components](#custom-widget-components)
         - [Custom component registration](#custom-component-registration)
@@ -809,6 +810,38 @@ The following props are part of each element in `items`:
 - `onReorderClick: (index, newIndex) => (event) => void`: Returns a function that swaps the items at `index` with `newIndex`.
 - `readonly`: A boolean value stating if the array item is readonly.
 
+### Error List template
+
+To take control over how the form errors are displayed, you can define an *error list template* for your form. This list is the form global error list that appears at the top of your forms.
+
+An error list template is basically a React stateless component being passed errors as props so you can render them as you like:
+
+```jsx
+function ErrorListTemplate(props) {
+  const {errors} = props;
+  return (
+    <div>
+      {errors.map((error, i) => {
+        return (
+          <li key={i}>
+            {error.stack}
+          </li>
+        );
+      })}
+    </div>
+  );
+}
+
+render((
+  <Form schema={schema}
+        showErrorList={true}
+        ErrorList={ErrorListTemplate} />,
+), document.getElementById("app"));
+```
+
+> Note: Your custom `ErrorList` template will only render when `showErrorList` is `true`.
+
+
 ### Custom widgets and fields
 
 The API allows to specify your own custom *widget* and *field* components:
@@ -1255,6 +1288,8 @@ render((
         showErrorList={false}/>
 ), document.getElementById("app"));
 ```
+
+> Note: you can also use your own [ErrorList](#error-list-template)
 
 ### The case of empty strings
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 
-import ErrorList from "./ErrorList";
+import { default as DefaultErrorList } from "./ErrorList";
 import {
   getDefaultFormState,
   shouldRender,
@@ -16,7 +16,8 @@ export default class Form extends Component {
     noValidate: false,
     liveValidate: false,
     safeRenderCompletion: false,
-    noHtml5Validate: false
+    noHtml5Validate: false,
+    ErrorList: DefaultErrorList
   };
 
   constructor(props) {
@@ -76,7 +77,7 @@ export default class Form extends Component {
 
   renderErrors() {
     const { status, errors } = this.state;
-    const { showErrorList } = this.props;
+    const { ErrorList, showErrorList } = this.props;
     if (status !== "editing" && errors.length && showErrorList != false) {
       return <ErrorList errors={errors} />;
     }
@@ -208,6 +209,7 @@ if (process.env.NODE_ENV !== "production") {
     fields: PropTypes.objectOf(PropTypes.func),
     ArrayFieldTemplate: PropTypes.func,
     FieldTemplate: PropTypes.func,
+    ErrorList: PropTypes.func,
     onChange: PropTypes.func,
     onError: PropTypes.func,
     showErrorList: PropTypes.bool,

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -1,3 +1,4 @@
+import React from "react";
 import { expect } from "chai";
 import sinon from "sinon";
 import { Simulate } from "react-addons-test-utils";
@@ -443,6 +444,33 @@ describe("Validation", () => {
             })
           );
         });
+      });
+    });
+
+    describe("Custom ErrorList", () => {
+      const schema = {
+        type: "string",
+        required: true,
+        minLength: 1
+      };
+
+      const formData = 0;
+
+      const CustomErrorList = ({ errors }) => (
+        <div className="CustomErrorList">{errors.length} custom</div>
+      );
+
+      it("should use CustomErrorList", () => {
+        const { node } = createFormComponent({
+          schema,
+          liveValidate: true,
+          formData,
+          ErrorList: CustomErrorList
+        });
+        expect(node.querySelectorAll(".CustomErrorList")).to.have.length.of(1);
+        expect(node.querySelector(".CustomErrorList").textContent).eql(
+          "1 custom"
+        );
       });
     });
   });


### PR DESCRIPTION
### Reasons for making this change

Add ability to use our own ErrorList component, from #488 

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [x] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
