### PR TITLE
Add pre-commit hook for linting and code autoformatting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,15 +7,24 @@
     "build:lib": "rimraf lib && cross-env NODE_ENV=production babel -d lib/ src/",
     "build:dist": "rimraf dist && cross-env NODE_ENV=production webpack --config webpack.config.dist.js --optimize-minimize",
     "build:playground": "rimraf build && cross-env NODE_ENV=production webpack --config webpack.config.prod.js --optimize-minimize && cp playground/index.prod.html build/index.html",
-    "cs-check": "prettier-check --jsx-bracket-same-line '{playground,src,test}/**/*.js'",
-    "cs-format": "prettier --jsx-bracket-same-line '{playground,src,test}/**/*.js' --write",
+    "cs-check": "prettier-check $npm_package_prettierOptions '{playground,src,test}/**/*.js'",
+    "cs-format": "prettier $npm_package_prettierOptions '{playground,src,test}/**/*.js' --write",
     "dist": "npm run build:lib && npm run build:dist",
     "lint": "eslint src test playground",
+    "precommit": "lint-staged",
     "publish-to-gh-pages": "npm run build:playground && gh-pages --dist build/",
     "publish-to-npm": "npm run build:readme && npm run dist && npm publish",
     "start": "node devServer.js",
     "tdd": "cross-env NODE_ENV=test  mocha --compilers js:babel-register --watch --require ./test/setup-jsdom.js test/**/*_test.js",
     "test": " cross-env NODE_ENV=test   mocha --compilers js:babel-register --require ./test/setup-jsdom.js test/**/*_test.js"
+  },
+  "prettierOptions": "--jsx-bracket-same-line --trailing-comma es5",
+  "lint-staged": {
+    "{playground,src,test}/**/*.js": [
+      "npm run lint",
+      "npm run cs-format",
+      "git add"
+    ]
   },
   "main": "lib/index.js",
   "files": [
@@ -59,7 +68,9 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "gh-pages": "^0.11.0",
     "html": "0.0.10",
+    "husky": "^0.13.2",
     "jsdom": "^8.3.0",
+    "lint-staged": "^3.3.1",
     "mocha": "^2.5.3",
     "prettier": "^0.22.0",
     "prettier-check": "^1.0.0",

--- a/playground/app.js
+++ b/playground/app.js
@@ -48,81 +48,81 @@ const cmOptions = {
   mode: {
     name: "javascript",
     json: true,
-    statementIndent: 2
+    statementIndent: 2,
   },
   lineNumbers: true,
   lineWrapping: true,
   indentWithTabs: false,
-  tabSize: 2
+  tabSize: 2,
 };
 const themes = {
   default: {
-    stylesheet: "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
+    stylesheet: "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css",
   },
   cerulean: {
-    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/cerulean/bootstrap.min.css"
+    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/cerulean/bootstrap.min.css",
   },
   cosmo: {
-    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/cosmo/bootstrap.min.css"
+    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/cosmo/bootstrap.min.css",
   },
   cyborg: {
     stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/cyborg/bootstrap.min.css",
-    editor: "blackboard"
+    editor: "blackboard",
   },
   darkly: {
     stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/darkly/bootstrap.min.css",
-    editor: "mbo"
+    editor: "mbo",
   },
   flatly: {
     stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/flatly/bootstrap.min.css",
-    editor: "ttcn"
+    editor: "ttcn",
   },
   journal: {
-    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/journal/bootstrap.min.css"
+    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/journal/bootstrap.min.css",
   },
   lumen: {
-    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/lumen/bootstrap.min.css"
+    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/lumen/bootstrap.min.css",
   },
   paper: {
-    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/paper/bootstrap.min.css"
+    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/paper/bootstrap.min.css",
   },
   readable: {
-    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/readable/bootstrap.min.css"
+    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/readable/bootstrap.min.css",
   },
   sandstone: {
     stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/sandstone/bootstrap.min.css",
-    editor: "solarized"
+    editor: "solarized",
   },
   simplex: {
     stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/simplex/bootstrap.min.css",
-    editor: "ttcn"
+    editor: "ttcn",
   },
   slate: {
     stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/slate/bootstrap.min.css",
-    editor: "monokai"
+    editor: "monokai",
   },
   spacelab: {
-    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/spacelab/bootstrap.min.css"
+    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/spacelab/bootstrap.min.css",
   },
   "solarized-dark": {
     stylesheet: "//cdn.rawgit.com/aalpern/bootstrap-solarized/master/bootstrap-solarized-dark.css",
-    editor: "dracula"
+    editor: "dracula",
   },
   "solarized-light": {
     stylesheet: "//cdn.rawgit.com/aalpern/bootstrap-solarized/master/bootstrap-solarized-light.css",
-    editor: "solarized"
+    editor: "solarized",
   },
   superhero: {
     stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/superhero/bootstrap.min.css",
-    editor: "dracula"
+    editor: "dracula",
   },
   united: {
-    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/united/bootstrap.min.css"
+    stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/united/bootstrap.min.css",
   },
   yeti: {
     stylesheet: "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/yeti/bootstrap.min.css",
-    editor: "eclipse"
-  }
+    editor: "eclipse",
+  },
 };
 
 class GeoPosition extends Component {
@@ -262,7 +262,7 @@ class Selector extends Component {
 function ThemeSelector({ theme, select }) {
   const themeSchema = {
     type: "string",
-    enum: Object.keys(themes)
+    enum: Object.keys(themes),
   };
   return (
     <Form
@@ -287,7 +287,7 @@ class App extends Component {
       validate,
       editor: "default",
       theme: "default",
-      liveValidate: true
+      liveValidate: true,
     };
   }
 
@@ -335,7 +335,7 @@ class App extends Component {
       theme,
       editor,
       ArrayFieldTemplate,
-      transformErrors
+      transformErrors,
     } = this.state;
 
     return (

--- a/playground/samples/arrays.js
+++ b/playground/samples/arrays.js
@@ -6,10 +6,10 @@ module.exports = {
         properties: {
           name: {
             type: "string",
-            default: "Default name"
-          }
-        }
-      }
+            default: "Default name",
+          },
+        },
+      },
     },
     type: "object",
     properties: {
@@ -18,17 +18,17 @@ module.exports = {
         title: "A list of strings",
         items: {
           type: "string",
-          default: "bazinga"
-        }
+          default: "bazinga",
+        },
       },
       multipleChoicesList: {
         type: "array",
         title: "A multiple choices list",
         items: {
           type: "string",
-          enum: ["foo", "bar", "fuzz", "qux"]
+          enum: ["foo", "bar", "fuzz", "qux"],
         },
-        uniqueItems: true
+        uniqueItems: true,
       },
       fixedItemsList: {
         type: "array",
@@ -37,25 +37,25 @@ module.exports = {
           {
             title: "A string value",
             type: "string",
-            default: "lorem ipsum"
+            default: "lorem ipsum",
           },
           {
             title: "a boolean value",
-            type: "boolean"
-          }
+            type: "boolean",
+          },
         ],
         additionalItems: {
           title: "Additional item",
-          type: "number"
-        }
+          type: "number",
+        },
       },
       minItemsList: {
         type: "array",
         title: "A list with a minimal number of items",
         minItems: 3,
         items: {
-          $ref: "#/definitions/Thing"
-        }
+          $ref: "#/definitions/Thing",
+        },
       },
       nestedList: {
         type: "array",
@@ -65,33 +65,33 @@ module.exports = {
           title: "Inner list",
           items: {
             type: "string",
-            default: "lorem ipsum"
-          }
-        }
+            default: "lorem ipsum",
+          },
+        },
       },
       unorderable: {
         title: "Unorderable items",
         type: "array",
         items: {
           type: "string",
-          default: "lorem ipsum"
-        }
+          default: "lorem ipsum",
+        },
       },
       unremovable: {
         title: "Unremovable items",
         type: "array",
         items: {
           type: "string",
-          default: "lorem ipsum"
-        }
+          default: "lorem ipsum",
+        },
       },
       noToolbar: {
         title: "No add, remove and order buttons",
         type: "array",
         items: {
           type: "string",
-          default: "lorem ipsum"
-        }
+          default: "lorem ipsum",
+        },
       },
       fixedNoToolbar: {
         title: "Fixed array without buttons",
@@ -100,56 +100,56 @@ module.exports = {
           {
             title: "A number",
             type: "number",
-            default: 42
+            default: 42,
           },
           {
             title: "A boolean",
             type: "boolean",
-            default: false
-          }
+            default: false,
+          },
         ],
         additionalItems: {
           title: "A string",
           type: "string",
-          default: "lorem ipsum"
-        }
-      }
-    }
+          default: "lorem ipsum",
+        },
+      },
+    },
   },
   uiSchema: {
     multipleChoicesList: {
-      "ui:widget": "checkboxes"
+      "ui:widget": "checkboxes",
     },
     fixedItemsList: {
       items: [{ "ui:widget": "textarea" }, { "ui:widget": "select" }],
       additionalItems: {
-        "ui:widget": "updown"
-      }
+        "ui:widget": "updown",
+      },
     },
     unorderable: {
       "ui:options": {
-        orderable: false
-      }
+        orderable: false,
+      },
     },
     unremovable: {
       "ui:options": {
-        removable: false
-      }
+        removable: false,
+      },
     },
     noToolbar: {
       "ui:options": {
         addable: false,
         orderable: false,
-        removable: false
-      }
+        removable: false,
+      },
     },
     fixedNoToolbar: {
       "ui:options": {
         addable: false,
         orderable: false,
-        removable: false
-      }
-    }
+        removable: false,
+      },
+    },
   },
   formData: {
     listOfStrings: ["foo", "bar"],
@@ -159,6 +159,6 @@ module.exports = {
     unorderable: ["one", "two"],
     unremovable: ["one", "two"],
     noToolbar: ["one", "two"],
-    fixedNoToolbar: [42, true, "additional item one", "additional item two"]
-  }
+    fixedNoToolbar: [42, true, "additional item one", "additional item two"],
+  },
 };

--- a/playground/samples/custom.js
+++ b/playground/samples/custom.js
@@ -5,18 +5,18 @@ module.exports = {
     required: ["lat", "lon"],
     properties: {
       lat: {
-        type: "number"
+        type: "number",
       },
       lon: {
-        type: "number"
-      }
-    }
+        type: "number",
+      },
+    },
   },
   uiSchema: {
-    "ui:field": "geo"
+    "ui:field": "geo",
   },
   formData: {
     lat: 0,
-    lon: 0
-  }
+    lon: 0,
+  },
 };

--- a/playground/samples/customArray.js
+++ b/playground/samples/customArray.js
@@ -47,9 +47,9 @@ module.exports = {
     title: "Custom array of strings",
     type: "array",
     items: {
-      type: "string"
-    }
+      type: "string",
+    },
   },
   formData: ["react", "jsonschema", "form"],
-  ArrayFieldTemplate
+  ArrayFieldTemplate,
 };

--- a/playground/samples/date.js
+++ b/playground/samples/date.js
@@ -10,13 +10,13 @@ module.exports = {
         properties: {
           datetime: {
             type: "string",
-            format: "date-time"
+            format: "date-time",
           },
           date: {
             type: "string",
-            format: "date"
-          }
-        }
+            format: "date",
+          },
+        },
       },
       alternative: {
         title: "Alternative",
@@ -25,25 +25,25 @@ module.exports = {
         properties: {
           "alt-datetime": {
             type: "string",
-            format: "date-time"
+            format: "date-time",
           },
           "alt-date": {
             type: "string",
-            format: "date"
-          }
-        }
-      }
-    }
+            format: "date",
+          },
+        },
+      },
+    },
   },
   uiSchema: {
     alternative: {
       "alt-datetime": {
-        "ui:widget": "alt-datetime"
+        "ui:widget": "alt-datetime",
       },
       "alt-date": {
-        "ui:widget": "alt-date"
-      }
-    }
+        "ui:widget": "alt-date",
+      },
+    },
   },
-  formData: {}
+  formData: {},
 };

--- a/playground/samples/errors.js
+++ b/playground/samples/errors.js
@@ -7,18 +7,18 @@ module.exports = {
         type: "string",
         title: "First name",
         minLength: 8,
-        pattern: "\\d+"
+        pattern: "\\d+",
       },
       active: {
         type: "boolean",
-        title: "Active"
+        title: "Active",
       },
       skills: {
         type: "array",
         items: {
           type: "string",
-          minLength: 5
-        }
+          minLength: 5,
+        },
       },
       multipleChoicesList: {
         type: "array",
@@ -27,16 +27,16 @@ module.exports = {
         maxItems: 2,
         items: {
           type: "string",
-          enum: ["foo", "bar", "fuzz"]
-        }
-      }
-    }
+          enum: ["foo", "bar", "fuzz"],
+        },
+      },
+    },
   },
   uiSchema: {},
   formData: {
     firstName: "Chuck",
     active: "wrong",
     skills: ["karate", "budo", "aikido"],
-    multipleChoicesList: ["foo", "bar", "fuzz"]
-  }
+    multipleChoicesList: ["foo", "bar", "fuzz"],
+  },
 };

--- a/playground/samples/files.js
+++ b/playground/samples/files.js
@@ -6,18 +6,18 @@ module.exports = {
       file: {
         type: "string",
         format: "data-url",
-        title: "Single file"
+        title: "Single file",
       },
       files: {
         type: "array",
         title: "Multiple files",
         items: {
           type: "string",
-          format: "data-url"
-        }
-      }
-    }
+          format: "data-url",
+        },
+      },
+    },
   },
   uiSchema: {},
-  formData: {}
+  formData: {},
 };

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -29,5 +29,5 @@ export const samples = {
   Validation: validation,
   Files: files,
   Single: single,
-  "Custom Array": customArray
+  "Custom Array": customArray,
 };

--- a/playground/samples/large.js
+++ b/playground/samples/large.js
@@ -9,14 +9,14 @@ function largeEnum(n) {
 module.exports = {
   schema: {
     definitions: {
-      largeEnum: { type: "string", enum: largeEnum(100) }
+      largeEnum: { type: "string", enum: largeEnum(100) },
     },
     title: "A rather large form",
     type: "object",
     properties: {
       string: {
         type: "string",
-        title: "Some string"
+        title: "Some string",
       },
       choice1: { $ref: "#/definitions/largeEnum" },
       choice2: { $ref: "#/definitions/largeEnum" },
@@ -27,13 +27,13 @@ module.exports = {
       choice7: { $ref: "#/definitions/largeEnum" },
       choice8: { $ref: "#/definitions/largeEnum" },
       choice9: { $ref: "#/definitions/largeEnum" },
-      choice10: { $ref: "#/definitions/largeEnum" }
-    }
+      choice10: { $ref: "#/definitions/largeEnum" },
+    },
   },
   uiSchema: {
     choice1: {
-      "ui:placeholder": "Choose one"
-    }
+      "ui:placeholder": "Choose one",
+    },
   },
-  formData: {}
+  formData: {},
 };

--- a/playground/samples/nested.js
+++ b/playground/samples/nested.js
@@ -6,7 +6,7 @@ module.exports = {
     properties: {
       title: {
         type: "string",
-        title: "Task list title"
+        title: "Task list title",
       },
       tasks: {
         type: "array",
@@ -18,31 +18,31 @@ module.exports = {
             title: {
               type: "string",
               title: "Title",
-              description: "A sample title"
+              description: "A sample title",
             },
             details: {
               type: "string",
               title: "Task details",
-              description: "Enter the task details"
+              description: "Enter the task details",
             },
             done: {
               type: "boolean",
               title: "Done?",
-              default: false
-            }
-          }
-        }
-      }
-    }
+              default: false,
+            },
+          },
+        },
+      },
+    },
   },
   uiSchema: {
     tasks: {
       items: {
         details: {
-          "ui:widget": "textarea"
-        }
-      }
-    }
+          "ui:widget": "textarea",
+        },
+      },
+    },
   },
   formData: {
     title: "My current tasks",
@@ -50,13 +50,13 @@ module.exports = {
       {
         title: "My first task",
         details: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
-        done: true
+        done: true,
       },
       {
         title: "My second task",
         details: "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur",
-        done: false
-      }
-    ]
-  }
+        done: false,
+      },
+    ],
+  },
 };

--- a/playground/samples/numbers.js
+++ b/playground/samples/numbers.js
@@ -5,59 +5,59 @@ module.exports = {
     properties: {
       number: {
         title: "Number",
-        type: "number"
+        type: "number",
       },
       integer: {
         title: "Integer",
-        type: "integer"
+        type: "integer",
       },
       numberEnum: {
         type: "number",
         title: "Number enum",
-        enum: [1, 2, 3]
+        enum: [1, 2, 3],
       },
       numberEnumRadio: {
         type: "number",
         title: "Number enum",
-        enum: [1, 2, 3]
+        enum: [1, 2, 3],
       },
       integerRange: {
         title: "Integer range",
         type: "integer",
         minimum: 42,
-        maximum: 100
+        maximum: 100,
       },
       integerRangeSteps: {
         title: "Integer range (by 10)",
         type: "integer",
         minimum: 50,
         maximum: 100,
-        multipleOf: 10
-      }
-    }
+        multipleOf: 10,
+      },
+    },
   },
   uiSchema: {
     integer: {
-      "ui:widget": "updown"
+      "ui:widget": "updown",
     },
     numberEnumRadio: {
       "ui:widget": "radio",
       "ui:options": {
-        inline: true
-      }
+        inline: true,
+      },
     },
     integerRange: {
-      "ui:widget": "range"
+      "ui:widget": "range",
     },
     integerRangeSteps: {
-      "ui:widget": "range"
-    }
+      "ui:widget": "range",
+    },
   },
   formData: {
     number: 3.14,
     integer: 42,
     numberEnum: 2,
     integerRange: 42,
-    integerRangeSteps: 80
-  }
+    integerRangeSteps: 80,
+  },
 };

--- a/playground/samples/ordering.js
+++ b/playground/samples/ordering.js
@@ -6,43 +6,43 @@ module.exports = {
     properties: {
       password: {
         type: "string",
-        title: "Password"
+        title: "Password",
       },
       lastName: {
         type: "string",
-        title: "Last name"
+        title: "Last name",
       },
       bio: {
         type: "string",
-        title: "Bio"
+        title: "Bio",
       },
       firstName: {
         type: "string",
-        title: "First name"
+        title: "First name",
       },
       age: {
         type: "integer",
-        title: "Age"
-      }
-    }
+        title: "Age",
+      },
+    },
   },
   uiSchema: {
     "ui:order": ["firstName", "lastName", "*", "password"],
     age: {
-      "ui:widget": "updown"
+      "ui:widget": "updown",
     },
     bio: {
-      "ui:widget": "textarea"
+      "ui:widget": "textarea",
     },
     password: {
-      "ui:widget": "password"
-    }
+      "ui:widget": "password",
+    },
   },
   formData: {
     firstName: "Chuck",
     lastName: "Norris",
     age: 75,
     bio: "Roundhouse kicking asses since 1940",
-    password: "noneed"
-  }
+    password: "noneed",
+  },
 };

--- a/playground/samples/references.js
+++ b/playground/samples/references.js
@@ -6,9 +6,9 @@ module.exports = {
         properties: {
           street_address: { type: "string" },
           city: { type: "string" },
-          state: { type: "string" }
+          state: { type: "string" },
         },
-        required: ["street_address", "city", "state"]
+        required: ["street_address", "city", "state"],
       },
       node: {
         type: "object",
@@ -17,45 +17,45 @@ module.exports = {
           children: {
             type: "array",
             items: {
-              $ref: "#/definitions/node"
-            }
-          }
-        }
-      }
+              $ref: "#/definitions/node",
+            },
+          },
+        },
+      },
     },
     type: "object",
     properties: {
       billing_address: {
         title: "Billing address",
-        $ref: "#/definitions/address"
+        $ref: "#/definitions/address",
       },
       shipping_address: {
         title: "Shipping address",
-        $ref: "#/definitions/address"
+        $ref: "#/definitions/address",
       },
       tree: {
         title: "Recursive references",
-        $ref: "#/definitions/node"
-      }
-    }
+        $ref: "#/definitions/node",
+      },
+    },
   },
   uiSchema: {
-    "ui:order": ["shipping_address", "billing_address", "tree"]
+    "ui:order": ["shipping_address", "billing_address", "tree"],
   },
   formData: {
     billing_address: {
       street_address: "21, Jump Street",
       city: "Babel",
-      state: "Neverland"
+      state: "Neverland",
     },
     shipping_address: {
       street_address: "221B, Baker Street",
       city: "London",
-      state: "N/A"
+      state: "N/A",
     },
     tree: {
       name: "root",
-      children: [{ name: "leaf" }]
-    }
-  }
+      children: [{ name: "leaf" }],
+    },
+  },
 };

--- a/playground/samples/simple.js
+++ b/playground/samples/simple.js
@@ -7,50 +7,50 @@ module.exports = {
     properties: {
       firstName: {
         type: "string",
-        title: "First name"
+        title: "First name",
       },
       lastName: {
         type: "string",
-        title: "Last name"
+        title: "Last name",
       },
       age: {
         type: "integer",
-        title: "Age"
+        title: "Age",
       },
       bio: {
         type: "string",
-        title: "Bio"
+        title: "Bio",
       },
       password: {
         type: "string",
         title: "Password",
-        minLength: 3
-      }
-    }
+        minLength: 3,
+      },
+    },
   },
   uiSchema: {
     firstName: {
-      "ui:autofocus": true
+      "ui:autofocus": true,
     },
     age: {
-      "ui:widget": "updown"
+      "ui:widget": "updown",
     },
     bio: {
-      "ui:widget": "textarea"
+      "ui:widget": "textarea",
     },
     password: {
       "ui:widget": "password",
-      "ui:help": "Hint: Make it strong!"
+      "ui:help": "Hint: Make it strong!",
     },
     date: {
-      "ui:widget": "alt-datetime"
-    }
+      "ui:widget": "alt-datetime",
+    },
   },
   formData: {
     firstName: "Chuck",
     lastName: "Norris",
     age: 75,
     bio: "Roundhouse kicking asses since 1940",
-    password: "noneed"
-  }
+    password: "noneed",
+  },
 };

--- a/playground/samples/single.js
+++ b/playground/samples/single.js
@@ -1,8 +1,8 @@
 module.exports = {
   schema: {
     title: "A single-field form",
-    type: "string"
+    type: "string",
   },
   formData: "initial value",
-  uiSchema: {}
+  uiSchema: {},
 };

--- a/playground/samples/validation.js
+++ b/playground/samples/validation.js
@@ -9,7 +9,7 @@ function transformErrors(errors) {
   return errors.map(error => {
     if (error.name === "minimum" && error.property === "instance.age") {
       return Object.assign({}, error, {
-        message: "You need to be 18 because of some legal thing"
+        message: "You need to be 18 because of some legal thing",
       });
     }
     return error;
@@ -25,25 +25,25 @@ module.exports = {
       pass1: {
         title: "Password",
         type: "string",
-        minLength: 3
+        minLength: 3,
       },
       pass2: {
         title: "Repeat password",
         type: "string",
-        minLength: 3
+        minLength: 3,
       },
       age: {
         title: "Age",
         type: "number",
-        minimum: 18
-      }
-    }
+        minimum: 18,
+      },
+    },
   },
   uiSchema: {
     pass1: { "ui:widget": "password" },
-    pass2: { "ui:widget": "password" }
+    pass2: { "ui:widget": "password" },
   },
   formData: {},
   validate,
-  transformErrors
+  transformErrors,
 };

--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -11,13 +11,13 @@ module.exports = {
         properties: {
           email: {
             type: "string",
-            format: "email"
+            format: "email",
           },
           uri: {
             type: "string",
-            format: "uri"
-          }
-        }
+            format: "uri",
+          },
+        },
       },
       boolean: {
         type: "object",
@@ -26,19 +26,19 @@ module.exports = {
           default: {
             type: "boolean",
             title: "checkbox (default)",
-            description: "This is the checkbox-description"
+            description: "This is the checkbox-description",
           },
           radio: {
             type: "boolean",
             title: "radio buttons",
-            description: "This is the radio-description"
+            description: "This is the radio-description",
           },
           select: {
             type: "boolean",
             title: "select box",
-            description: "This is the select-description"
-          }
-        }
+            description: "This is the select-description",
+          },
+        },
       },
       string: {
         type: "object",
@@ -46,74 +46,74 @@ module.exports = {
         properties: {
           default: {
             type: "string",
-            title: "text input (default)"
+            title: "text input (default)",
           },
           textarea: {
             type: "string",
-            title: "textarea"
+            title: "textarea",
           },
           color: {
             type: "string",
             title: "color picker",
-            default: "#151ce6"
-          }
-        }
+            default: "#151ce6",
+          },
+        },
       },
       secret: {
         type: "string",
-        default: "I'm a hidden string."
+        default: "I'm a hidden string.",
       },
       disabled: {
         type: "string",
         title: "A disabled field",
-        default: "I am disabled."
+        default: "I am disabled.",
       },
       readonly: {
         type: "string",
         title: "A readonly field",
-        default: "I am read-only."
+        default: "I am read-only.",
       },
       widgetOptions: {
         title: "Custom widget with options",
         type: "string",
-        default: "I am yellow"
+        default: "I am yellow",
       },
       selectWidgetOptions: {
         title: "Custom select widget with options",
         type: "string",
         enum: ["foo", "bar"],
-        enumNames: ["Foo", "Bar"]
-      }
-    }
+        enumNames: ["Foo", "Bar"],
+      },
+    },
   },
   uiSchema: {
     boolean: {
       radio: {
-        "ui:widget": "radio"
+        "ui:widget": "radio",
       },
       select: {
-        "ui:widget": "select"
-      }
+        "ui:widget": "select",
+      },
     },
     string: {
       textarea: {
         "ui:widget": "textarea",
         "ui:options": {
-          rows: 5
-        }
+          rows: 5,
+        },
       },
       color: {
-        "ui:widget": "color"
-      }
+        "ui:widget": "color",
+      },
     },
     secret: {
-      "ui:widget": "hidden"
+      "ui:widget": "hidden",
     },
     disabled: {
-      "ui:disabled": true
+      "ui:disabled": true,
     },
     readonly: {
-      "ui:readonly": true
+      "ui:readonly": true,
     },
     widgetOptions: {
       "ui:widget": ({ value, onChange, options }) => {
@@ -128,8 +128,8 @@ module.exports = {
         );
       },
       "ui:options": {
-        backgroundColor: "yellow"
-      }
+        backgroundColor: "yellow",
+      },
     },
     selectWidgetOptions: {
       "ui:widget": ({ value, onChange, options }) => {
@@ -147,24 +147,24 @@ module.exports = {
         );
       },
       "ui:options": {
-        backgroundColor: "pink"
-      }
-    }
+        backgroundColor: "pink",
+      },
+    },
   },
   formData: {
     stringFormats: {
       email: "chuck@norris.net",
-      uri: "http://chucknorris.com/"
+      uri: "http://chucknorris.com/",
     },
     boolean: {
       default: true,
       radio: true,
-      select: true
+      select: true,
     },
     string: {
       default: "Hello...",
-      textarea: "... World"
+      textarea: "... World",
     },
-    secret: "I'm a hidden string."
-  }
+    secret: "I'm a hidden string.",
+  },
 };

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -6,7 +6,7 @@ import {
   shouldRender,
   toIdSchema,
   setState,
-  getDefaultRegistry
+  getDefaultRegistry,
 } from "../utils";
 import validateFormData from "../validate";
 
@@ -16,7 +16,7 @@ export default class Form extends Component {
     noValidate: false,
     liveValidate: false,
     safeRenderCompletion: false,
-    noHtml5Validate: false
+    noHtml5Validate: false,
   };
 
   constructor(props) {
@@ -41,7 +41,7 @@ export default class Form extends Component {
       ? this.validate(formData, schema)
       : {
           errors: state.errors || [],
-          errorSchema: state.errorSchema || {}
+          errorSchema: state.errorSchema || {},
         };
     const idSchema = toIdSchema(
       schema,
@@ -56,7 +56,7 @@ export default class Form extends Component {
       formData,
       edit,
       errors,
-      errorSchema
+      errorSchema,
     };
   }
 
@@ -138,7 +138,7 @@ export default class Form extends Component {
       ArrayFieldTemplate: this.props.ArrayFieldTemplate,
       FieldTemplate: this.props.FieldTemplate,
       definitions: this.props.schema.definitions || {},
-      formContext: this.props.formContext || {}
+      formContext: this.props.formContext || {},
     };
   }
 
@@ -155,7 +155,7 @@ export default class Form extends Component {
       autocomplete,
       enctype,
       acceptcharset,
-      noHtml5Validate
+      noHtml5Validate,
     } = this.props;
 
     const { schema, uiSchema, formData, errorSchema, idSchema } = this.state;
@@ -227,6 +227,6 @@ if (process.env.NODE_ENV !== "production") {
     validate: PropTypes.func,
     transformErrors: PropTypes.func,
     safeRenderCompletion: PropTypes.bool,
-    formContext: PropTypes.object
+    formContext: PropTypes.object,
   };
 }

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -11,7 +11,7 @@ import {
   optionsList,
   retrieveSchema,
   toIdSchema,
-  getDefaultRegistry
+  getDefaultRegistry,
 } from "../../utils";
 
 function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
@@ -50,7 +50,7 @@ function DefaultArrayItem(props) {
     flex: 1,
     paddingLeft: 6,
     paddingRight: 6,
-    fontWeight: "bold"
+    fontWeight: "bold",
   };
   return (
     <div key={props.index} className={props.className}>
@@ -182,7 +182,7 @@ class ArrayField extends Component {
     required: false,
     disabled: false,
     readonly: false,
-    autofocus: false
+    autofocus: false,
   };
 
   get itemTitle() {
@@ -292,7 +292,7 @@ class ArrayField extends Component {
       autofocus,
       registry,
       formContext,
-      onBlur
+      onBlur,
     } = this.props;
     const title = schema.title === undefined ? name : schema.title;
     const { ArrayFieldTemplate, definitions, fields } = registry;
@@ -316,7 +316,7 @@ class ArrayField extends Component {
           itemData: formData[index],
           itemUiSchema: uiSchema.items,
           autofocus: autofocus && index === 0,
-          onBlur
+          onBlur,
         });
       }),
       className: `field field-array field-array-of-${itemsSchema.type}`,
@@ -329,7 +329,7 @@ class ArrayField extends Component {
       schema,
       title,
       TitleField,
-      formContext
+      formContext,
     };
 
     // Check if a custom render function was passed in
@@ -346,7 +346,7 @@ class ArrayField extends Component {
       disabled,
       readonly,
       autofocus,
-      onBlur
+      onBlur,
     } = this.props;
     const items = this.props.formData;
     const { widgets, definitions, formContext } = this.props.registry;
@@ -354,7 +354,7 @@ class ArrayField extends Component {
     const enumOptions = optionsList(itemsSchema);
     const { widget = "select", ...options } = {
       ...getUiOptions(uiSchema),
-      enumOptions
+      enumOptions,
     };
     const Widget = getWidget(schema, widget, widgets);
     return (
@@ -383,7 +383,7 @@ class ArrayField extends Component {
       disabled,
       readonly,
       autofocus,
-      onBlur
+      onBlur,
     } = this.props;
     const title = schema.title || name;
     const items = this.props.formData;
@@ -420,7 +420,7 @@ class ArrayField extends Component {
       readonly,
       autofocus,
       registry,
-      onBlur
+      onBlur,
     } = this.props;
     const title = schema.title || name;
     let items = this.props.formData;
@@ -469,7 +469,7 @@ class ArrayField extends Component {
           itemIdSchema,
           itemErrorSchema,
           autofocus: autofocus && index === 0,
-          onBlur
+          onBlur,
         });
       }),
       onAddClick: this.onAddClick,
@@ -477,7 +477,7 @@ class ArrayField extends Component {
       required,
       schema,
       title,
-      TitleField
+      TitleField,
     };
 
     // Check if a custom template template was passed in
@@ -497,19 +497,19 @@ class ArrayField extends Component {
       itemIdSchema,
       itemErrorSchema,
       autofocus,
-      onBlur
+      onBlur,
     } = props;
     const { SchemaField } = this.props.registry.fields;
     const { disabled, readonly, uiSchema } = this.props;
     const { orderable, removable } = {
       orderable: true,
       removable: true,
-      ...uiSchema["ui:options"]
+      ...uiSchema["ui:options"],
     };
     const has = {
       moveUp: orderable && canMoveUp,
       moveDown: orderable && canMoveDown,
-      remove: removable && canRemove
+      remove: removable && canRemove,
     };
     has.toolbar = Object.keys(has).some(key => has[key]);
 
@@ -539,7 +539,7 @@ class ArrayField extends Component {
       index,
       onDropIndexClick: this.onDropIndexClick,
       onReorderClick: this.onReorderClick,
-      readonly
+      readonly,
     };
   }
 }
@@ -568,8 +568,8 @@ if (process.env.NODE_ENV !== "production") {
       "ui:options": PropTypes.shape({
         addable: PropTypes.bool,
         orderable: PropTypes.bool,
-        removable: PropTypes.bool
-      })
+        removable: PropTypes.bool,
+      }),
     }),
     idSchema: PropTypes.object,
     errorSchema: PropTypes.object,
@@ -586,8 +586,8 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired
-    })
+      formContext: PropTypes.object.isRequired,
+    }),
   };
 }
 

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -4,7 +4,7 @@ import {
   getWidget,
   getUiOptions,
   optionsList,
-  getDefaultRegistry
+  getDefaultRegistry,
 } from "../../utils";
 
 function BooleanField(props) {
@@ -19,7 +19,7 @@ function BooleanField(props) {
     disabled,
     readonly,
     autofocus,
-    onChange
+    onChange,
   } = props;
   const { title } = schema;
   const { widgets, formContext } = registry;
@@ -27,7 +27,7 @@ function BooleanField(props) {
   const Widget = getWidget(schema, widget, widgets);
   const enumOptions = optionsList({
     enum: [true, false],
-    enumNames: schema.enumNames || ["yes", "no"]
+    enumNames: schema.enumNames || ["yes", "no"],
   });
   return (
     <Widget
@@ -64,8 +64,8 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired
-    })
+      formContext: PropTypes.object.isRequired,
+    }),
   };
 }
 
@@ -74,7 +74,7 @@ BooleanField.defaultProps = {
   registry: getDefaultRegistry(),
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 export default BooleanField;

--- a/src/components/fields/DescriptionField.js
+++ b/src/components/fields/DescriptionField.js
@@ -16,7 +16,7 @@ function DescriptionField(props) {
 if (process.env.NODE_ENV !== "production") {
   DescriptionField.propTypes = {
     id: PropTypes.string,
-    description: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+    description: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   };
 }
 

--- a/src/components/fields/NumberField.js
+++ b/src/components/fields/NumberField.js
@@ -20,12 +20,12 @@ if (process.env.NODE_ENV !== "production") {
     onChange: PropTypes.func.isRequired,
     formData: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     required: PropTypes.bool,
-    formContext: PropTypes.object.isRequired
+    formContext: PropTypes.object.isRequired,
   };
 }
 
 NumberField.defaultProps = {
-  uiSchema: {}
+  uiSchema: {},
 };
 
 export default NumberField;

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -3,7 +3,7 @@ import React, { Component, PropTypes } from "react";
 import {
   orderProperties,
   retrieveSchema,
-  getDefaultRegistry
+  getDefaultRegistry,
 } from "../../utils";
 
 class ObjectField extends Component {
@@ -15,7 +15,7 @@ class ObjectField extends Component {
     registry: getDefaultRegistry(),
     required: false,
     disabled: false,
-    readonly: false
+    readonly: false,
   };
 
   isRequired(name) {
@@ -41,7 +41,7 @@ class ObjectField extends Component {
       required,
       disabled,
       readonly,
-      onBlur
+      onBlur,
     } = this.props;
     const { definitions, fields, formContext } = this.props.registry;
     const { SchemaField, TitleField, DescriptionField } = fields;
@@ -118,8 +118,8 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired
-    })
+      formContext: PropTypes.object.isRequired,
+    }),
   };
 }
 

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -5,7 +5,7 @@ import {
   retrieveSchema,
   getDefaultRegistry,
   isFilesArray,
-  deepEquals
+  deepEquals,
 } from "../../utils";
 import UnsupportedField from "./UnsupportedField";
 
@@ -16,7 +16,7 @@ const COMPONENT_TYPES = {
   integer: "NumberField",
   number: "NumberField",
   object: "ObjectField",
-  string: "StringField"
+  string: "StringField",
 };
 
 function getFieldComponent(schema, uiSchema, fields) {
@@ -84,7 +84,7 @@ function DefaultTemplate(props) {
     description,
     hidden,
     required,
-    displayLabel
+    displayLabel,
   } = props;
   if (hidden) {
     return children;
@@ -118,7 +118,7 @@ if (process.env.NODE_ENV !== "production") {
     readonly: PropTypes.bool,
     displayLabel: PropTypes.bool,
     fields: PropTypes.object,
-    formContext: PropTypes.object
+    formContext: PropTypes.object,
   };
 }
 
@@ -126,7 +126,7 @@ DefaultTemplate.defaultProps = {
   hidden: false,
   readonly: false,
   required: false,
-  displayLabel: true
+  displayLabel: true,
 };
 
 function SchemaFieldRender(props) {
@@ -135,7 +135,7 @@ function SchemaFieldRender(props) {
     definitions,
     fields,
     formContext,
-    FieldTemplate = DefaultTemplate
+    FieldTemplate = DefaultTemplate,
   } = registry;
   const schema = retrieveSchema(props.schema, definitions);
   const FieldComponent = getFieldComponent(schema, uiSchema, fields);
@@ -191,7 +191,7 @@ function SchemaFieldRender(props) {
     "field",
     `field-${type}`,
     errors && errors.length > 0 ? "field-error has-error has-danger" : "",
-    uiSchema.classNames
+    uiSchema.classNames,
   ]
     .join(" ")
     .trim();
@@ -219,7 +219,7 @@ function SchemaFieldRender(props) {
     formContext,
     fields,
     schema,
-    uiSchema
+    uiSchema,
   };
 
   return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
@@ -247,7 +247,7 @@ SchemaField.defaultProps = {
   registry: getDefaultRegistry(),
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -265,8 +265,8 @@ if (process.env.NODE_ENV !== "production") {
       definitions: PropTypes.object.isRequired,
       ArrayFieldTemplate: PropTypes.func,
       FieldTemplate: PropTypes.func,
-      formContext: PropTypes.object.isRequired
-    })
+      formContext: PropTypes.object.isRequired,
+    }),
   };
 }
 

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -4,7 +4,7 @@ import {
   getWidget,
   getUiOptions,
   optionsList,
-  getDefaultRegistry
+  getDefaultRegistry,
 } from "../../utils";
 
 function StringField(props) {
@@ -20,7 +20,7 @@ function StringField(props) {
     autofocus,
     registry,
     onChange,
-    onBlur
+    onBlur,
   } = props;
   const { title, format } = schema;
   const { widgets, formContext } = registry;
@@ -60,7 +60,7 @@ if (process.env.NODE_ENV !== "production") {
     onBlur: PropTypes.func.isRequired,
     formData: PropTypes.oneOfType([
       React.PropTypes.string,
-      React.PropTypes.number
+      React.PropTypes.number,
     ]),
     registry: PropTypes.shape({
       widgets: PropTypes.objectOf(
@@ -68,13 +68,13 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired
+      formContext: PropTypes.object.isRequired,
     }),
     formContext: PropTypes.object.isRequired,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
     readonly: PropTypes.bool,
-    autofocus: PropTypes.bool
+    autofocus: PropTypes.bool,
   };
 }
 
@@ -83,7 +83,7 @@ StringField.defaultProps = {
   registry: getDefaultRegistry(),
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 export default StringField;

--- a/src/components/fields/TitleField.js
+++ b/src/components/fields/TitleField.js
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV !== "production") {
   TitleField.propTypes = {
     id: PropTypes.string,
     title: PropTypes.string,
-    required: PropTypes.bool
+    required: PropTypes.bool,
   };
 }
 

--- a/src/components/fields/index.js
+++ b/src/components/fields/index.js
@@ -17,5 +17,5 @@ export default {
   SchemaField,
   StringField,
   TitleField,
-  UnsupportedField
+  UnsupportedField,
 };

--- a/src/components/widgets/AltDateTimeWidget.js
+++ b/src/components/widgets/AltDateTimeWidget.js
@@ -11,7 +11,7 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     value: React.PropTypes.string,
     required: PropTypes.bool,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
   };
 }
 

--- a/src/components/widgets/AltDateWidget.js
+++ b/src/components/widgets/AltDateWidget.js
@@ -25,7 +25,7 @@ function DateElement(props) {
     readonly,
     autofocus,
     registry,
-    onBlur
+    onBlur,
   } = props;
   const id = rootId + "_" + type;
   const { SelectWidget } = registry.widgets;
@@ -51,7 +51,7 @@ class AltDateWidget extends Component {
     time: false,
     disabled: false,
     readonly: false,
-    autofocus: false
+    autofocus: false,
   };
 
   constructor(props) {
@@ -104,7 +104,7 @@ class AltDateWidget extends Component {
     const data = [
       { type: "year", range: [1900, 2020], value: year },
       { type: "month", range: [1, 12], value: month },
-      { type: "day", range: [1, 31], value: day }
+      { type: "day", range: [1, 31], value: day },
     ];
     if (time) {
       data.push(
@@ -163,7 +163,7 @@ if (process.env.NODE_ENV !== "production") {
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
-    time: PropTypes.bool
+    time: PropTypes.bool,
   };
 }
 

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -35,7 +35,7 @@ BaseInput.defaultProps = {
   required: false,
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -48,7 +48,7 @@ if (process.env.NODE_ENV !== "production") {
     readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
-    onBlur: PropTypes.func
+    onBlur: PropTypes.func,
   };
 }
 

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -10,7 +10,7 @@ function CheckboxWidget(props) {
     disabled,
     label,
     autofocus,
-    onChange
+    onChange,
   } = props;
   return (
     <div className={`checkbox ${disabled ? "disabled" : ""}`}>
@@ -33,7 +33,7 @@ function CheckboxWidget(props) {
 }
 
 CheckboxWidget.defaultProps = {
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -43,7 +43,7 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.bool,
     required: PropTypes.bool,
     autofocus: PropTypes.bool,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
   };
 }
 

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -57,8 +57,8 @@ function CheckboxesWidget(props) {
 CheckboxesWidget.defaultProps = {
   autofocus: false,
   options: {
-    inline: false
-  }
+    inline: false,
+  },
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -67,14 +67,14 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     options: PropTypes.shape({
       enumOptions: PropTypes.array,
-      inline: PropTypes.bool
+      inline: PropTypes.bool,
     }).isRequired,
     value: PropTypes.any,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
     multiple: PropTypes.bool,
     autofocus: PropTypes.bool,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
   };
 }
 

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -8,7 +8,7 @@ function ColorWidget(props) {
 
 if (process.env.NODE_ENV !== "production") {
   ColorWidget.propTypes = {
-    value: PropTypes.string
+    value: PropTypes.string,
   };
 }
 

--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -26,7 +26,7 @@ function DateTimeWidget(props) {
 
 if (process.env.NODE_ENV !== "production") {
   DateTimeWidget.propTypes = {
-    value: PropTypes.string
+    value: PropTypes.string,
   };
 }
 

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -15,7 +15,7 @@ function DateWidget(props) {
 
 if (process.env.NODE_ENV !== "production") {
   DateWidget.propTypes = {
-    value: PropTypes.string
+    value: PropTypes.string,
   };
 }
 

--- a/src/components/widgets/EmailWidget.js
+++ b/src/components/widgets/EmailWidget.js
@@ -8,7 +8,7 @@ function EmailWidget(props) {
 
 if (process.env.NODE_ENV !== "production") {
   EmailWidget.propTypes = {
-    value: PropTypes.string
+    value: PropTypes.string,
   };
 }
 

--- a/src/components/widgets/FileWidget.js
+++ b/src/components/widgets/FileWidget.js
@@ -15,7 +15,7 @@ function processFile(file) {
         dataURL: addNameToDataURL(event.target.result, name),
         name,
         size,
-        type
+        type,
       });
     };
     reader.readAsDataURL(file);
@@ -53,14 +53,14 @@ function extractFileInfo(dataURLs) {
       return {
         name: name,
         size: blob.size,
-        type: blob.type
+        type: blob.type,
       };
     });
 }
 
 class FileWidget extends Component {
   defaultProps = {
-    multiple: false
+    multiple: false,
   };
 
   constructor(props) {
@@ -79,7 +79,7 @@ class FileWidget extends Component {
     processFiles(event.target.files).then(filesInfo => {
       const state = {
         values: filesInfo.map(fileInfo => fileInfo.dataURL),
-        filesInfo
+        filesInfo,
       };
       setState(this, state, () => {
         if (multiple) {
@@ -115,7 +115,7 @@ class FileWidget extends Component {
 }
 
 FileWidget.defaultProps = {
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -123,9 +123,9 @@ if (process.env.NODE_ENV !== "production") {
     multiple: PropTypes.bool,
     value: PropTypes.oneOfType([
       PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string)
+      PropTypes.arrayOf(PropTypes.string),
     ]),
-    autofocus: PropTypes.bool
+    autofocus: PropTypes.bool,
   };
 }
 

--- a/src/components/widgets/HiddenWidget.js
+++ b/src/components/widgets/HiddenWidget.js
@@ -16,8 +16,8 @@ if (process.env.NODE_ENV !== "production") {
     value: PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number,
-      React.PropTypes.bool
-    ])
+      React.PropTypes.bool,
+    ]),
   };
 }
 

--- a/src/components/widgets/PasswordWidget.js
+++ b/src/components/widgets/PasswordWidget.js
@@ -8,7 +8,7 @@ function PasswordWidget(props) {
 
 if (process.env.NODE_ENV !== "production") {
   PasswordWidget.propTypes = {
-    value: PropTypes.string
+    value: PropTypes.string,
   };
 }
 

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -43,7 +43,7 @@ function RadioWidget(props) {
 }
 
 RadioWidget.defaultProps = {
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -52,12 +52,12 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     options: PropTypes.shape({
       enumOptions: PropTypes.array,
-      inline: PropTypes.bool
+      inline: PropTypes.bool,
     }).isRequired,
     value: PropTypes.any,
     required: PropTypes.bool,
     autofocus: PropTypes.bool,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
   };
 }
 export default RadioWidget;

--- a/src/components/widgets/RangeWidget.js
+++ b/src/components/widgets/RangeWidget.js
@@ -15,7 +15,7 @@ function RangeWidget(props) {
 
 if (process.env.NODE_ENV !== "production") {
   RangeWidget.propTypes = {
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   };
 }
 

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -45,7 +45,7 @@ function SelectWidget(props) {
     autofocus,
     onChange,
     onBlur,
-    placeholder
+    placeholder,
   } = props;
   const { enumOptions } = options;
   const emptyValue = multiple ? [] : "";
@@ -79,7 +79,7 @@ function SelectWidget(props) {
 }
 
 SelectWidget.defaultProps = {
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -87,14 +87,14 @@ if (process.env.NODE_ENV !== "production") {
     schema: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
     options: PropTypes.shape({
-      enumOptions: PropTypes.array
+      enumOptions: PropTypes.array,
     }).isRequired,
     value: PropTypes.any,
     required: PropTypes.bool,
     multiple: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
-    onBlur: PropTypes.func
+    onBlur: PropTypes.func,
   };
 }
 

--- a/src/components/widgets/TextWidget.js
+++ b/src/components/widgets/TextWidget.js
@@ -8,7 +8,10 @@ function TextWidget(props) {
 
 if (process.env.NODE_ENV !== "production") {
   TextWidget.propTypes = {
-    value: PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number])
+    value: PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.number,
+    ]),
   };
 }
 

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -11,7 +11,7 @@ function TextareaWidget(props) {
     readonly,
     autofocus,
     onChange,
-    onBlur
+    onBlur,
   } = props;
   const _onChange = ({ target: { value } }) => {
     return onChange(value === "" ? undefined : value);
@@ -35,7 +35,7 @@ function TextareaWidget(props) {
 
 TextareaWidget.defaultProps = {
   autofocus: false,
-  options: {}
+  options: {},
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -44,13 +44,13 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     options: PropTypes.shape({
-      rows: PropTypes.number
+      rows: PropTypes.number,
     }),
     value: PropTypes.string,
     required: PropTypes.bool,
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
-    onBlur: PropTypes.func
+    onBlur: PropTypes.func,
   };
 }
 

--- a/src/components/widgets/URLWidget.js
+++ b/src/components/widgets/URLWidget.js
@@ -8,7 +8,7 @@ function URLWidget(props) {
 
 if (process.env.NODE_ENV !== "production") {
   URLWidget.propTypes = {
-    value: PropTypes.string
+    value: PropTypes.string,
   };
 }
 

--- a/src/components/widgets/UpDownWidget.js
+++ b/src/components/widgets/UpDownWidget.js
@@ -9,7 +9,7 @@ function UpDownWidget(props) {
 
 if (process.env.NODE_ENV !== "production") {
   UpDownWidget.propTypes = {
-    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   };
 }
 

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -35,5 +35,5 @@ export default {
   ColorWidget,
   FileWidget,
   CheckboxWidget,
-  CheckboxesWidget
+  CheckboxesWidget,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,7 @@ const widgetMap = {
     checkbox: "CheckboxWidget",
     radio: "RadioWidget",
     select: "SelectWidget",
-    hidden: "HiddenWidget"
+    hidden: "HiddenWidget",
   },
   string: {
     text: "TextWidget",
@@ -27,7 +27,7 @@ const widgetMap = {
     "alt-date": "AltDateWidget",
     "alt-datetime": "AltDateTimeWidget",
     color: "ColorWidget",
-    file: "FileWidget"
+    file: "FileWidget",
   },
   number: {
     text: "TextWidget",
@@ -35,7 +35,7 @@ const widgetMap = {
     updown: "UpDownWidget",
     range: "RangeWidget",
     radio: "RadioWidget",
-    hidden: "HiddenWidget"
+    hidden: "HiddenWidget",
   },
   integer: {
     text: "TextWidget",
@@ -43,20 +43,20 @@ const widgetMap = {
     updown: "UpDownWidget",
     range: "RangeWidget",
     radio: "RadioWidget",
-    hidden: "HiddenWidget"
+    hidden: "HiddenWidget",
   },
   array: {
     select: "SelectWidget",
     checkboxes: "CheckboxesWidget",
-    files: "FileWidget"
-  }
+    files: "FileWidget",
+  },
 };
 
 const defaultRegistry = {
   fields: require("./components/fields").default,
   widgets: require("./components/widgets").default,
   definitions: {},
-  formContext: {}
+  formContext: {},
 };
 
 export function getDefaultRegistry() {
@@ -423,7 +423,7 @@ export function shouldRender(comp, nextProps, nextState) {
 
 export function toIdSchema(schema, id, definitions) {
   const idSchema = {
-    $id: id || "root"
+    $id: id || "root",
   };
   if ("$ref" in schema) {
     const _schema = retrieveSchema(schema, definitions);
@@ -451,7 +451,7 @@ export function parseDateString(dateString, includeTime = true) {
       day: -1,
       hour: includeTime ? -1 : 0,
       minute: includeTime ? -1 : 0,
-      second: includeTime ? -1 : 0
+      second: includeTime ? -1 : 0,
     };
   }
   const date = new Date(dateString);
@@ -464,7 +464,7 @@ export function parseDateString(dateString, includeTime = true) {
     day: date.getUTCDate(),
     hour: includeTime ? date.getUTCHours() : 0,
     minute: includeTime ? date.getUTCMinutes() : 0,
-    second: includeTime ? date.getUTCSeconds() : 0
+    second: includeTime ? date.getUTCSeconds() : 0,
   };
 }
 
@@ -475,7 +475,7 @@ export function toDateString(
     day,
     hour = 0,
     minute = 0,
-    second = 0
+    second = 0,
   },
   time = true
 ) {

--- a/src/validate.js
+++ b/src/validate.js
@@ -54,7 +54,7 @@ export function toErrorList(errorSchema, fieldName = "root") {
     errorList = errorList.concat(
       errorSchema.__errors.map(stack => {
         return {
-          stack: `${fieldName}: ${stack}`
+          stack: `${fieldName}: ${stack}`,
         };
       })
     );
@@ -78,7 +78,7 @@ function createErrorHandler(formData) {
     __errors: [],
     addError(message) {
       this.__errors.push(message);
-    }
+    },
   };
   if (isObject(formData)) {
     return Object.keys(formData).reduce(

--- a/test/ArrayFieldTemplate_test.js
+++ b/test/ArrayFieldTemplate_test.js
@@ -42,7 +42,7 @@ describe("ArrayFieldTemplate", () => {
         type: "array",
         title: "my list",
         description: "my description",
-        items: { type: "string" }
+        items: { type: "string" },
       };
 
       let node;
@@ -50,7 +50,7 @@ describe("ArrayFieldTemplate", () => {
         node = createFormComponent({
           ArrayFieldTemplate,
           formData,
-          schema
+          schema,
         }).node;
       });
 
@@ -92,7 +92,7 @@ describe("ArrayFieldTemplate", () => {
         type: "array",
         title: "my list",
         description: "my description",
-        items: [{ type: "string" }, { type: "string" }, { type: "string" }]
+        items: [{ type: "string" }, { type: "string" }, { type: "string" }],
       };
 
       let node;
@@ -100,7 +100,7 @@ describe("ArrayFieldTemplate", () => {
         node = createFormComponent({
           ArrayFieldTemplate,
           formData,
-          schema
+          schema,
         }).node;
       });
 

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -22,7 +22,7 @@ describe("ArrayField", () => {
       type: "array",
       title: "my list",
       description: "my description",
-      items: { type: "string" }
+      items: { type: "string" },
     };
 
     it("should render a fieldset", () => {
@@ -54,7 +54,7 @@ describe("ArrayField", () => {
 
       const { node } = createFormComponent({
         schema,
-        fields: { TitleField: CustomTitleField }
+        fields: { TitleField: CustomTitleField },
       });
       expect(node.querySelector("fieldset > #custom").textContent).to.eql(
         "my list"
@@ -69,8 +69,8 @@ describe("ArrayField", () => {
       const { node } = createFormComponent({
         schema,
         fields: {
-          DescriptionField: CustomDescriptionField
-        }
+          DescriptionField: CustomDescriptionField,
+        },
       });
       expect(node.querySelector("fieldset > #custom").textContent).to.eql(
         "my description"
@@ -81,9 +81,9 @@ describe("ArrayField", () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
-          "ui:widget": "files"
+          "ui:widget": "files",
         },
-        widgets: { FileWidget: CustomComponent }
+        widgets: { FileWidget: CustomComponent },
       });
       expect(node.querySelector("#custom")).to.exist;
     });
@@ -103,7 +103,7 @@ describe("ArrayField", () => {
     it("should not have an add button if addable is false", () => {
       const { node } = createFormComponent({
         schema,
-        uiSchema: { "ui:options": { addable: false } }
+        uiSchema: { "ui:options": { addable: false } },
       });
 
       expect(node.querySelector(".array-item-add button")).to.be.null;
@@ -130,7 +130,7 @@ describe("ArrayField", () => {
     it("should fill an array field with data", () => {
       const { node } = createFormComponent({
         schema,
-        formData: ["foo", "bar"]
+        formData: ["foo", "bar"],
       });
       const inputs = node.querySelectorAll(".field-string input[type=text]");
 
@@ -149,7 +149,7 @@ describe("ArrayField", () => {
     it("should have reorder buttons when list length >= 2", () => {
       const { node } = createFormComponent({
         schema,
-        formData: ["foo", "bar"]
+        formData: ["foo", "bar"],
       });
 
       expect(node.querySelector(".array-item-move-up")).not.eql(null);
@@ -159,7 +159,7 @@ describe("ArrayField", () => {
     it("should move down a field from the list", () => {
       const { node } = createFormComponent({
         schema,
-        formData: ["foo", "bar", "baz"]
+        formData: ["foo", "bar", "baz"],
       });
       const moveDownBtns = node.querySelectorAll(".array-item-move-down");
 
@@ -175,7 +175,7 @@ describe("ArrayField", () => {
     it("should move up a field from the list", () => {
       const { node } = createFormComponent({
         schema,
-        formData: ["foo", "bar", "baz"]
+        formData: ["foo", "bar", "baz"],
       });
       const moveUpBtns = node.querySelectorAll(".array-item-move-up");
 
@@ -191,7 +191,7 @@ describe("ArrayField", () => {
     it("should disable move buttons on the ends of the list", () => {
       const { node } = createFormComponent({
         schema,
-        formData: ["foo", "bar"]
+        formData: ["foo", "bar"],
       });
       const moveUpBtns = node.querySelectorAll(".array-item-move-up");
       const moveDownBtns = node.querySelectorAll(".array-item-move-down");
@@ -206,7 +206,7 @@ describe("ArrayField", () => {
       const { node } = createFormComponent({
         schema,
         formData: ["foo", "bar"],
-        uiSchema: { "ui:options": { orderable: false } }
+        uiSchema: { "ui:options": { orderable: false } },
       });
       const moveUpBtns = node.querySelector(".array-item-move-up");
       const moveDownBtns = node.querySelector(".array-item-move-down");
@@ -218,7 +218,7 @@ describe("ArrayField", () => {
     it("should remove a field from the list", () => {
       const { node } = createFormComponent({
         schema,
-        formData: ["foo", "bar"]
+        formData: ["foo", "bar"],
       });
       const dropBtns = node.querySelectorAll(".array-item-remove");
 
@@ -233,7 +233,7 @@ describe("ArrayField", () => {
       const { node } = createFormComponent({
         schema,
         formData: ["foo", "bar"],
-        uiSchema: { "ui:options": { removable: false } }
+        uiSchema: { "ui:options": { removable: false } },
       });
       const dropBtn = node.querySelector(".array-item-remove");
 
@@ -245,9 +245,9 @@ describe("ArrayField", () => {
       const { node } = createFormComponent({
         schema: {
           ...schema,
-          items: { ...schema.items, minLength: 4 }
+          items: { ...schema.items, minLength: 4 },
         },
-        formData: ["foo", "bar!"]
+        formData: ["foo", "bar!"],
       });
 
       try {
@@ -272,17 +272,17 @@ describe("ArrayField", () => {
     it("should handle cleared field values in the array", () => {
       const schema = {
         type: "array",
-        items: { type: "integer" }
+        items: { type: "integer" },
       };
       const formData = [1, 2, 3];
       const { comp, node } = createFormComponent({
         liveValidate: true,
         schema,
-        formData
+        formData,
       });
 
       Simulate.change(node.querySelector("#root_1"), {
-        target: { value: "" }
+        target: { value: "" },
       });
 
       expect(comp.state.formData).eql([1, null, 3]);
@@ -292,7 +292,7 @@ describe("ArrayField", () => {
     it("should render the input widgets with the expected ids", () => {
       const { node } = createFormComponent({
         schema,
-        formData: ["foo", "bar"]
+        formData: ["foo", "bar"],
       });
 
       const inputs = node.querySelectorAll("input[type=text]");
@@ -310,17 +310,17 @@ describe("ArrayField", () => {
               type: "object",
               properties: {
                 bar: { type: "string" },
-                baz: { type: "string" }
-              }
-            }
-          }
-        }
+                baz: { type: "string" },
+              },
+            },
+          },
+        },
       };
       const { node } = createFormComponent({
         schema: complexSchema,
         formData: {
-          foo: [{ bar: "bar1", baz: "baz1" }, { bar: "bar2", baz: "baz2" }]
-        }
+          foo: [{ bar: "bar1", baz: "baz1" }, { bar: "bar2", baz: "baz2" }],
+        },
       });
 
       const inputs = node.querySelectorAll("input[type=text]");
@@ -339,20 +339,20 @@ describe("ArrayField", () => {
             properties: {
               name: {
                 type: "string",
-                default: "Default name"
-              }
-            }
-          }
+                default: "Default name",
+              },
+            },
+          },
         },
         properties: {
           foo: {
             type: "array",
             minItems: 2,
             items: {
-              $ref: "#/definitions/Thing"
-            }
-          }
-        }
+              $ref: "#/definitions/Thing",
+            },
+          },
+        },
       };
       let form = createFormComponent({ schema: complexSchema, formData: {} });
       let inputs = form.node.querySelectorAll("input[type=text]");
@@ -369,24 +369,24 @@ describe("ArrayField", () => {
             properties: {
               name: {
                 type: "string",
-                default: "Default name"
-              }
-            }
-          }
+                default: "Default name",
+              },
+            },
+          },
         },
         properties: {
           foo: {
             type: "array",
             minItems: 2,
             items: {
-              $ref: "#/definitions/Thing"
-            }
-          }
-        }
+              $ref: "#/definitions/Thing",
+            },
+          },
+        },
       };
       const form = createFormComponent({
         schema: complexSchema,
-        formData: { foo: [] }
+        formData: { foo: [] },
       });
       const inputs = form.node.querySelectorAll("input[type=text]");
       expect(inputs.length).eql(0);
@@ -399,9 +399,9 @@ describe("ArrayField", () => {
       title: "My field",
       items: {
         enum: ["foo", "bar", "fuzz"],
-        type: "string"
+        type: "string",
       },
-      uniqueItems: true
+      uniqueItems: true,
     };
 
     describe("Select multiple widget", () => {
@@ -439,9 +439,9 @@ describe("ArrayField", () => {
             options: [
               { selected: true, value: "foo" },
               { selected: true, value: "bar" },
-              { selected: false, value: "fuzz" }
-            ]
-          }
+              { selected: false, value: "fuzz" },
+            ],
+          },
         });
 
         expect(comp.state.formData).eql(["foo", "bar"]);
@@ -457,9 +457,9 @@ describe("ArrayField", () => {
             options: [
               { selected: true, value: "foo" },
               { selected: true, value: "bar" },
-              { selected: false, value: "fuzz" }
-            ]
-          }
+              { selected: false, value: "fuzz" },
+            ],
+          },
         });
 
         expect(onBlur.calledWith(select.id, ["foo", "bar"])).to.be.true;
@@ -468,7 +468,7 @@ describe("ArrayField", () => {
       it("should fill field with data", () => {
         const { node } = createFormComponent({
           schema,
-          formData: ["foo", "bar"]
+          formData: ["foo", "bar"],
         });
 
         const options = node.querySelectorAll(".field select option");
@@ -487,7 +487,7 @@ describe("ArrayField", () => {
 
     describe("CheckboxesWidget", () => {
       const uiSchema = {
-        "ui:widget": "checkboxes"
+        "ui:widget": "checkboxes",
       };
 
       it("should render the expected number of checkboxes", () => {
@@ -510,10 +510,10 @@ describe("ArrayField", () => {
         const { comp, node } = createFormComponent({ schema, uiSchema });
 
         Simulate.change(node.querySelectorAll("[type=checkbox]")[0], {
-          target: { checked: true }
+          target: { checked: true },
         });
         Simulate.change(node.querySelectorAll("[type=checkbox]")[2], {
-          target: { checked: true }
+          target: { checked: true },
         });
 
         expect(comp.state.formData).eql(["foo", "fuzz"]);
@@ -523,7 +523,7 @@ describe("ArrayField", () => {
         const { node } = createFormComponent({
           schema,
           uiSchema,
-          formData: ["foo", "fuzz"]
+          formData: ["foo", "fuzz"],
         });
 
         const labels = [].map.call(
@@ -545,9 +545,9 @@ describe("ArrayField", () => {
           uiSchema: {
             "ui:widget": "checkboxes",
             "ui:options": {
-              inline: true
-            }
-          }
+              inline: true,
+            },
+          },
         });
 
         expect(node.querySelectorAll(".checkbox-inline")).to.have.length.of(3);
@@ -561,8 +561,8 @@ describe("ArrayField", () => {
       title: "My field",
       items: {
         type: "string",
-        format: "data-url"
-      }
+        format: "data-url",
+      },
     };
 
     it("should render an input[type=file] widget", () => {
@@ -590,7 +590,7 @@ describe("ArrayField", () => {
         set onload(fn) {
           fn({ target: { result: "data:text/plain;base64,x=" } });
         },
-        readAsDataUrl() {}
+        readAsDataUrl() {},
       });
 
       const { comp, node } = createFormComponent({ schema });
@@ -599,15 +599,15 @@ describe("ArrayField", () => {
         target: {
           files: [
             { name: "file1.txt", size: 1, type: "type" },
-            { name: "file2.txt", size: 2, type: "type" }
-          ]
-        }
+            { name: "file2.txt", size: 2, type: "type" },
+          ],
+        },
       });
 
       return new Promise(setImmediate).then(() =>
         expect(comp.state.formData).eql([
           "data:text/plain;name=file1.txt;base64,x=",
-          "data:text/plain;name=file2.txt;base64,x="
+          "data:text/plain;name=file2.txt;base64,x=",
         ]));
     });
 
@@ -616,8 +616,8 @@ describe("ArrayField", () => {
         schema,
         formData: [
           "data:text/plain;name=file1.txt;base64,dGVzdDE=",
-          "data:image/png;name=file2.png;base64,ZmFrZXBuZw=="
-        ]
+          "data:image/png;name=file2.png;base64,ZmFrZXBuZw==",
+        ],
       });
 
       const li = node.querySelectorAll(".file-info li");
@@ -642,15 +642,15 @@ describe("ArrayField", () => {
         type: "array",
         title: "A list of numbers",
         items: {
-          type: "number"
-        }
-      }
+          type: "number",
+        },
+      },
     };
 
     it("should render two lists of inputs inside of a list", () => {
       const { node } = createFormComponent({
         schema,
-        formData: [[1, 2], [3, 4]]
+        formData: [[1, 2], [3, 4]],
       });
       expect(node.querySelectorAll("fieldset fieldset")).to.have.length.of(2);
     });
@@ -672,13 +672,13 @@ describe("ArrayField", () => {
       items: [
         {
           type: "string",
-          title: "Some text"
+          title: "Some text",
         },
         {
           type: "number",
-          title: "A number"
-        }
-      ]
+          title: "A number",
+        },
+      ],
     };
 
     const schemaAdditional = {
@@ -687,17 +687,17 @@ describe("ArrayField", () => {
       items: [
         {
           type: "number",
-          title: "A number"
+          title: "A number",
         },
         {
           type: "number",
-          title: "Another number"
-        }
+          title: "Another number",
+        },
       ],
       additionalItems: {
         type: "string",
-        title: "Additional item"
-      }
+        title: "Additional item",
+      },
     };
 
     it("should render a fieldset", () => {
@@ -767,7 +767,7 @@ describe("ArrayField", () => {
     it("should generate additional fields and fill data", () => {
       const { node } = createFormComponent({
         schema: schemaAdditional,
-        formData: [1, 2, "bar"]
+        formData: [1, 2, "bar"],
       });
       const addInput = node.querySelector(
         "fieldset .field-string input[type=text]"
@@ -789,7 +789,7 @@ describe("ArrayField", () => {
     it("should not have an add button if addable is false", () => {
       const { node } = createFormComponent({
         schema,
-        uiSchema: { "ui:options": { addable: false } }
+        uiSchema: { "ui:options": { addable: false } },
       });
       expect(node.querySelector(".array-item-add button")).to.be.null;
     });
@@ -797,7 +797,7 @@ describe("ArrayField", () => {
     describe("operations for additional items", () => {
       const { comp, node } = createFormComponent({
         schema: schemaAdditional,
-        formData: [1, 2, "foo"]
+        formData: [1, 2, "foo"],
       });
 
       it("should add a field when clicking add button", () => {
@@ -841,9 +841,9 @@ describe("ArrayField", () => {
       title: "My field",
       items: {
         enum: [1, 2, 3],
-        type: "integer"
+        type: "integer",
       },
-      uniqueItems: true
+      uniqueItems: true,
     };
 
     it("should convert array of strings to numbers if type of items is 'number'", () => {
@@ -854,9 +854,9 @@ describe("ArrayField", () => {
           options: [
             { selected: true, value: "1" },
             { selected: true, value: "2" },
-            { selected: false, value: "3" }
-          ]
-        }
+            { selected: false, value: "3" },
+          ],
+        },
       });
 
       expect(comp.state.formData).eql([1, 2]);
@@ -874,9 +874,9 @@ describe("ArrayField", () => {
         properties: {
           array: {
             type: "array",
-            items: {}
-          }
-        }
+            items: {},
+          },
+        },
       };
 
       const { node } = createFormComponent({ schema, fields });
@@ -887,7 +887,7 @@ describe("ArrayField", () => {
       const schema = {
         type: "array",
         title: "test",
-        items: {}
+        items: {},
       };
 
       const { node } = createFormComponent({ schema, fields });
@@ -898,7 +898,7 @@ describe("ArrayField", () => {
       const schema = {
         type: "array",
         title: "",
-        items: {}
+        items: {},
       };
       const { node } = createFormComponent({ schema, fields });
       expect(node.querySelector("#title-")).to.be.null;

--- a/test/BooleanField_test.js
+++ b/test/BooleanField_test.js
@@ -20,8 +20,8 @@ describe("BooleanField", () => {
   it("should render a boolean field", () => {
     const { node } = createFormComponent({
       schema: {
-        type: "boolean"
-      }
+        type: "boolean",
+      },
     });
 
     expect(
@@ -33,8 +33,8 @@ describe("BooleanField", () => {
     const { node } = createFormComponent({
       schema: {
         type: "boolean",
-        title: "foo"
-      }
+        title: "foo",
+      },
     });
 
     expect(node.querySelector(".field label span").textContent).eql("foo");
@@ -44,8 +44,8 @@ describe("BooleanField", () => {
     const { node } = createFormComponent({
       schema: {
         type: "boolean",
-        title: "foo"
-      }
+        title: "foo",
+      },
     });
 
     expect(node.querySelectorAll(".field label")).to.have.length.of(1);
@@ -55,8 +55,8 @@ describe("BooleanField", () => {
     const { node } = createFormComponent({
       schema: {
         type: "boolean",
-        description: "my description"
-      }
+        description: "my description",
+      },
     });
 
     const description = node.querySelector(".field-description");
@@ -67,8 +67,8 @@ describe("BooleanField", () => {
     const { node } = createFormComponent({
       schema: {
         type: "boolean",
-        default: true
-      }
+        default: true,
+      },
     });
 
     expect(node.querySelector(".field input").checked).eql(true);
@@ -84,12 +84,12 @@ describe("BooleanField", () => {
     const { comp, node } = createFormComponent({
       schema: {
         type: "boolean",
-        default: false
-      }
+        default: false,
+      },
     });
 
     Simulate.change(node.querySelector("input"), {
-      target: { checked: true }
+      target: { checked: true },
     });
 
     expect(comp.state.formData).eql(true);
@@ -98,9 +98,9 @@ describe("BooleanField", () => {
   it("should fill field with data", () => {
     const { node } = createFormComponent({
       schema: {
-        type: "boolean"
+        type: "boolean",
       },
-      formData: true
+      formData: true,
     });
 
     expect(node.querySelector(".field input").checked).eql(true);
@@ -110,10 +110,10 @@ describe("BooleanField", () => {
     const { node } = createFormComponent({
       schema: {
         type: "boolean",
-        enumNames: ["Yes", "No"]
+        enumNames: ["Yes", "No"],
       },
       formData: true,
-      uiSchema: { "ui:widget": "radio" }
+      uiSchema: { "ui:widget": "radio" },
     });
 
     const labels = [].map.call(
@@ -130,9 +130,9 @@ describe("BooleanField", () => {
       uiSchema: {
         "ui:widget": "radio",
         "ui:options": {
-          inline: true
-        }
-      }
+          inline: true,
+        },
+      },
     });
 
     expect(node.querySelectorAll(".radio-inline")).to.have.length.of(2);
@@ -142,10 +142,10 @@ describe("BooleanField", () => {
     const { node } = createFormComponent({
       schema: {
         type: "boolean",
-        enumNames: ["Yes", "No"]
+        enumNames: ["Yes", "No"],
       },
       formData: true,
-      uiSchema: { "ui:widget": "select" }
+      uiSchema: { "ui:widget": "select" },
     });
 
     const labels = [].map.call(
@@ -158,8 +158,8 @@ describe("BooleanField", () => {
   it("should render the widget with the expected id", () => {
     const { node } = createFormComponent({
       schema: {
-        type: "boolean"
-      }
+        type: "boolean",
+      },
     });
 
     expect(node.querySelector("input[type=checkbox]").id).eql("root");
@@ -168,11 +168,11 @@ describe("BooleanField", () => {
   it("should render customized checkbox", () => {
     const { node } = createFormComponent({
       schema: {
-        type: "boolean"
+        type: "boolean",
       },
       widgets: {
-        CheckboxWidget: CustomWidget
-      }
+        CheckboxWidget: CustomWidget,
+      },
     });
 
     expect(node.querySelector("#custom")).to.exist;
@@ -188,14 +188,14 @@ describe("BooleanField", () => {
         type: "object",
         properties: {
           boolean: {
-            type: "boolean"
-          }
-        }
+            type: "boolean",
+          },
+        },
       };
       const uiSchema = {
         boolean: {
-          "ui:widget": "Widget"
-        }
+          "ui:widget": "Widget",
+        },
       };
 
       const { node } = createFormComponent({ schema, widgets, uiSchema });
@@ -205,10 +205,10 @@ describe("BooleanField", () => {
     it("should pass schema title to widget", () => {
       const schema = {
         type: "boolean",
-        title: "test"
+        title: "test",
       };
       const uiSchema = {
-        "ui:widget": "Widget"
+        "ui:widget": "Widget",
       };
 
       const { node } = createFormComponent({ schema, widgets, uiSchema });
@@ -218,10 +218,10 @@ describe("BooleanField", () => {
     it("should pass empty schema title to widget", () => {
       const schema = {
         type: "boolean",
-        title: ""
+        title: "",
       };
       const uiSchema = {
-        "ui:widget": "Widget"
+        "ui:widget": "Widget",
       };
       const { node } = createFormComponent({ schema, widgets, uiSchema });
       expect(node.querySelector("#label-")).to.not.be.null;

--- a/test/DescriptionField_test.js
+++ b/test/DescriptionField_test.js
@@ -28,7 +28,7 @@ describe("DescriptionField", () => {
 
   it("should return a div for a custom component", () => {
     const props = {
-      description: <em>description</em>
+      description: <em>description</em>,
     };
     const { node } = createComponent(DescriptionFieldWrapper, props);
 
@@ -37,7 +37,7 @@ describe("DescriptionField", () => {
 
   it("should return a p for a description text", () => {
     const props = {
-      description: "description"
+      description: "description",
     };
     const { node } = createComponent(DescriptionFieldWrapper, props);
 
@@ -47,7 +47,7 @@ describe("DescriptionField", () => {
   it("should have the expected id", () => {
     const props = {
       description: "Field description",
-      id: "sample_id"
+      id: "sample_id",
     };
     const { node } = createComponent(DescriptionFieldWrapper, props);
 

--- a/test/FormContext_test.js
+++ b/test/FormContext_test.js
@@ -25,7 +25,7 @@ describe("FormContext", () => {
   it("should be passed to Form", () => {
     const { comp } = createFormComponent({
       schema: schema,
-      formContext
+      formContext,
     });
     expect(comp.props.formContext).eq(formContext);
   });
@@ -37,7 +37,7 @@ describe("FormContext", () => {
       schema: schema,
       uiSchema: { "ui:field": "custom" },
       fields,
-      formContext
+      formContext,
     });
 
     expect(node.querySelector("#" + formContext.foo)).to.exist;
@@ -50,7 +50,7 @@ describe("FormContext", () => {
       schema: { type: "string" },
       uiSchema: { "ui:widget": "custom" },
       widgets,
-      formContext
+      formContext,
     });
 
     expect(node.querySelector("#" + formContext.foo)).to.exist;
@@ -66,12 +66,12 @@ describe("FormContext", () => {
         type: "object",
         properties: {
           prop: {
-            type: "string"
-          }
-        }
+            type: "string",
+          },
+        },
       },
       FieldTemplate: CustomTemplateField,
-      formContext
+      formContext,
     });
 
     expect(node.querySelector("#" + formContext.foo)).to.exist;
@@ -86,11 +86,11 @@ describe("FormContext", () => {
       schema: {
         type: "array",
         items: {
-          type: "string"
-        }
+          type: "string",
+        },
       },
       ArrayFieldTemplate: CustomArrayTemplateField,
-      formContext
+      formContext,
     });
 
     expect(node.querySelector("#" + formContext.foo)).to.exist;
@@ -105,12 +105,12 @@ describe("FormContext", () => {
         title: "A title",
         properties: {
           prop: {
-            type: "string"
-          }
-        }
+            type: "string",
+          },
+        },
       },
       fields,
-      formContext
+      formContext,
     });
 
     expect(node.querySelector("#" + formContext.foo)).to.exist;
@@ -122,7 +122,7 @@ describe("FormContext", () => {
     const { node } = createFormComponent({
       schema: { type: "string", description: "A description" },
       fields,
-      formContext
+      formContext,
     });
 
     expect(node.querySelector("#" + formContext.foo)).to.exist;
@@ -136,12 +136,12 @@ describe("FormContext", () => {
         items: {
           type: "string",
           enum: ["foo"],
-          enumNames: ["bar"]
+          enumNames: ["bar"],
         },
-        uniqueItems: true
+        uniqueItems: true,
       },
       widgets,
-      formContext
+      formContext,
     });
 
     expect(node.querySelector("#" + formContext.foo)).to.exist;
@@ -154,11 +154,11 @@ describe("FormContext", () => {
         type: "array",
         items: {
           type: "string",
-          format: "data-url"
-        }
+          format: "data-url",
+        },
       },
       widgets,
-      formContext
+      formContext,
     });
 
     expect(node.querySelector("#" + formContext.foo)).to.exist;

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -53,15 +53,15 @@ describe("Form", () => {
         foo: {
           type: "string",
           description: "this is description",
-          minLength: 32
-        }
-      }
+          minLength: 32,
+        },
+      },
     };
 
     const uiSchema = {
       foo: {
-        "ui:help": "this is help"
-      }
+        "ui:help": "this is help",
+      },
     };
 
     const formData = { foo: "invalid" };
@@ -78,7 +78,7 @@ describe("Form", () => {
         rawDescription,
         errors,
         rawErrors,
-        children
+        children,
       } = props;
       return (
         <div className={"my-template " + classNames}>
@@ -112,7 +112,7 @@ describe("Form", () => {
         uiSchema,
         formData,
         FieldTemplate,
-        liveValidate: true
+        liveValidate: true,
       }).node;
     });
 
@@ -181,9 +181,9 @@ describe("Form", () => {
     it("should use a single schema definition reference", () => {
       const schema = {
         definitions: {
-          testdef: { type: "string" }
+          testdef: { type: "string" },
         },
-        $ref: "#/definitions/testdef"
+        $ref: "#/definitions/testdef",
       };
 
       const { node } = createFormComponent({ schema });
@@ -194,13 +194,13 @@ describe("Form", () => {
     it("should handle multiple schema definition references", () => {
       const schema = {
         definitions: {
-          testdef: { type: "string" }
+          testdef: { type: "string" },
         },
         type: "object",
         properties: {
           foo: { $ref: "#/definitions/testdef" },
-          bar: { $ref: "#/definitions/testdef" }
-        }
+          bar: { $ref: "#/definitions/testdef" },
+        },
       };
 
       const { node } = createFormComponent({ schema });
@@ -211,17 +211,17 @@ describe("Form", () => {
     it("should handle deeply referenced schema definitions", () => {
       const schema = {
         definitions: {
-          testdef: { type: "string" }
+          testdef: { type: "string" },
         },
         type: "object",
         properties: {
           foo: {
             type: "object",
             properties: {
-              bar: { $ref: "#/definitions/testdef" }
-            }
-          }
-        }
+              bar: { $ref: "#/definitions/testdef" },
+            },
+          },
+        },
       };
 
       const { node } = createFormComponent({ schema });
@@ -232,22 +232,22 @@ describe("Form", () => {
     it("should handle referenced definitions for array items", () => {
       const schema = {
         definitions: {
-          testdef: { type: "string" }
+          testdef: { type: "string" },
         },
         type: "object",
         properties: {
           foo: {
             type: "array",
-            items: { $ref: "#/definitions/testdef" }
-          }
-        }
+            items: { $ref: "#/definitions/testdef" },
+          },
+        },
       };
 
       const { node } = createFormComponent({
         schema,
         formData: {
-          foo: ["blah"]
-        }
+          foo: ["blah"],
+        },
       });
 
       expect(node.querySelectorAll("input[type=text]")).to.have.length.of(1);
@@ -257,8 +257,8 @@ describe("Form", () => {
       const schema = {
         type: "object",
         properties: {
-          foo: { $ref: "#/definitions/nonexistent" }
-        }
+          foo: { $ref: "#/definitions/nonexistent" },
+        },
       };
 
       expect(() => createFormComponent({ schema })).to.Throw(
@@ -270,9 +270,9 @@ describe("Form", () => {
     it("should propagate referenced definition defaults", () => {
       const schema = {
         definitions: {
-          testdef: { type: "string", default: "hello" }
+          testdef: { type: "string", default: "hello" },
         },
-        $ref: "#/definitions/testdef"
+        $ref: "#/definitions/testdef",
       };
 
       const { node } = createFormComponent({ schema });
@@ -283,12 +283,12 @@ describe("Form", () => {
     it("should propagate nested referenced definition defaults", () => {
       const schema = {
         definitions: {
-          testdef: { type: "string", default: "hello" }
+          testdef: { type: "string", default: "hello" },
         },
         type: "object",
         properties: {
-          foo: { $ref: "#/definitions/testdef" }
-        }
+          foo: { $ref: "#/definitions/testdef" },
+        },
       };
 
       const { node } = createFormComponent({ schema });
@@ -299,12 +299,12 @@ describe("Form", () => {
     it("should propagate referenced definition defaults for array items", () => {
       const schema = {
         definitions: {
-          testdef: { type: "string", default: "hello" }
+          testdef: { type: "string", default: "hello" },
         },
         type: "array",
         items: {
-          $ref: "#/definitions/testdef"
-        }
+          $ref: "#/definitions/testdef",
+        },
       };
 
       const { node } = createFormComponent({ schema });
@@ -325,12 +325,12 @@ describe("Form", () => {
               children: {
                 type: "array",
                 items: {
-                  $ref: "#/definitions/node"
-                }
-              }
-            }
-          }
-        }
+                  $ref: "#/definitions/node",
+                },
+              },
+            },
+          },
+        },
       };
 
       const { node } = createFormComponent({ schema });
@@ -350,17 +350,17 @@ describe("Form", () => {
           name: { type: "string" },
           childObj: {
             type: "object",
-            $ref: "#/definitions/childObj"
-          }
+            $ref: "#/definitions/childObj",
+          },
         },
         definitions: {
           childObj: {
             type: "object",
             properties: {
-              otherName: { type: "string" }
-            }
-          }
-        }
+              otherName: { type: "string" },
+            },
+          },
+        },
       };
 
       const { node } = createFormComponent({ schema });
@@ -375,18 +375,18 @@ describe("Form", () => {
         properties: {
           foo: {
             title: "custom title",
-            $ref: "#/definitions/objectDef"
-          }
+            $ref: "#/definitions/objectDef",
+          },
         },
         definitions: {
           objectDef: {
             type: "object",
             title: "definition title",
             properties: {
-              field: { type: "string" }
-            }
-          }
-        }
+              field: { type: "string" },
+            },
+          },
+        },
       };
 
       const { node } = createFormComponent({ schema });
@@ -397,12 +397,12 @@ describe("Form", () => {
     it("should propagate and handle a resolved schema definition", () => {
       const schema = {
         definitions: {
-          enumDef: { type: "string", enum: ["a", "b"] }
+          enumDef: { type: "string", enum: ["a", "b"] },
         },
         type: "object",
         properties: {
-          name: { $ref: "#/definitions/enumDef" }
-        }
+          name: { $ref: "#/definitions/enumDef" },
+        },
       };
 
       const { node } = createFormComponent({ schema });
@@ -414,14 +414,14 @@ describe("Form", () => {
   describe("Default value handling on clear", () => {
     const schema = {
       type: "string",
-      default: "foo"
+      default: "foo",
     };
 
     it("should not set default when a text field is cleared", () => {
       const { node } = createFormComponent({ schema, formData: "bar" });
 
       Simulate.change(node.querySelector("input"), {
-        target: { value: "" }
+        target: { value: "" },
       });
 
       expect(node.querySelector("input").value).eql("");
@@ -445,14 +445,14 @@ describe("Form", () => {
                 properties: {
                   bool: {
                     type: "boolean",
-                    default: true
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+                    default: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     };
 
     it("should propagate deeply nested defaults to form state", done => {
@@ -468,10 +468,10 @@ describe("Form", () => {
             object: {
               array: [
                 {
-                  bool: true
-                }
-              ]
-            }
+                  bool: true,
+                },
+              ],
+            },
           });
           done();
         },
@@ -485,17 +485,17 @@ describe("Form", () => {
       const schema = {
         type: "object",
         properties: {
-          foo: { type: "string" }
-        }
+          foo: { type: "string" },
+        },
       };
       const formData = {
-        foo: "bar"
+        foo: "bar",
       };
       const onSubmit = sandbox.spy();
       const { comp, node } = createFormComponent({
         schema,
         formData,
-        onSubmit
+        onSubmit,
       });
 
       Simulate.submit(node);
@@ -509,12 +509,12 @@ describe("Form", () => {
         properties: {
           foo: {
             type: "string",
-            minLength: 1
-          }
-        }
+            minLength: 1,
+          },
+        },
       };
       const formData = {
-        foo: ""
+        foo: "",
       };
       const onSubmit = sandbox.spy();
       const onError = sandbox.spy();
@@ -522,7 +522,7 @@ describe("Form", () => {
         schema,
         formData,
         onSubmit,
-        onError
+        onError,
       });
 
       Simulate.submit(node);
@@ -537,24 +537,24 @@ describe("Form", () => {
         type: "object",
         properties: {
           foo: {
-            type: "string"
-          }
-        }
+            type: "string",
+          },
+        },
       };
       const formData = {
-        foo: ""
+        foo: "",
       };
       const onChange = sandbox.spy();
       const { node } = createFormComponent({ schema, formData, onChange });
 
       Simulate.change(node.querySelector("[type=text]"), {
-        target: { value: "new" }
+        target: { value: "new" },
       });
 
       sinon.assert.calledWithMatch(onChange, {
         formData: {
-          foo: "new"
-        }
+          foo: "new",
+        },
       });
     });
   });
@@ -564,19 +564,19 @@ describe("Form", () => {
         type: "object",
         properties: {
           foo: {
-            type: "string"
-          }
-        }
+            type: "string",
+          },
+        },
       };
       const formData = {
-        foo: ""
+        foo: "",
       };
       const onBlur = sandbox.spy();
       const { node } = createFormComponent({ schema, formData, onBlur });
 
       const input = node.querySelector("[type=text]");
       Simulate.blur(input, {
-        target: { value: "new" }
+        target: { value: "new" },
       });
 
       sinon.assert.calledWithMatch(onBlur, input.id, "new");
@@ -590,12 +590,12 @@ describe("Form", () => {
         properties: {
           foo: {
             type: "string",
-            minLength: 1
-          }
-        }
+            minLength: 1,
+          },
+        },
       };
       const formData = {
-        foo: ""
+        foo: "",
       };
       const onError = sandbox.spy();
       const { node } = createFormComponent({ schema, formData, onError });
@@ -610,7 +610,7 @@ describe("Form", () => {
     describe("root level", () => {
       const formProps = {
         schema: { type: "string" },
-        liveValidate: true
+        liveValidate: true,
       };
 
       it("should update form state from new formData prop value", () => {
@@ -626,7 +626,7 @@ describe("Form", () => {
 
         comp.componentWillReceiveProps({
           formData: "yo",
-          schema: { type: "number" }
+          schema: { type: "number" },
         });
 
         expect(comp.state.errors).to.have.length.of(1);
@@ -643,10 +643,10 @@ describe("Form", () => {
             type: "object",
             properties: {
               foo: {
-                type: "string"
-              }
-            }
-          }
+                type: "string",
+              },
+            },
+          },
         });
 
         comp.componentWillReceiveProps({ formData: { foo: "yo" } });
@@ -660,8 +660,8 @@ describe("Form", () => {
         const schema = {
           type: "array",
           items: {
-            type: "string"
-          }
+            type: "string",
+          },
         };
         const { comp } = createFormComponent({ schema });
 
@@ -676,7 +676,7 @@ describe("Form", () => {
     describe("on form state updated", () => {
       const schema = {
         type: "string",
-        minLength: 8
+        minLength: 8,
       };
 
       describe("Lazy validation", () => {
@@ -684,7 +684,7 @@ describe("Form", () => {
           const { comp, node } = createFormComponent({ schema });
 
           Simulate.change(node.querySelector("input[type=text]"), {
-            target: { value: "short" }
+            target: { value: "short" },
           });
 
           expect(comp.state.errorSchema).eql({});
@@ -694,7 +694,7 @@ describe("Form", () => {
           const { node } = createFormComponent({ schema });
 
           Simulate.change(node.querySelector("input[type=text]"), {
-            target: { value: "short" }
+            target: { value: "short" },
           });
 
           expect(node.querySelectorAll(".field-error")).to.have.length.of(0);
@@ -705,15 +705,15 @@ describe("Form", () => {
             type: "object",
             properties: {
               field1: { type: "string", minLength: 8 },
-              field2: { type: "string", minLength: 8 }
-            }
+              field2: { type: "string", minLength: 8 },
+            },
           };
           const { node } = createFormComponent({
             schema: altSchema,
             formData: {
               field1: "short",
-              field2: "short"
-            }
+              field2: "short",
+            },
           });
 
           function submit(node) {
@@ -729,7 +729,7 @@ describe("Form", () => {
 
           // Fix the first field
           Simulate.change(node.querySelectorAll("input[type=text]")[0], {
-            target: { value: "fixed error" }
+            target: { value: "fixed error" },
           });
           submit(node);
 
@@ -737,7 +737,7 @@ describe("Form", () => {
 
           // Fix the second field
           Simulate.change(node.querySelectorAll("input[type=text]")[1], {
-            target: { value: "fixed error too" }
+            target: { value: "fixed error too" },
           });
           submit(node);
 
@@ -752,15 +752,15 @@ describe("Form", () => {
         it("should update the errorSchema when the formData changes", () => {
           const { comp, node } = createFormComponent({
             schema,
-            liveValidate: true
+            liveValidate: true,
           });
 
           Simulate.change(node.querySelector("input[type=text]"), {
-            target: { value: "short" }
+            target: { value: "short" },
           });
 
           expect(comp.state.errorSchema).eql({
-            __errors: ["does not meet minimum length of 8"]
+            __errors: ["does not meet minimum length of 8"],
           });
         });
 
@@ -768,7 +768,7 @@ describe("Form", () => {
           const { node } = createFormComponent({ schema, liveValidate: true });
 
           Simulate.change(node.querySelector("input[type=text]"), {
-            target: { value: "short" }
+            target: { value: "short" },
           });
 
           expect(node.querySelectorAll(".field-error")).to.have.length.of(1);
@@ -783,11 +783,11 @@ describe("Form", () => {
           const { comp, node } = createFormComponent({
             schema,
             noValidate: true,
-            liveValidate: true
+            liveValidate: true,
           });
 
           Simulate.change(node.querySelector("input[type=text]"), {
-            target: { value: "short" }
+            target: { value: "short" },
           });
 
           expect(comp.state.errorSchema).eql({});
@@ -798,11 +798,11 @@ describe("Form", () => {
         it("should not update errorSchema when the formData changes", () => {
           const { comp, node } = createFormComponent({
             schema,
-            noValidate: true
+            noValidate: true,
           });
 
           Simulate.change(node.querySelector("input[type=text]"), {
-            target: { value: "short" }
+            target: { value: "short" },
           });
           Simulate.submit(node);
 
@@ -814,22 +814,22 @@ describe("Form", () => {
     describe("on form submitted", () => {
       const schema = {
         type: "string",
-        minLength: 8
+        minLength: 8,
       };
 
       it("should update the errorSchema on form submission", () => {
         const { comp, node } = createFormComponent({
           schema,
-          onError: () => {}
+          onError: () => {},
         });
 
         Simulate.change(node.querySelector("input[type=text]"), {
-          target: { value: "short" }
+          target: { value: "short" },
         });
         Simulate.submit(node);
 
         expect(comp.state.errorSchema).eql({
-          __errors: ["does not meet minimum length of 8"]
+          __errors: ["does not meet minimum length of 8"],
         });
       });
 
@@ -838,7 +838,7 @@ describe("Form", () => {
         const { node } = createFormComponent({ schema, onError });
 
         Simulate.change(node.querySelector("input[type=text]"), {
-          target: { value: "short" }
+          target: { value: "short" },
         });
         Simulate.submit(node);
 
@@ -857,16 +857,16 @@ describe("Form", () => {
         liveValidate: true,
         schema: {
           type: "string",
-          minLength: 8
+          minLength: 8,
         },
-        formData: "short"
+        formData: "short",
       };
 
       it("should reflect the contextualized error in state", () => {
         const { comp } = createFormComponent(formProps);
 
         expect(comp.state.errorSchema).eql({
-          __errors: ["does not meet minimum length of 8"]
+          __errors: ["does not meet minimum length of 8"],
         });
       });
 
@@ -886,9 +886,9 @@ describe("Form", () => {
         schema: {
           type: "string",
           minLength: 8,
-          pattern: "\d+"
+          pattern: "\d+",
         },
-        formData: "short"
+        formData: "short",
       };
 
       it("should reflect the contextualized error in state", () => {
@@ -896,8 +896,8 @@ describe("Form", () => {
         expect(comp.state.errorSchema).eql({
           __errors: [
             "does not meet minimum length of 8",
-            'does not match pattern "\d+"'
-          ]
+            'does not match pattern "\d+"',
+          ],
         });
       });
 
@@ -909,7 +909,7 @@ describe("Form", () => {
 
         expect(errors).eql([
           "does not meet minimum length of 8",
-          'does not match pattern "\d+"'
+          'does not match pattern "\d+"',
         ]);
       });
     });
@@ -923,11 +923,11 @@ describe("Form", () => {
             properties: {
               level2: {
                 type: "string",
-                minLength: 8
-              }
-            }
-          }
-        }
+                minLength: 8,
+              },
+            },
+          },
+        },
       };
 
       const formProps = {
@@ -935,9 +935,9 @@ describe("Form", () => {
         liveValidate: true,
         formData: {
           level1: {
-            level2: "short"
-          }
-        }
+            level2: "short",
+          },
+        },
       };
 
       it("should reflect the contextualized error in state", () => {
@@ -946,9 +946,9 @@ describe("Form", () => {
         expect(comp.state.errorSchema).eql({
           level1: {
             level2: {
-              __errors: ["does not meet minimum length of 8"]
-            }
-          }
+              __errors: ["does not meet minimum length of 8"],
+            },
+          },
         });
       });
 
@@ -970,21 +970,21 @@ describe("Form", () => {
         type: "array",
         items: {
           type: "string",
-          minLength: 4
-        }
+          minLength: 4,
+        },
       };
 
       const formProps = {
         schema,
         liveValidate: true,
-        formData: ["good", "bad", "good"]
+        formData: ["good", "bad", "good"],
       };
 
       it("should contextualize the error for array indices", () => {
         const { comp } = createFormComponent(formProps);
 
         expect(comp.state.errorSchema).eql({
-          1: { __errors: ["does not meet minimum length of 4"] }
+          1: { __errors: ["does not meet minimum length of 4"] },
         });
       });
 
@@ -1018,10 +1018,10 @@ describe("Form", () => {
             type: "array",
             items: {
               type: "string",
-              minLength: 4
-            }
-          }
-        }
+              minLength: 4,
+            },
+          },
+        },
       };
 
       const formProps = { schema, liveValidate: true };
@@ -1030,15 +1030,15 @@ describe("Form", () => {
         const { comp } = createFormComponent({
           ...formProps,
           formData: {
-            level1: ["good", "bad", "good", "bad"]
-          }
+            level1: ["good", "bad", "good", "bad"],
+          },
         });
 
         expect(comp.state.errorSchema).eql({
           level1: {
             1: { __errors: ["does not meet minimum length of 4"] },
-            3: { __errors: ["does not meet minimum length of 4"] }
-          }
+            3: { __errors: ["does not meet minimum length of 4"] },
+          },
         });
       });
 
@@ -1046,8 +1046,8 @@ describe("Form", () => {
         const { node } = createFormComponent({
           ...formProps,
           formData: {
-            level1: ["good", "bad", "good"]
-          }
+            level1: ["good", "bad", "good"],
+          },
         });
 
         const liNodes = node.querySelectorAll(".field-string .error-detail li");
@@ -1067,15 +1067,15 @@ describe("Form", () => {
               type: "array",
               items: {
                 type: "string",
-                minLength: 4
-              }
-            }
-          }
-        }
+                minLength: 4,
+              },
+            },
+          },
+        },
       };
 
       const formData = {
-        outer: [["good", "bad"], ["bad", "good"]]
+        outer: [["good", "bad"], ["bad", "good"]],
       };
 
       const formProps = { schema, formData, liveValidate: true };
@@ -1086,12 +1086,12 @@ describe("Form", () => {
         expect(comp.state.errorSchema).eql({
           outer: {
             0: {
-              1: { __errors: ["does not meet minimum length of 4"] }
+              1: { __errors: ["does not meet minimum length of 4"] },
             },
             1: {
-              0: { __errors: ["does not meet minimum length of 4"] }
-            }
-          }
+              0: { __errors: ["does not meet minimum length of 4"] },
+            },
+          },
         });
       });
 
@@ -1107,7 +1107,7 @@ describe("Form", () => {
           null,
           "does not meet minimum length of 4",
           "does not meet minimum length of 4",
-          null
+          null,
         ]);
       });
     });
@@ -1120,16 +1120,16 @@ describe("Form", () => {
           properties: {
             foo: {
               type: "string",
-              minLength: 4
-            }
-          }
-        }
+              minLength: 4,
+            },
+          },
+        },
       };
 
       const formProps = {
         schema,
         liveValidate: true,
-        formData: [{ foo: "good" }, { foo: "bad" }, { foo: "good" }]
+        formData: [{ foo: "good" }, { foo: "bad" }, { foo: "good" }],
       };
 
       it("should contextualize the error for array nested items", () => {
@@ -1138,9 +1138,9 @@ describe("Form", () => {
         expect(comp.state.errorSchema).eql({
           1: {
             foo: {
-              __errors: ["does not meet minimum length of 4"]
-            }
-          }
+              __errors: ["does not meet minimum length of 4"],
+            },
+          },
         });
       });
 
@@ -1165,8 +1165,8 @@ describe("Form", () => {
       type: "object",
       properties: {
         foo: { type: "string" },
-        bar: { type: "string" }
-      }
+        bar: { type: "string" },
+      },
     };
 
     it("should replace state when formData have keys removed", () => {
@@ -1176,14 +1176,14 @@ describe("Form", () => {
         schema: {
           type: "object",
           properties: {
-            bar: { type: "string" }
-          }
+            bar: { type: "string" },
+          },
         },
-        formData: { bar: "bar" }
+        formData: { bar: "bar" },
       });
 
       Simulate.change(node.querySelector("#root_bar"), {
-        target: { value: "baz" }
+        target: { value: "baz" },
       });
 
       expect(comp.state.formData).eql({ bar: "baz" });
@@ -1197,14 +1197,14 @@ describe("Form", () => {
           type: "object",
           properties: {
             foo: { type: "string" },
-            baz: { type: "string" }
-          }
+            baz: { type: "string" },
+          },
         },
-        formData: { foo: "foo", baz: "bar" }
+        formData: { foo: "foo", baz: "bar" },
       });
 
       Simulate.change(node.querySelector("#root_baz"), {
-        target: { value: "baz" }
+        target: { value: "baz" },
       });
 
       expect(comp.state.formData).eql({ foo: "foo", baz: "baz" });
@@ -1223,7 +1223,7 @@ describe("Form", () => {
       autocomplete: "off",
       enctype: "multipart/form-data",
       acceptcharset: "ISO-8859-1",
-      noHtml5Validate: true
+      noHtml5Validate: true,
     };
 
     let node;

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -19,8 +19,8 @@ describe("NumberField", () => {
     it("should render a string field", () => {
       const { node } = createFormComponent({
         schema: {
-          type: "number"
-        }
+          type: "number",
+        },
       });
 
       expect(
@@ -32,8 +32,8 @@ describe("NumberField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "number",
-          title: "foo"
-        }
+          title: "foo",
+        },
       });
 
       expect(node.querySelector(".field label").textContent).eql("foo");
@@ -43,8 +43,8 @@ describe("NumberField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "number",
-          description: "bar"
-        }
+          description: "bar",
+        },
       });
 
       expect(node.querySelector(".field-description").textContent).eql("bar");
@@ -60,8 +60,8 @@ describe("NumberField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "number",
-          default: 2
-        }
+          default: 2,
+        },
       });
 
       expect(node.querySelector(".field input").value).eql("2");
@@ -70,12 +70,12 @@ describe("NumberField", () => {
     it("should handle a change event", () => {
       const { comp, node } = createFormComponent({
         schema: {
-          type: "number"
-        }
+          type: "number",
+        },
       });
 
       Simulate.change(node.querySelector("input"), {
-        target: { value: "2" }
+        target: { value: "2" },
       });
 
       expect(comp.state.formData).eql(2);
@@ -85,14 +85,14 @@ describe("NumberField", () => {
       const onBlur = sandbox.spy();
       const { node } = createFormComponent({
         schema: {
-          type: "number"
+          type: "number",
         },
-        onBlur
+        onBlur,
       });
 
       const input = node.querySelector("input");
       Simulate.blur(input, {
-        target: { value: "2" }
+        target: { value: "2" },
       });
 
       expect(onBlur.calledWith(input.id, 2));
@@ -100,9 +100,9 @@ describe("NumberField", () => {
     it("should fill field with data", () => {
       const { node } = createFormComponent({
         schema: {
-          type: "number"
+          type: "number",
         },
-        formData: 2
+        formData: 2,
       });
 
       expect(node.querySelector(".field input").value).eql("2");
@@ -111,12 +111,12 @@ describe("NumberField", () => {
     it("should not cast the input as a number if it ends with a dot", () => {
       const { comp, node } = createFormComponent({
         schema: {
-          type: "number"
-        }
+          type: "number",
+        },
       });
 
       Simulate.change(node.querySelector("input"), {
-        target: { value: "2." }
+        target: { value: "2." },
       });
 
       expect(comp.state.formData).eql("2.");
@@ -125,8 +125,8 @@ describe("NumberField", () => {
     it("should render the widget with the expected id", () => {
       const { node } = createFormComponent({
         schema: {
-          type: "number"
-        }
+          type: "number",
+        },
       });
 
       expect(node.querySelector("input[type=text]").id).eql("root");
@@ -135,27 +135,27 @@ describe("NumberField", () => {
     it("should render with trailing zeroes", () => {
       const { node } = createFormComponent({
         schema: {
-          type: "number"
-        }
+          type: "number",
+        },
       });
 
       Simulate.change(node.querySelector("input"), {
-        target: { value: "2." }
+        target: { value: "2." },
       });
       expect(node.querySelector(".field input").value).eql("2.");
 
       Simulate.change(node.querySelector("input"), {
-        target: { value: "2.0" }
+        target: { value: "2.0" },
       });
       expect(node.querySelector(".field input").value).eql("2.0");
 
       Simulate.change(node.querySelector("input"), {
-        target: { value: "2.00" }
+        target: { value: "2.00" },
       });
       expect(node.querySelector(".field input").value).eql("2.00");
 
       Simulate.change(node.querySelector("input"), {
-        target: { value: "2.000" }
+        target: { value: "2.000" },
       });
       expect(node.querySelector(".field input").value).eql("2.000");
     });
@@ -165,11 +165,11 @@ describe("NumberField", () => {
 
       const { node } = createFormComponent({
         schema: {
-          type: "number"
+          type: "number",
         },
         fields: {
-          StringField: CustomStringField
-        }
+          StringField: CustomStringField,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -181,8 +181,8 @@ describe("NumberField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "number",
-          enum: [1, 2]
-        }
+          enum: [1, 2],
+        },
       });
 
       expect(node.querySelectorAll(".field select")).to.have.length.of(1);
@@ -193,8 +193,8 @@ describe("NumberField", () => {
         schema: {
           type: "number",
           enum: [1, 2],
-          title: "foo"
-        }
+          title: "foo",
+        },
       });
 
       expect(node.querySelector(".field label").textContent).eql("foo");
@@ -205,8 +205,8 @@ describe("NumberField", () => {
         schema: {
           type: "number",
           enum: [1, 2],
-          default: 1
-        }
+          default: 1,
+        },
       });
 
       expect(comp.state.formData).eql(1);
@@ -216,12 +216,12 @@ describe("NumberField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "number",
-          enum: [1, 2]
-        }
+          enum: [1, 2],
+        },
       });
 
       Simulate.change(node.querySelector("select"), {
-        target: { value: "2" }
+        target: { value: "2" },
       });
 
       expect(comp.state.formData).eql(2);
@@ -231,9 +231,9 @@ describe("NumberField", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "number",
-          enum: [1, 2]
+          enum: [1, 2],
         },
-        formData: 2
+        formData: 2,
       });
 
       expect(comp.state.formData).eql(2);
@@ -243,8 +243,8 @@ describe("NumberField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "number",
-          enum: [1, 2]
-        }
+          enum: [1, 2],
+        },
       });
 
       expect(node.querySelector("select").id).eql("root");

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -23,17 +23,17 @@ describe("ObjectField", () => {
       required: ["foo"],
       default: {
         foo: "hey",
-        bar: true
+        bar: true,
       },
       properties: {
         foo: {
           title: "Foo",
-          type: "string"
+          type: "string",
         },
         bar: {
-          type: "boolean"
-        }
-      }
+          type: "boolean",
+        },
+      },
     };
 
     it("should render a fieldset", () => {
@@ -57,8 +57,8 @@ describe("ObjectField", () => {
       const { node } = createFormComponent({
         schema,
         fields: {
-          TitleField: CustomTitleField
-        }
+          TitleField: CustomTitleField,
+        },
       });
       expect(node.querySelector("fieldset > #custom").textContent).to.eql(
         "my object"
@@ -72,7 +72,7 @@ describe("ObjectField", () => {
 
       const { node } = createFormComponent({
         schema,
-        fields: { DescriptionField: CustomDescriptionField }
+        fields: { DescriptionField: CustomDescriptionField },
       });
       expect(node.querySelector("fieldset > #custom").textContent).to.eql(
         "my description"
@@ -125,8 +125,8 @@ describe("ObjectField", () => {
         schema,
         formData: {
           foo: "hey",
-          bar: true
-        }
+          bar: true,
+        },
       });
 
       expect(node.querySelector(".field input[type=text]").value).eql("hey");
@@ -139,7 +139,7 @@ describe("ObjectField", () => {
       const { comp, node } = createFormComponent({ schema });
 
       Simulate.change(node.querySelector("input[type=text]"), {
-        target: { value: "changed" }
+        target: { value: "changed" },
       });
 
       expect(comp.state.formData.foo).eql("changed");
@@ -151,7 +151,7 @@ describe("ObjectField", () => {
 
       const input = node.querySelector("input[type=text]");
       Simulate.blur(input, {
-        target: { value: "changed" }
+        target: { value: "changed" },
       });
 
       expect(onBlur.calledWith(input.id, "changed")).to.be.true;
@@ -172,16 +172,16 @@ describe("ObjectField", () => {
         foo: { type: "string" },
         bar: { type: "string" },
         baz: { type: "string" },
-        qux: { type: "string" }
-      }
+        qux: { type: "string" },
+      },
     };
 
     it("should use provided order", () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
-          "ui:order": ["baz", "qux", "bar", "foo"]
-        }
+          "ui:order": ["baz", "qux", "bar", "foo"],
+        },
       });
       const labels = [].map.call(
         node.querySelectorAll(".field > label"),
@@ -195,8 +195,8 @@ describe("ObjectField", () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
-          "ui:order": ["baz", "*", "foo"]
-        }
+          "ui:order": ["baz", "*", "foo"],
+        },
       });
       const labels = [].map.call(
         node.querySelectorAll(".field > label"),
@@ -210,8 +210,8 @@ describe("ObjectField", () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
-          "ui:order": ["baz", "qux", "bar", "wut?", "foo", "huh?"]
-        }
+          "ui:order": ["baz", "qux", "bar", "wut?", "foo", "huh?"],
+        },
       });
 
       expect(node.querySelector(".config-error").textContent).to.match(
@@ -223,8 +223,8 @@ describe("ObjectField", () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
-          "ui:order": ["baz", "bar"]
-        }
+          "ui:order": ["baz", "bar"],
+        },
       });
 
       expect(node.querySelector(".config-error").textContent).to.match(
@@ -236,8 +236,8 @@ describe("ObjectField", () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
-          "ui:order": ["baz", "*", "bar", "*"]
-        }
+          "ui:order": ["baz", "*", "bar", "*"],
+        },
       });
 
       expect(node.querySelector(".config-error").textContent).to.match(
@@ -248,20 +248,20 @@ describe("ObjectField", () => {
     it("should order referenced schema definitions", () => {
       const refSchema = {
         definitions: {
-          testdef: { type: "string" }
+          testdef: { type: "string" },
         },
         type: "object",
         properties: {
           foo: { $ref: "#/definitions/testdef" },
-          bar: { $ref: "#/definitions/testdef" }
-        }
+          bar: { $ref: "#/definitions/testdef" },
+        },
       };
 
       const { node } = createFormComponent({
         schema: refSchema,
         uiSchema: {
-          "ui:order": ["bar", "foo"]
-        }
+          "ui:order": ["bar", "foo"],
+        },
       });
       const labels = [].map.call(
         node.querySelectorAll(".field > label"),
@@ -278,23 +278,23 @@ describe("ObjectField", () => {
             type: "object",
             properties: {
               foo: { type: "string" },
-              bar: { type: "string" }
-            }
-          }
+              bar: { type: "string" },
+            },
+          },
         },
         type: "object",
         properties: {
-          root: { $ref: "#/definitions/testdef" }
-        }
+          root: { $ref: "#/definitions/testdef" },
+        },
       };
 
       const { node } = createFormComponent({
         schema: refSchema,
         uiSchema: {
           root: {
-            "ui:order": ["bar", "foo"]
-          }
-        }
+            "ui:order": ["bar", "foo"],
+          },
+        },
       });
       const labels = [].map.call(
         node.querySelectorAll(".field > label"),
@@ -309,15 +309,15 @@ describe("ObjectField", () => {
         type: "object",
         properties: {
           foo: { type: "string" },
-          bar: { type: "string" }
-        }
+          bar: { type: "string" },
+        },
       };
 
       const { node } = createFormComponent({
         schema,
         uiSchema: {
-          "ui:order": ["bar", "foo"]
-        }
+          "ui:order": ["bar", "foo"],
+        },
       });
 
       const ids = [].map.call(
@@ -339,9 +339,9 @@ describe("ObjectField", () => {
         properties: {
           object: {
             type: "object",
-            properties: {}
-          }
-        }
+            properties: {},
+          },
+        },
       };
 
       const { node } = createFormComponent({ schema, fields });
@@ -352,7 +352,7 @@ describe("ObjectField", () => {
       const schema = {
         type: "object",
         properties: {},
-        title: "test"
+        title: "test",
       };
 
       const { node } = createFormComponent({ schema, fields });
@@ -363,7 +363,7 @@ describe("ObjectField", () => {
       const schema = {
         type: "object",
         properties: {},
-        title: ""
+        title: "",
       };
       const { node } = createFormComponent({ schema, fields });
       expect(node.querySelector("#title-")).to.be.null;

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -29,7 +29,7 @@ describe("SchemaField", () => {
       const fields = { SchemaField: CustomSchemaField };
       const { node } = createFormComponent({
         schema: { type: "string" },
-        fields
+        fields,
       });
 
       expect(
@@ -53,8 +53,8 @@ describe("SchemaField", () => {
       type: "object",
       properties: {
         foo: { type: "string" },
-        bar: { type: "string" }
-      }
+        bar: { type: "string" },
+      },
     };
 
     it("should use provided direct custom component for object", () => {
@@ -69,7 +69,7 @@ describe("SchemaField", () => {
 
     it("should use provided direct custom component for specific property", () => {
       const uiSchema = {
-        foo: { "ui:field": MyObject }
+        foo: { "ui:field": MyObject },
       };
 
       const { node } = createFormComponent({ schema, uiSchema });
@@ -94,8 +94,8 @@ describe("SchemaField", () => {
             render() {
               return <div />;
             }
-          }
-        }
+          },
+        },
       });
 
       const { registry } = receivedProps;
@@ -123,11 +123,11 @@ describe("SchemaField", () => {
             type: "object",
             properties: {
               foo: { type: "string" },
-              bar: { type: "string" }
-            }
-          }
+              bar: { type: "string" },
+            },
+          },
         },
-        $ref: "#/definitions/foobar"
+        $ref: "#/definitions/foobar",
       };
       const uiSchema = { "ui:field": "myobject" };
       const fields = { myobject: MyObject };
@@ -148,11 +148,11 @@ describe("SchemaField", () => {
       };
 
       const schema = {
-        type: "string"
+        type: "string",
       };
       const uiSchema = {
         "ui:field": "customSchemaField",
-        classNames: "foo"
+        classNames: "foo",
       };
       const fields = { customSchemaField: CustomSchemaField };
 
@@ -167,8 +167,8 @@ describe("SchemaField", () => {
       type: "object",
       properties: {
         foo: { type: "string", description: "A Foo field" },
-        bar: { type: "string" }
-      }
+        bar: { type: "string" },
+      },
     };
 
     it("should render description if available from the schema", () => {
@@ -185,14 +185,14 @@ describe("SchemaField", () => {
         type: "object",
         properties: {
           foo: { $ref: "#/definitions/foo" },
-          bar: { type: "string" }
+          bar: { type: "string" },
         },
         definitions: {
           foo: {
             type: "string",
-            description: "A Foo field"
-          }
-        }
+            description: "A Foo field",
+          },
+        },
       };
       const { node } = createFormComponent({ schema: schemaWithReference });
 
@@ -217,8 +217,8 @@ describe("SchemaField", () => {
       const { node } = createFormComponent({
         schema,
         fields: {
-          DescriptionField: CustomDescriptionField
-        }
+          DescriptionField: CustomDescriptionField,
+        },
       });
 
       expect(node.querySelector("#custom").textContent).to.eql("A Foo field");
@@ -229,15 +229,15 @@ describe("SchemaField", () => {
     const schema = {
       type: "object",
       properties: {
-        foo: { type: "string" }
-      }
+        foo: { type: "string" },
+      },
     };
 
     const uiSchema = {
       "ui:field": props => {
         const { uiSchema, ...fieldProps } = props; //eslint-disable-line
         return <SchemaField {...fieldProps} />;
-      }
+      },
     };
 
     function validate(formData, errors) {

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -22,8 +22,8 @@ describe("StringField", () => {
     it("should render a string field", () => {
       const { node } = createFormComponent({
         schema: {
-          type: "string"
-        }
+          type: "string",
+        },
       });
 
       expect(
@@ -35,8 +35,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          title: "foo"
-        }
+          title: "foo",
+        },
       });
 
       expect(node.querySelector(".field label").textContent).eql("foo");
@@ -46,8 +46,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          description: "bar"
-        }
+          description: "bar",
+        },
       });
 
       expect(node.querySelector(".field-description").textContent).eql("bar");
@@ -57,8 +57,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          default: "plop"
-        }
+          default: "plop",
+        },
       });
 
       expect(node.querySelector(".field input").value).eql("plop");
@@ -73,12 +73,12 @@ describe("StringField", () => {
     it("should handle a change event", () => {
       const { comp, node } = createFormComponent({
         schema: {
-          type: "string"
-        }
+          type: "string",
+        },
       });
 
       Simulate.change(node.querySelector("input"), {
-        target: { value: "yo" }
+        target: { value: "yo" },
       });
 
       expect(comp.state.formData).eql("yo");
@@ -88,13 +88,13 @@ describe("StringField", () => {
       const onBlur = sandbox.spy();
       const { node } = createFormComponent({
         schema: {
-          type: "string"
+          type: "string",
         },
-        onBlur
+        onBlur,
       });
       const input = node.querySelector("input");
       Simulate.blur(input, {
-        target: { value: "yo" }
+        target: { value: "yo" },
       });
 
       expect(onBlur.calledWith(input.id, "yo")).to.be.true;
@@ -103,11 +103,11 @@ describe("StringField", () => {
     it("should handle an empty string change event", () => {
       const { comp, node } = createFormComponent({
         schema: { type: "string" },
-        formData: "x"
+        formData: "x",
       });
 
       Simulate.change(node.querySelector("input"), {
-        target: { value: "" }
+        target: { value: "" },
       });
 
       expect(comp.state.formData).eql(undefined);
@@ -116,9 +116,9 @@ describe("StringField", () => {
     it("should fill field with data", () => {
       const { node } = createFormComponent({
         schema: {
-          type: "string"
+          type: "string",
         },
-        formData: "plip"
+        formData: "plip",
       });
 
       expect(node.querySelector(".field input").value).eql("plip");
@@ -127,8 +127,8 @@ describe("StringField", () => {
     it("should render the widget with the expected id", () => {
       const { node } = createFormComponent({
         schema: {
-          type: "string"
-        }
+          type: "string",
+        },
       });
 
       expect(node.querySelector("input[type=text]").id).eql("root");
@@ -137,11 +137,11 @@ describe("StringField", () => {
     it("should render customized TextWidget", () => {
       const { node } = createFormComponent({
         schema: {
-          type: "string"
+          type: "string",
         },
         widgets: {
-          TextWidget: CustomWidget
-        }
+          TextWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -153,8 +153,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          enum: ["foo", "bar"]
-        }
+          enum: ["foo", "bar"],
+        },
       });
 
       expect(node.querySelectorAll(".field select")).to.have.length.of(1);
@@ -165,8 +165,8 @@ describe("StringField", () => {
         schema: {
           type: "string",
           enum: ["foo", "bar"],
-          title: "foo"
-        }
+          title: "foo",
+        },
       });
 
       expect(node.querySelector(".field label").textContent).eql("foo");
@@ -176,8 +176,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          enum: ["foo", "bar"]
-        }
+          enum: ["foo", "bar"],
+        },
       });
 
       expect(node.querySelectorAll(".field option")[0].value).eql("");
@@ -187,13 +187,13 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          enum: ["foo", "bar"]
+          enum: ["foo", "bar"],
         },
         uiSchema: {
           "ui:options": {
-            placeholder: "Test"
-          }
-        }
+            placeholder: "Test",
+          },
+        },
       });
 
       console.log(node.querySelectorAll(".field option")[0].innerHTML);
@@ -205,8 +205,8 @@ describe("StringField", () => {
         schema: {
           type: "string",
           enum: ["foo", "bar"],
-          default: "bar"
-        }
+          default: "bar",
+        },
       });
 
       expect(comp.state.formData).eql("bar");
@@ -216,12 +216,12 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          enum: ["foo", "bar"]
-        }
+          enum: ["foo", "bar"],
+        },
       });
 
       Simulate.change(node.querySelector("select"), {
-        target: { value: "foo" }
+        target: { value: "foo" },
       });
 
       expect(comp.state.formData).eql("foo");
@@ -231,12 +231,12 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          enum: ["foo", "bar"]
-        }
+          enum: ["foo", "bar"],
+        },
       });
 
       Simulate.change(node.querySelector("select"), {
-        target: { value: "" }
+        target: { value: "" },
       });
 
       expect(comp.state.formData).to.be.undefined;
@@ -246,12 +246,12 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          enum: ["foo", "bar"]
-        }
+          enum: ["foo", "bar"],
+        },
       });
 
       Simulate.change(node.querySelector("select"), {
-        target: { value: "foo" }
+        target: { value: "foo" },
       });
 
       expect(node.querySelector("select").value).eql("foo");
@@ -261,12 +261,12 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          enum: ["foo", "bar"]
-        }
+          enum: ["foo", "bar"],
+        },
       });
 
       Simulate.change(node.querySelector("select"), {
-        target: { value: "" }
+        target: { value: "" },
       });
 
       expect(node.querySelector("select").value).eql("");
@@ -276,9 +276,9 @@ describe("StringField", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "string",
-          enum: ["foo", "bar"]
+          enum: ["foo", "bar"],
         },
-        formData: "bar"
+        formData: "bar",
       });
 
       expect(comp.state.formData).eql("bar");
@@ -288,8 +288,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          enum: ["a", "b"]
-        }
+          enum: ["a", "b"],
+        },
       });
 
       expect(node.querySelector("select").id).eql("root");
@@ -299,11 +299,11 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          enum: []
+          enum: [],
         },
         widgets: {
-          SelectWidget: CustomWidget
-        }
+          SelectWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -315,11 +315,11 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: { type: "string" },
         uiSchema: { "ui:widget": "textarea" },
-        formData: "x"
+        formData: "x",
       });
 
       Simulate.change(node.querySelector("textarea"), {
-        target: { value: "" }
+        target: { value: "" },
       });
 
       expect(comp.state.formData).eql(undefined);
@@ -330,9 +330,9 @@ describe("StringField", () => {
         schema: { type: "string" },
         uiSchema: {
           "ui:widget": "textarea",
-          "ui:options": { rows: 20 }
+          "ui:options": { rows: 20 },
         },
-        formData: "x"
+        formData: "x",
       });
 
       expect(node.querySelector("textarea").getAttribute("rows")).eql("20");
@@ -344,8 +344,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
-        }
+          format: "date-time",
+        },
       });
 
       expect(
@@ -359,8 +359,8 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "date-time",
-          default: datetime
-        }
+          default: datetime,
+        },
       });
 
       expect(comp.state.formData).eql(datetime);
@@ -370,14 +370,14 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
-        }
+          format: "date-time",
+        },
       });
 
       const newDatetime = new Date().toJSON();
 
       Simulate.change(node.querySelector("[type=datetime-local]"), {
-        target: { value: newDatetime }
+        target: { value: newDatetime },
       });
 
       expect(node.querySelector("[type=datetime-local]").value)
@@ -390,9 +390,9 @@ describe("StringField", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
+          format: "date-time",
         },
-        formData: datetime
+        formData: datetime,
       });
 
       expect(comp.state.formData).eql(datetime);
@@ -402,8 +402,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
-        }
+          format: "date-time",
+        },
       });
 
       expect(node.querySelector("[type=datetime-local]").id).eql("root");
@@ -413,13 +413,13 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
+          format: "date-time",
         },
-        liveValidate: true
+        liveValidate: true,
       });
 
       Simulate.change(node.querySelector("[type=datetime-local]"), {
-        target: { value: "invalid" }
+        target: { value: "invalid" },
       });
 
       expect(comp.state.errors).to.have.length.of(1);
@@ -429,11 +429,11 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
+          format: "date-time",
         },
         widgets: {
-          DateTimeWidget: CustomWidget
-        }
+          DateTimeWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -447,9 +447,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(node.querySelectorAll(".field [type=date]")).to.have.length.of(1);
@@ -461,9 +461,9 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "date",
-          default: datetime
+          default: datetime,
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(comp.state.formData).eql(datetime);
@@ -473,15 +473,15 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
-        uiSchema
+        uiSchema,
       });
 
       const newDatetime = "2012-12-12";
 
       Simulate.change(node.querySelector("[type=date]"), {
-        target: { value: newDatetime }
+        target: { value: newDatetime },
       });
 
       expect(node.querySelector("[type=date]").value)
@@ -494,9 +494,9 @@ describe("StringField", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
-        formData: datetime
+        formData: datetime,
       });
 
       expect(comp.state.formData).eql(datetime);
@@ -506,9 +506,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(node.querySelector("[type=date]").id).eql("root");
@@ -518,14 +518,14 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
         uiSchema,
-        liveValidate: true
+        liveValidate: true,
       });
 
       Simulate.change(node.querySelector("[type=date]"), {
-        target: { value: "2012-12-12" }
+        target: { value: "2012-12-12" },
       });
 
       expect(comp.state.errors).to.have.length.of(0);
@@ -536,14 +536,14 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
         uiSchema,
-        liveValidate: true
+        liveValidate: true,
       });
 
       Simulate.change(node.querySelector("[type=date]"), {
-        target: { value: "invalid" }
+        target: { value: "invalid" },
       });
 
       expect(comp.state.errors).to.have.length.of(1);
@@ -553,14 +553,14 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
         uiSchema,
-        liveValidate: true
+        liveValidate: true,
       });
 
       Simulate.change(node.querySelector("[type=date]"), {
-        target: { value: null }
+        target: { value: null },
       });
 
       expect(comp.state.formData).to.be.a("undefined");
@@ -571,11 +571,11 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
         widgets: {
-          DateWidget: CustomWidget
-        }
+          DateWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -589,9 +589,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
+          format: "date-time",
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(node.querySelectorAll(".field select")).to.have.length.of(6);
@@ -602,9 +602,9 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "date-time",
-          title: "foo"
+          title: "foo",
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(node.querySelector(".field label").textContent).eql("foo");
@@ -616,9 +616,9 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "date-time",
-          default: datetime
+          default: datetime,
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(comp.state.formData).eql(datetime);
@@ -628,28 +628,28 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
+          format: "date-time",
         },
-        uiSchema
+        uiSchema,
       });
 
       Simulate.change(node.querySelector("#root_year"), {
-        target: { value: 2012 }
+        target: { value: 2012 },
       });
       Simulate.change(node.querySelector("#root_month"), {
-        target: { value: 10 }
+        target: { value: 10 },
       });
       Simulate.change(node.querySelector("#root_day"), {
-        target: { value: 2 }
+        target: { value: 2 },
       });
       Simulate.change(node.querySelector("#root_hour"), {
-        target: { value: 1 }
+        target: { value: 1 },
       });
       Simulate.change(node.querySelector("#root_minute"), {
-        target: { value: 2 }
+        target: { value: 2 },
       });
       Simulate.change(node.querySelector("#root_second"), {
-        target: { value: 3 }
+        target: { value: 3 },
       });
 
       expect(comp.state.formData).eql("2012-10-02T01:02:03.000Z");
@@ -660,9 +660,9 @@ describe("StringField", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
+          format: "date-time",
         },
-        formData: datetime
+        formData: datetime,
       });
 
       expect(comp.state.formData).eql(datetime);
@@ -672,9 +672,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
+          format: "date-time",
         },
-        uiSchema
+        uiSchema,
       });
 
       const ids = [].map.call(node.querySelectorAll("select"), node => node.id);
@@ -685,7 +685,7 @@ describe("StringField", () => {
         "root_day",
         "root_hour",
         "root_minute",
-        "root_second"
+        "root_second",
       ]);
     });
 
@@ -693,9 +693,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
+          format: "date-time",
         },
-        uiSchema
+        uiSchema,
       });
 
       const lengths = [].map.call(
@@ -709,7 +709,7 @@ describe("StringField", () => {
         31 + 1,
         24 + 1,
         60 + 1,
-        60 + 1
+        60 + 1,
       ]);
       const monthOptions = node.querySelectorAll("select#root_month option");
       const monthOptionsValues = [].map.call(monthOptions, o => o.value);
@@ -726,7 +726,7 @@ describe("StringField", () => {
         "9",
         "10",
         "11",
-        "12"
+        "12",
       ]);
     });
 
@@ -734,9 +734,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
+          format: "date-time",
         },
-        uiSchema
+        uiSchema,
       });
 
       const monthOptions = node.querySelectorAll("select#root_month option");
@@ -754,7 +754,7 @@ describe("StringField", () => {
         "09",
         "10",
         "11",
-        "12"
+        "12",
       ]);
     });
 
@@ -763,9 +763,9 @@ describe("StringField", () => {
         const { node } = createFormComponent({
           schema: {
             type: "string",
-            format: "date-time"
+            format: "date-time",
           },
-          uiSchema
+          uiSchema,
         });
 
         const buttonLabels = [].map.call(
@@ -779,9 +779,9 @@ describe("StringField", () => {
         const { comp, node } = createFormComponent({
           schema: {
             type: "string",
-            format: "date-time"
+            format: "date-time",
           },
-          uiSchema
+          uiSchema,
         });
 
         Simulate.click(node.querySelector("a.btn-now"));
@@ -796,9 +796,9 @@ describe("StringField", () => {
         const { comp, node } = createFormComponent({
           schema: {
             type: "string",
-            format: "date-time"
+            format: "date-time",
           },
-          uiSchema
+          uiSchema,
         });
 
         Simulate.click(node.querySelector("a.btn-now"));
@@ -812,14 +812,14 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date-time"
+          format: "date-time",
         },
         uiSchema: {
-          "ui:widget": "alt-datetime"
+          "ui:widget": "alt-datetime",
         },
         widgets: {
-          AltDateTimeWidget: CustomWidget
-        }
+          AltDateTimeWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -829,14 +829,14 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
         uiSchema: {
-          "ui:widget": "alt-datetime"
+          "ui:widget": "alt-datetime",
         },
         widgets: {
-          AltDateTimeWidget: CustomWidget
-        }
+          AltDateTimeWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -850,9 +850,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(node.querySelectorAll(".field select")).to.have.length.of(3);
@@ -863,9 +863,9 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "date",
-          title: "foo"
+          title: "foo",
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(node.querySelector(".field label").textContent).eql("foo");
@@ -877,9 +877,9 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "date",
-          default: datetime
+          default: datetime,
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(comp.state.formData).eql(datetime);
@@ -889,19 +889,19 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
-        uiSchema
+        uiSchema,
       });
 
       Simulate.change(node.querySelector("#root_year"), {
-        target: { value: 2012 }
+        target: { value: 2012 },
       });
       Simulate.change(node.querySelector("#root_month"), {
-        target: { value: 10 }
+        target: { value: 10 },
       });
       Simulate.change(node.querySelector("#root_day"), {
-        target: { value: 2 }
+        target: { value: 2 },
       });
 
       expect(comp.state.formData).eql("2012-10-02");
@@ -912,10 +912,10 @@ describe("StringField", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
         uiSchema,
-        formData: datetime
+        formData: datetime,
       });
 
       expect(comp.state.formData).eql(datetime);
@@ -925,9 +925,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
-        uiSchema
+        uiSchema,
       });
 
       const ids = [].map.call(node.querySelectorAll("select"), node => node.id);
@@ -939,9 +939,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
-        uiSchema
+        uiSchema,
       });
 
       const lengths = [].map.call(
@@ -952,7 +952,7 @@ describe("StringField", () => {
       expect(lengths).eql([
         121 + 1, // from 1900 to 2020 + undefined
         12 + 1,
-        31 + 1
+        31 + 1,
       ]);
       const monthOptions = node.querySelectorAll("select#root_month option");
       const monthOptionsValues = [].map.call(monthOptions, o => o.value);
@@ -969,7 +969,7 @@ describe("StringField", () => {
         "9",
         "10",
         "11",
-        "12"
+        "12",
       ]);
     });
 
@@ -977,9 +977,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
-        uiSchema
+        uiSchema,
       });
 
       const monthOptions = node.querySelectorAll("select#root_month option");
@@ -997,7 +997,7 @@ describe("StringField", () => {
         "09",
         "10",
         "11",
-        "12"
+        "12",
       ]);
     });
 
@@ -1005,10 +1005,10 @@ describe("StringField", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
         uiSchema,
-        liveValidate: true
+        liveValidate: true,
       });
 
       comp.componentWillReceiveProps({ formData: "2012-12-12" });
@@ -1021,9 +1021,9 @@ describe("StringField", () => {
         const { node } = createFormComponent({
           schema: {
             type: "string",
-            format: "date"
+            format: "date",
           },
-          uiSchema
+          uiSchema,
         });
 
         const buttonLabels = [].map.call(
@@ -1037,9 +1037,9 @@ describe("StringField", () => {
         const { comp, node } = createFormComponent({
           schema: {
             type: "string",
-            format: "date"
+            format: "date",
           },
-          uiSchema
+          uiSchema,
         });
 
         Simulate.click(node.querySelector("a.btn-now"));
@@ -1055,9 +1055,9 @@ describe("StringField", () => {
         const { comp, node } = createFormComponent({
           schema: {
             type: "string",
-            format: "date"
+            format: "date",
           },
-          uiSchema
+          uiSchema,
         });
 
         Simulate.click(node.querySelector("a.btn-now"));
@@ -1071,14 +1071,14 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "date"
+          format: "date",
         },
         uiSchema: {
-          "ui:widget": "alt-date"
+          "ui:widget": "alt-date",
         },
         widgets: {
-          AltDateWidget: CustomWidget
-        }
+          AltDateWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -1090,8 +1090,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "email"
-        }
+          format: "email",
+        },
       });
 
       expect(node.querySelectorAll(".field [type=email]")).to.have.length.of(1);
@@ -1102,8 +1102,8 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "email",
-          title: "foo"
-        }
+          title: "foo",
+        },
       });
 
       expect(node.querySelector(".field label").textContent).eql("foo");
@@ -1114,8 +1114,8 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "email",
-          description: "baz"
-        }
+          description: "baz",
+        },
       });
 
       expect(node.querySelector(".field-description").textContent).eql("baz");
@@ -1127,8 +1127,8 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "email",
-          default: email
-        }
+          default: email,
+        },
       });
 
       expect(comp.state.formData).eql(email);
@@ -1138,14 +1138,14 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "email"
-        }
+          format: "email",
+        },
       });
 
       const newDatetime = new Date().toJSON();
 
       Simulate.change(node.querySelector("[type=email]"), {
-        target: { value: newDatetime }
+        target: { value: newDatetime },
       });
 
       expect(node.querySelector("[type=email]").value).eql(newDatetime);
@@ -1156,9 +1156,9 @@ describe("StringField", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "string",
-          format: "email"
+          format: "email",
         },
-        formData: email
+        formData: email,
       });
 
       expect(comp.state.formData).eql(email);
@@ -1168,8 +1168,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "email"
-        }
+          format: "email",
+        },
       });
 
       expect(node.querySelector("[type=email]").id).eql("root");
@@ -1179,13 +1179,13 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          format: "email"
+          format: "email",
         },
-        liveValidate: true
+        liveValidate: true,
       });
 
       Simulate.change(node.querySelector("[type=email]"), {
-        target: { value: "invalid" }
+        target: { value: "invalid" },
       });
 
       expect(comp.state.errors).to.have.length.of(1);
@@ -1195,11 +1195,11 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "email"
+          format: "email",
         },
         widgets: {
-          EmailWidget: CustomWidget
-        }
+          EmailWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -1211,8 +1211,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "uri"
-        }
+          format: "uri",
+        },
       });
 
       expect(node.querySelectorAll(".field [type=url]")).to.have.length.of(1);
@@ -1223,8 +1223,8 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "uri",
-          title: "foo"
-        }
+          title: "foo",
+        },
       });
 
       expect(node.querySelector(".field label").textContent).eql("foo");
@@ -1235,8 +1235,8 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "uri",
-          description: "baz"
-        }
+          description: "baz",
+        },
       });
 
       expect(node.querySelector(".field-description").textContent).eql("baz");
@@ -1248,8 +1248,8 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "uri",
-          default: url
-        }
+          default: url,
+        },
       });
 
       expect(comp.state.formData).eql(url);
@@ -1259,13 +1259,13 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "uri"
-        }
+          format: "uri",
+        },
       });
 
       const newDatetime = new Date().toJSON();
       Simulate.change(node.querySelector("[type=url]"), {
-        target: { value: newDatetime }
+        target: { value: newDatetime },
       });
 
       expect(node.querySelector("[type=url]").value).eql(newDatetime);
@@ -1276,9 +1276,9 @@ describe("StringField", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "string",
-          format: "uri"
+          format: "uri",
         },
-        formData: url
+        formData: url,
       });
 
       expect(comp.state.formData).eql(url);
@@ -1288,8 +1288,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "uri"
-        }
+          format: "uri",
+        },
       });
 
       expect(node.querySelector("[type=url]").id).eql("root");
@@ -1299,13 +1299,13 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          format: "uri"
+          format: "uri",
         },
-        liveValidate: true
+        liveValidate: true,
       });
 
       Simulate.change(node.querySelector("[type=url]"), {
-        target: { value: "invalid" }
+        target: { value: "invalid" },
       });
 
       expect(comp.state.errors).to.have.length.of(1);
@@ -1315,11 +1315,11 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "uri"
+          format: "uri",
         },
         widgets: {
-          URLWidget: CustomWidget
-        }
+          URLWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -1334,9 +1334,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "color"
+          format: "color",
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(node.querySelectorAll(".field [type=color]")).to.have.length.of(1);
@@ -1347,9 +1347,9 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "color",
-          default: color
+          default: color,
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(comp.state.formData).eql(color);
@@ -1359,15 +1359,15 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "color"
+          format: "color",
         },
-        uiSchema
+        uiSchema,
       });
 
       const newColor = "#654321";
 
       Simulate.change(node.querySelector("[type=color]"), {
-        target: { value: newColor }
+        target: { value: newColor },
       });
 
       expect(node.querySelector("[type=color]").value).eql(newColor);
@@ -1377,9 +1377,9 @@ describe("StringField", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "string",
-          format: "color"
+          format: "color",
         },
-        formData: color
+        formData: color,
       });
 
       expect(comp.state.formData).eql(color);
@@ -1389,9 +1389,9 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "color"
+          format: "color",
         },
-        uiSchema
+        uiSchema,
       });
 
       expect(node.querySelector("[type=color]").id).eql("root");
@@ -1401,14 +1401,14 @@ describe("StringField", () => {
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          format: "color"
+          format: "color",
         },
         uiSchema,
-        liveValidate: true
+        liveValidate: true,
       });
 
       Simulate.change(node.querySelector("[type=color]"), {
-        target: { value: "invalid" }
+        target: { value: "invalid" },
       });
 
       expect(comp.state.errors).to.have.length.of(1);
@@ -1418,11 +1418,11 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "color"
+          format: "color",
         },
         widgets: {
-          ColorWidget: CustomWidget
-        }
+          ColorWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -1436,8 +1436,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "data-url"
-        }
+          format: "data-url",
+        },
       });
 
       expect(node.querySelectorAll(".field [type=file]")).to.have.length.of(1);
@@ -1448,8 +1448,8 @@ describe("StringField", () => {
         schema: {
           type: "string",
           format: "color",
-          default: initialValue
-        }
+          default: initialValue,
+        },
       });
 
       expect(comp.state.formData).eql(initialValue);
@@ -1460,18 +1460,18 @@ describe("StringField", () => {
         set onload(fn) {
           fn({ target: { result: "data:text/plain;base64,x=" } });
         },
-        readAsDataUrl() {}
+        readAsDataUrl() {},
       });
 
       const { comp, node } = createFormComponent({
         schema: {
           type: "string",
-          format: "data-url"
-        }
+          format: "data-url",
+        },
       });
 
       Simulate.change(node.querySelector("[type=file]"), {
-        target: { files: [{ name: "file1.txt", size: 1, type: "type" }] }
+        target: { files: [{ name: "file1.txt", size: 1, type: "type" }] },
       });
 
       return new Promise(setImmediate).then(() =>
@@ -1484,8 +1484,8 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "data-url"
-        }
+          format: "data-url",
+        },
       });
 
       expect(node.querySelector("[type=file]").id).eql("root");
@@ -1495,11 +1495,11 @@ describe("StringField", () => {
       const { node } = createFormComponent({
         schema: {
           type: "string",
-          format: "data-url"
+          format: "data-url",
         },
         widgets: {
-          FileWidget: CustomWidget
-        }
+          FileWidget: CustomWidget,
+        },
       });
 
       expect(node.querySelector("#custom")).to.exist;
@@ -1516,14 +1516,14 @@ describe("StringField", () => {
         type: "object",
         properties: {
           string: {
-            type: "string"
-          }
-        }
+            type: "string",
+          },
+        },
       };
       const uiSchema = {
         string: {
-          "ui:widget": "Widget"
-        }
+          "ui:widget": "Widget",
+        },
       };
 
       const { node } = createFormComponent({ schema, widgets, uiSchema });
@@ -1533,10 +1533,10 @@ describe("StringField", () => {
     it("should pass schema title to widget", () => {
       const schema = {
         type: "string",
-        title: "test"
+        title: "test",
       };
       const uiSchema = {
-        "ui:widget": "Widget"
+        "ui:widget": "Widget",
       };
 
       const { node } = createFormComponent({ schema, widgets, uiSchema });
@@ -1546,10 +1546,10 @@ describe("StringField", () => {
     it("should pass empty schema title to widget", () => {
       const schema = {
         type: "string",
-        title: ""
+        title: "",
       };
       const uiSchema = {
-        "ui:widget": "Widget"
+        "ui:widget": "Widget",
       };
       const { node } = createFormComponent({ schema, widgets, uiSchema });
       expect(node.querySelector("#label-")).to.not.be.null;

--- a/test/TitleField_test.js
+++ b/test/TitleField_test.js
@@ -29,7 +29,7 @@ describe("TitleField", () => {
   it("should return a legend", () => {
     const props = {
       title: "Field title",
-      required: true
+      required: true,
     };
     const { node } = createComponent(TitleFieldWrapper, props);
 
@@ -40,7 +40,7 @@ describe("TitleField", () => {
     const props = {
       title: "Field title",
       required: true,
-      id: "sample_id"
+      id: "sample_id",
     };
     const { node } = createComponent(TitleFieldWrapper, props);
 
@@ -50,7 +50,7 @@ describe("TitleField", () => {
   it("should include only title, when field is not required", () => {
     const props = {
       title: "Field title",
-      required: false
+      required: false,
     };
     const { node } = createComponent(TitleFieldWrapper, props);
 
@@ -60,7 +60,7 @@ describe("TitleField", () => {
   it("should add an asterisk to the title, when field is required", () => {
     const props = {
       title: "Field title",
-      required: true
+      required: true,
     };
     const { node } = createComponent(TitleFieldWrapper, props);
 

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -7,7 +7,7 @@ import {
   createComponent,
   createFormComponent,
   createSandbox,
-  setProps
+  setProps,
 } from "./test_utils";
 
 describe("Rendering performance optimizations", () => {
@@ -51,13 +51,13 @@ describe("Rendering performance optimizations", () => {
         type: "object",
         properties: {
           const: { type: "string" },
-          var: { type: "string" }
-        }
+          var: { type: "string" },
+        },
       };
 
       const { comp } = createFormComponent({
         schema,
-        formData: { const: "0", var: "0" }
+        formData: { const: "0", var: "0" },
       });
 
       const fields = scryRenderedComponentsWithType(
@@ -78,12 +78,12 @@ describe("Rendering performance optimizations", () => {
     it("should only render changed array items", () => {
       const schema = {
         type: "array",
-        items: { type: "string" }
+        items: { type: "string" },
       };
 
       const { comp } = createFormComponent({
         schema,
-        formData: ["const", "var0"]
+        formData: ["const", "var0"],
       });
 
       const fields = scryRenderedComponentsWithType(
@@ -110,8 +110,8 @@ describe("Rendering performance optimizations", () => {
     const schema = {
       type: "object",
       properties: {
-        foo: { type: "string" }
-      }
+        foo: { type: "string" },
+      },
     };
     const idSchema = { $id: "root", foo: { $id: "root_plop" } };
 
@@ -122,7 +122,7 @@ describe("Rendering performance optimizations", () => {
         uiSchema,
         onChange,
         idSchema,
-        onBlur
+        onBlur,
       };
 
       const { comp } = createComponent(SchemaField, props);
@@ -140,7 +140,7 @@ describe("Rendering performance optimizations", () => {
         formData: { foo: "blah" },
         onChange,
         idSchema,
-        onBlur
+        onBlur,
       };
 
       const { comp } = createComponent(SchemaField, props);

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -20,13 +20,13 @@ describe("uiSchema", () => {
       type: "object",
       properties: {
         foo: { type: "string" },
-        bar: { type: "string" }
-      }
+        bar: { type: "string" },
+      },
     };
 
     const uiSchema = {
       foo: { classNames: "class-for-foo" },
-      bar: { classNames: "class-for-bar another-for-bar" }
+      bar: { classNames: "class-for-bar another-for-bar" },
     };
 
     it("should apply custom class names to target widgets", () => {
@@ -42,7 +42,7 @@ describe("uiSchema", () => {
   describe("custom widget", () => {
     describe("root widget", () => {
       const schema = {
-        type: "string"
+        type: "string",
       };
 
       const uiSchema = {
@@ -57,7 +57,7 @@ describe("uiSchema", () => {
               onChange={event => props.onChange(event.target.value)}
             />
           );
-        }
+        },
       };
 
       it("should render a root custom widget", () => {
@@ -75,7 +75,7 @@ describe("uiSchema", () => {
 
         widget = ({ label, options }) => <div id={label} style={options} />;
         widget.defaultProps = {
-          options: { background: "yellow", color: "green" }
+          options: { background: "yellow", color: "green" },
         };
 
         widgets = { widget };
@@ -88,8 +88,8 @@ describe("uiSchema", () => {
             funcAll: { type: "string" },
             funcNone: { type: "string" },
             stringAll: { type: "string" },
-            stringNone: { type: "string" }
-          }
+            stringNone: { type: "string" },
+          },
         };
 
         uiSchema = {
@@ -98,16 +98,16 @@ describe("uiSchema", () => {
             "ui:widget": {
               component: widget,
               options: {
-                background: "purple"
-              }
+                background: "purple",
+              },
             },
             "ui:options": {
-              margin: "7px"
+              margin: "7px",
             },
-            "ui:padding": "42px"
+            "ui:padding": "42px",
           },
           funcNone: {
-            "ui:widget": widget
+            "ui:widget": widget,
           },
 
           // pass widget as string
@@ -115,17 +115,17 @@ describe("uiSchema", () => {
             "ui:widget": {
               component: "widget",
               options: {
-                background: "blue"
-              }
+                background: "blue",
+              },
             },
             "ui:options": {
-              margin: "19px"
+              margin: "19px",
             },
-            "ui:padding": "41px"
+            "ui:padding": "41px",
           },
           stringNone: {
-            "ui:widget": "widget"
-          }
+            "ui:widget": "widget",
+          },
         };
       });
 
@@ -133,7 +133,7 @@ describe("uiSchema", () => {
         createFormComponent({
           schema: { type: "string" },
           uiSchema: { "ui:widget": { component: "widget" } },
-          widgets
+          widgets,
         });
         expect(
           console.warn.calledWithMatch(/ui:widget object is deprecated/)
@@ -145,14 +145,14 @@ describe("uiSchema", () => {
         createFormComponent({
           schema: { type: "string" },
           uiSchema: { "ui:widget": "widget" },
-          widgets
+          widgets,
         });
         const cached = widget.MergedWidget;
         expect(cached).to.be.ok;
         createFormComponent({
           schema: { type: "string" },
           uiSchema: { "ui:widget": "widget" },
-          widgets
+          widgets,
         });
         expect(widget.MergedWidget).to.equal(cached);
       });
@@ -203,15 +203,15 @@ describe("uiSchema", () => {
         type: "object",
         properties: {
           field: {
-            type: "string"
-          }
-        }
+            type: "string",
+          },
+        },
       };
 
       const uiSchema = {
         field: {
-          "ui:widget": "custom"
-        }
+          "ui:widget": "custom",
+        },
       };
 
       const CustomWidget = props => {
@@ -228,7 +228,7 @@ describe("uiSchema", () => {
       };
 
       const widgets = {
-        custom: CustomWidget
+        custom: CustomWidget,
       };
 
       it("should render a nested custom widget", () => {
@@ -243,9 +243,9 @@ describe("uiSchema", () => {
         type: "object",
         properties: {
           field: {
-            type: "string"
-          }
-        }
+            type: "string",
+          },
+        },
       };
 
       const CustomWidget = props => {
@@ -260,9 +260,9 @@ describe("uiSchema", () => {
           field: {
             "ui:widget": CustomWidget,
             "ui:options": {
-              className: "custom"
-            }
-          }
+              className: "custom",
+            },
+          },
         };
 
         it("should render a custom widget with options", () => {
@@ -277,13 +277,13 @@ describe("uiSchema", () => {
           field: {
             "ui:widget": "custom",
             "ui:options": {
-              className: "custom"
-            }
-          }
+              className: "custom",
+            },
+          },
         };
 
         const widgets = {
-          custom: CustomWidget
+          custom: CustomWidget,
         };
 
         it("should render a custom widget with options", () => {
@@ -300,9 +300,9 @@ describe("uiSchema", () => {
         properties: {
           field: {
             type: "string",
-            enum: ["foo", "bar"]
-          }
-        }
+            enum: ["foo", "bar"],
+          },
+        },
       };
 
       const CustomWidget = props => {
@@ -321,9 +321,9 @@ describe("uiSchema", () => {
         field: {
           "ui:widget": CustomWidget,
           "ui:options": {
-            className: "custom"
-          }
-        }
+            className: "custom",
+          },
+        },
       };
 
       it("should merge enumOptions with custom options", () => {
@@ -495,7 +495,7 @@ describe("uiSchema", () => {
           {
             type: "array",
             items: { type: "string", enum: ["foo", "bar"] },
-            uniqueItems: true
+            uniqueItems: true,
           },
           { "ui:widget": "checkboxes", "ui:autofocus": true },
           "input",
@@ -531,16 +531,16 @@ describe("uiSchema", () => {
       type: "object",
       properties: {
         foo: {
-          type: "string"
-        }
-      }
+          type: "string",
+        },
+      },
     };
 
     describe("file", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "file"
-        }
+          "ui:widget": "file",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -554,8 +554,8 @@ describe("uiSchema", () => {
       const uiSchema = {
         foo: {
           "ui:widget": "textarea",
-          "ui:placeholder": "sample"
-        }
+          "ui:placeholder": "sample",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -569,8 +569,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: "a"
-          }
+            foo: "a",
+          },
         });
 
         expect(node.querySelector("textarea").value).eql("a");
@@ -581,12 +581,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: "a"
-          }
+            foo: "a",
+          },
         });
 
         Simulate.change(node.querySelector("textarea"), {
-          target: { value: "b" }
+          target: { value: "b" },
         });
 
         expect(comp.state.formData).eql({ foo: "b" });
@@ -603,8 +603,8 @@ describe("uiSchema", () => {
       const uiSchema = {
         foo: {
           "ui:widget": "password",
-          "ui:placeholder": "sample"
-        }
+          "ui:placeholder": "sample",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -618,8 +618,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: "a"
-          }
+            foo: "a",
+          },
         });
 
         expect(node.querySelector("[type=password]").value).eql("a");
@@ -630,12 +630,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: "a"
-          }
+            foo: "a",
+          },
         });
 
         Simulate.change(node.querySelector("[type=password]"), {
-          target: { value: "b" }
+          target: { value: "b" },
         });
 
         expect(comp.state.formData).eql({ foo: "b" });
@@ -651,8 +651,8 @@ describe("uiSchema", () => {
     describe("color", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "color"
-        }
+          "ui:widget": "color",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -666,8 +666,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: "#151ce6"
-          }
+            foo: "#151ce6",
+          },
         });
 
         expect(node.querySelector("[type=color]").value).eql("#151ce6");
@@ -678,12 +678,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: "#151ce6"
-          }
+            foo: "#151ce6",
+          },
         });
 
         Simulate.change(node.querySelector("[type=color]"), {
-          target: { value: "#001122" }
+          target: { value: "#001122" },
         });
 
         expect(comp.state.formData).eql({ foo: "#001122" });
@@ -693,8 +693,8 @@ describe("uiSchema", () => {
     describe("hidden", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "hidden"
-        }
+          "ui:widget": "hidden",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -708,8 +708,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: "a"
-          }
+            foo: "a",
+          },
         });
 
         expect(node.querySelector("[type=hidden]").value).eql("a");
@@ -720,8 +720,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: "a"
-          }
+            foo: "a",
+          },
         });
 
         expect(comp.state.formData.foo).eql("a");
@@ -735,16 +735,16 @@ describe("uiSchema", () => {
       properties: {
         foo: {
           type: "string",
-          enum: ["a", "b"]
-        }
-      }
+          enum: ["a", "b"],
+        },
+      },
     };
 
     describe("radio", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "radio"
-        }
+          "ui:widget": "radio",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -758,8 +758,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: "b"
-          }
+            foo: "b",
+          },
         });
 
         expect(node.querySelectorAll("[type=radio]")[1].checked).eql(true);
@@ -770,12 +770,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: "a"
-          }
+            foo: "a",
+          },
         });
 
         Simulate.change(node.querySelectorAll("[type=radio]")[1], {
-          target: { checked: true }
+          target: { checked: true },
         });
 
         expect(comp.state.formData).eql({ foo: "b" });
@@ -791,16 +791,16 @@ describe("uiSchema", () => {
           type: "number",
           multipleOf: 1,
           minimum: 10,
-          maximum: 100
-        }
-      }
+          maximum: 100,
+        },
+      },
     };
 
     describe("updown", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "updown"
-        }
+          "ui:widget": "updown",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -814,8 +814,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 3.14
-          }
+            foo: 3.14,
+          },
         });
 
         expect(node.querySelector("[type=number]").value).eql("3.14");
@@ -826,12 +826,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 3.14
-          }
+            foo: 3.14,
+          },
         });
 
         Simulate.change(node.querySelector("[type=number]"), {
-          target: { value: "6.28" }
+          target: { value: "6.28" },
         });
 
         expect(comp.state.formData).eql({ foo: 6.28 });
@@ -857,7 +857,7 @@ describe("uiSchema", () => {
           const schema = {
             type: "number",
             minimum: 0,
-            maximum: 0
+            maximum: 0,
           };
           const uiSchema = { "ui:widget": "updown" };
           const { node } = createFormComponent({ schema, uiSchema });
@@ -876,8 +876,8 @@ describe("uiSchema", () => {
     describe("range", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "range"
-        }
+          "ui:widget": "range",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -891,8 +891,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 3.14
-          }
+            foo: 3.14,
+          },
         });
 
         expect(node.querySelector("[type=range]").value).eql("3.14");
@@ -903,12 +903,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 3.14
-          }
+            foo: 3.14,
+          },
         });
 
         Simulate.change(node.querySelector("[type=range]"), {
-          target: { value: "6.28" }
+          target: { value: "6.28" },
         });
 
         expect(comp.state.formData).eql({ foo: 6.28 });
@@ -934,7 +934,7 @@ describe("uiSchema", () => {
           const schema = {
             type: "number",
             minimum: 0,
-            maximum: 0
+            maximum: 0,
           };
           const uiSchema = { "ui:widget": "range" };
           const { node } = createFormComponent({ schema, uiSchema });
@@ -956,15 +956,15 @@ describe("uiSchema", () => {
         properties: {
           foo: {
             type: "number",
-            enum: [3.14159, 2.718, 1.4142]
-          }
-        }
+            enum: [3.14159, 2.718, 1.4142],
+          },
+        },
       };
 
       const uiSchema = {
         foo: {
-          "ui:widget": "radio"
-        }
+          "ui:widget": "radio",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -978,8 +978,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 2.718
-          }
+            foo: 2.718,
+          },
         });
 
         expect(node.querySelectorAll("[type=radio]")[1].checked).eql(true);
@@ -990,12 +990,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 1.4142
-          }
+            foo: 1.4142,
+          },
         });
 
         Simulate.change(node.querySelectorAll("[type=radio]")[2], {
-          target: { checked: true }
+          target: { checked: true },
         });
 
         expect(comp.state.formData).eql({ foo: 1.4142 });
@@ -1005,8 +1005,8 @@ describe("uiSchema", () => {
     describe("hidden", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "hidden"
-        }
+          "ui:widget": "hidden",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -1020,8 +1020,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 42
-          }
+            foo: 42,
+          },
         });
 
         expect(node.querySelector("[type=hidden]").value).eql("42");
@@ -1032,8 +1032,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 42
-          }
+            foo: 42,
+          },
         });
 
         expect(comp.state.formData.foo).eql(42);
@@ -1046,16 +1046,16 @@ describe("uiSchema", () => {
       type: "object",
       properties: {
         foo: {
-          type: "integer"
-        }
-      }
+          type: "integer",
+        },
+      },
     };
 
     describe("updown", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "updown"
-        }
+          "ui:widget": "updown",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -1069,8 +1069,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 3
-          }
+            foo: 3,
+          },
         });
 
         expect(node.querySelector("[type=number]").value).eql("3");
@@ -1081,12 +1081,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 3
-          }
+            foo: 3,
+          },
         });
 
         Simulate.change(node.querySelector("[type=number]"), {
-          target: { value: "6" }
+          target: { value: "6" },
         });
 
         expect(comp.state.formData).eql({ foo: 6 });
@@ -1096,8 +1096,8 @@ describe("uiSchema", () => {
     describe("range", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "range"
-        }
+          "ui:widget": "range",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -1111,8 +1111,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 3
-          }
+            foo: 3,
+          },
         });
 
         expect(node.querySelector("[type=range]").value).eql("3");
@@ -1123,12 +1123,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 3
-          }
+            foo: 3,
+          },
         });
 
         Simulate.change(node.querySelector("[type=range]"), {
-          target: { value: "6" }
+          target: { value: "6" },
         });
 
         expect(comp.state.formData).eql({ foo: 6 });
@@ -1141,15 +1141,15 @@ describe("uiSchema", () => {
         properties: {
           foo: {
             type: "integer",
-            enum: [1, 2]
-          }
-        }
+            enum: [1, 2],
+          },
+        },
       };
 
       const uiSchema = {
         foo: {
-          "ui:widget": "radio"
-        }
+          "ui:widget": "radio",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -1163,8 +1163,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 2
-          }
+            foo: 2,
+          },
         });
 
         expect(node.querySelectorAll("[type=radio]")[1].checked).eql(true);
@@ -1175,12 +1175,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 1
-          }
+            foo: 1,
+          },
         });
 
         Simulate.change(node.querySelectorAll("[type=radio]")[1], {
-          target: { checked: true }
+          target: { checked: true },
         });
 
         expect(comp.state.formData).eql({ foo: 2 });
@@ -1190,8 +1190,8 @@ describe("uiSchema", () => {
     describe("hidden", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "hidden"
-        }
+          "ui:widget": "hidden",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -1205,8 +1205,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 42
-          }
+            foo: 42,
+          },
         });
 
         expect(node.querySelector("[type=hidden]").value).eql("42");
@@ -1217,8 +1217,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: 42
-          }
+            foo: 42,
+          },
         });
 
         expect(comp.state.formData.foo).eql(42);
@@ -1231,16 +1231,16 @@ describe("uiSchema", () => {
       type: "object",
       properties: {
         foo: {
-          type: "boolean"
-        }
-      }
+          type: "boolean",
+        },
+      },
     };
 
     describe("radio", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "radio"
-        }
+          "ui:widget": "radio",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -1266,8 +1266,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: false
-          }
+            foo: false,
+          },
         });
 
         expect(node.querySelectorAll("[type=radio]")[1].checked).eql(true);
@@ -1278,12 +1278,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: true
-          }
+            foo: true,
+          },
         });
 
         Simulate.change(node.querySelectorAll("[type=radio]")[1], {
-          target: { checked: true }
+          target: { checked: true },
         });
 
         expect(comp.state.formData).eql({ foo: false });
@@ -1294,12 +1294,12 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: false
-          }
+            foo: false,
+          },
         });
 
         Simulate.change(node.querySelectorAll("[type=radio]")[0], {
-          target: { checked: true }
+          target: { checked: true },
         });
 
         expect(comp.state.formData).eql({ foo: true });
@@ -1309,8 +1309,8 @@ describe("uiSchema", () => {
     describe("select", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "select"
-        }
+          "ui:widget": "select",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -1331,13 +1331,13 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: false
-          }
+            foo: false,
+          },
         });
 
         Simulate.change(node.querySelector("select"), {
           // DOM option change events always return strings
-          target: { value: "true" }
+          target: { value: "true" },
         });
 
         expect(comp.state.formData).eql({ foo: true });
@@ -1348,13 +1348,13 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: false
-          }
+            foo: false,
+          },
         });
 
         Simulate.change(node.querySelector("select"), {
           // DOM option change events always return strings
-          target: { value: "false" }
+          target: { value: "false" },
         });
 
         expect(comp.state.formData).eql({ foo: false });
@@ -1364,8 +1364,8 @@ describe("uiSchema", () => {
     describe("hidden", () => {
       const uiSchema = {
         foo: {
-          "ui:widget": "hidden"
-        }
+          "ui:widget": "hidden",
+        },
       };
 
       it("should accept a uiSchema object", () => {
@@ -1379,8 +1379,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: true
-          }
+            foo: true,
+          },
         });
 
         expect(node.querySelector("[type=hidden]").value).eql("true");
@@ -1391,8 +1391,8 @@ describe("uiSchema", () => {
           schema,
           uiSchema,
           formData: {
-            foo: true
-          }
+            foo: true,
+          },
         });
 
         expect(comp.state.formData.foo).eql(true);
@@ -1406,8 +1406,8 @@ describe("uiSchema", () => {
         type: "object",
         properties: {
           foo: { type: "string" },
-          bar: { type: "string" }
-        }
+          bar: { type: "string" },
+        },
       };
       const uiSchema = { "ui:rootFieldId": "myform" };
       const { node } = createFormComponent({ schema, uiSchema });
@@ -1422,13 +1422,13 @@ describe("uiSchema", () => {
     it("should use a custom root field id for arrays", () => {
       const schema = {
         type: "array",
-        items: { type: "string" }
+        items: { type: "string" },
       };
       const uiSchema = { "ui:rootFieldId": "myform" };
       const { node } = createFormComponent({
         schema,
         uiSchema,
-        formData: ["foo", "bar"]
+        formData: ["foo", "bar"],
       });
 
       const ids = [].map.call(
@@ -1445,15 +1445,15 @@ describe("uiSchema", () => {
           type: "object",
           properties: {
             foo: { type: "string" },
-            bar: { type: "string" }
-          }
-        }
+            bar: { type: "string" },
+          },
+        },
       };
       const uiSchema = { "ui:rootFieldId": "myform" };
       const { node } = createFormComponent({
         schema,
         uiSchema,
-        formData: [{ foo: "foo1", bar: "bar1" }, { foo: "foo2", bar: "bar2" }]
+        formData: [{ foo: "foo1", bar: "bar1" }, { foo: "foo2", bar: "bar2" }],
       });
 
       const ids = [].map.call(
@@ -1464,7 +1464,7 @@ describe("uiSchema", () => {
         "myform_0_foo",
         "myform_0_bar",
         "myform_1_foo",
-        "myform_1_bar"
+        "myform_1_bar",
       ]);
     });
   });
@@ -1510,8 +1510,8 @@ describe("uiSchema", () => {
             type: "object",
             properties: {
               foo: { type: "string" },
-              bar: { type: "string" }
-            }
+              bar: { type: "string" },
+            },
           };
           const uiSchema = { "ui:disabled": true };
 
@@ -1546,7 +1546,7 @@ describe("uiSchema", () => {
       it("should disabled a file widget", () => {
         const { node } = createFormComponent({
           schema: { type: "string", format: "data-url" },
-          uiSchema: { "ui:disabled": true }
+          uiSchema: { "ui:disabled": true },
         });
         expect(
           node.querySelector("input[type=file]").hasAttribute("disabled")
@@ -1652,7 +1652,7 @@ describe("uiSchema", () => {
       it("should disable an alternative date widget", () => {
         const { node } = createFormComponent({
           schema: { type: "string", format: "date" },
-          uiSchema: { "ui:disabled": true, "ui:widget": "alt-date" }
+          uiSchema: { "ui:disabled": true, "ui:widget": "alt-date" },
         });
 
         const disabled = [].map.call(
@@ -1665,7 +1665,7 @@ describe("uiSchema", () => {
       it("should disable an alternative datetime widget", () => {
         const { node } = createFormComponent({
           schema: { type: "string", format: "date-time" },
-          uiSchema: { "ui:disabled": true, "ui:widget": "alt-datetime" }
+          uiSchema: { "ui:disabled": true, "ui:widget": "alt-datetime" },
         });
 
         const disabled = [].map.call(
@@ -1718,8 +1718,8 @@ describe("uiSchema", () => {
             type: "object",
             properties: {
               foo: { type: "string" },
-              bar: { type: "string" }
-            }
+              bar: { type: "string" },
+            },
           };
           const uiSchema = { "ui:readonly": true };
 
@@ -1755,7 +1755,7 @@ describe("uiSchema", () => {
         // We mark a file widget as readonly by disabling it.
         const { node } = createFormComponent({
           schema: { type: "string", format: "data-url" },
-          uiSchema: { "ui:readonly": true }
+          uiSchema: { "ui:readonly": true },
         });
         expect(
           node.querySelector("input[type=file]").hasAttribute("disabled")
@@ -1853,7 +1853,7 @@ describe("uiSchema", () => {
       it("should mark as readonly an alternative date widget", () => {
         const { node } = createFormComponent({
           schema: { type: "string", format: "date" },
-          uiSchema: { "ui:readonly": true, "ui:widget": "alt-date" }
+          uiSchema: { "ui:readonly": true, "ui:widget": "alt-date" },
         });
 
         const readonly = [].map.call(node.querySelectorAll("select"), node =>
@@ -1864,7 +1864,7 @@ describe("uiSchema", () => {
       it("should mark as readonly an alternative datetime widget", () => {
         const { node } = createFormComponent({
           schema: { type: "string", format: "date-time" },
-          uiSchema: { "ui:readonly": true, "ui:widget": "alt-datetime" }
+          uiSchema: { "ui:readonly": true, "ui:widget": "alt-datetime" },
         });
 
         const readonly = [].map.call(node.querySelectorAll("select"), node =>

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -12,7 +12,7 @@ import {
   retrieveSchema,
   shouldRender,
   toDateString,
-  toIdSchema
+  toIdSchema,
 } from "../src/utils";
 
 describe("utils", () => {
@@ -22,7 +22,7 @@ describe("utils", () => {
         expect(
           getDefaultFormState({
             type: "string",
-            default: "foo"
+            default: "foo",
           })
         ).to.eql("foo");
       });
@@ -36,9 +36,9 @@ describe("utils", () => {
             properties: {
               string: {
                 type: "string",
-                default: "foo"
-              }
-            }
+                default: "foo",
+              },
+            },
           })
         ).to.eql({ string: "foo" });
       });
@@ -53,11 +53,11 @@ describe("utils", () => {
                 properties: {
                   string: {
                     type: "string",
-                    default: "foo"
-                  }
-                }
-              }
-            }
+                    default: "foo",
+                  },
+                },
+              },
+            },
           })
         ).to.eql({ object: { string: "foo" } });
       });
@@ -71,10 +71,10 @@ describe("utils", () => {
                 type: "array",
                 default: ["foo", "bar"],
                 items: {
-                  type: "string"
-                }
-              }
-            }
+                  type: "string",
+                },
+              },
+            },
           })
         ).to.eql({ array: ["foo", "bar"] });
       });
@@ -91,12 +91,12 @@ describe("utils", () => {
                     type: "array",
                     default: ["foo", "bar"],
                     items: {
-                      type: "string"
-                    }
-                  }
-                }
-              }
-            }
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            },
           })
         ).to.eql({ object: { array: ["foo", "bar"] } });
       });
@@ -112,19 +112,19 @@ describe("utils", () => {
                   type: "array",
                   default: ["foo", "bar"],
                   items: {
-                    type: "string"
-                  }
+                    type: "string",
+                  },
                 },
                 bool: {
                   type: "boolean",
-                  default: true
-                }
-              }
-            }
-          }
+                  default: true,
+                },
+              },
+            },
+          },
         };
         expect(getDefaultFormState(schema, {})).eql({
-          object: { array: ["foo", "bar"], bool: true }
+          object: { array: ["foo", "bar"], bool: true },
         });
       });
 
@@ -141,23 +141,23 @@ describe("utils", () => {
                   default: {
                     // No level2 default for leaf1
                     leaf2: 2,
-                    leaf3: 2
+                    leaf3: 2,
                   },
                   properties: {
                     leaf1: { type: "number" }, // No level2 default for leaf1
                     leaf2: { type: "number" }, // No level3 default for leaf2
                     leaf3: { type: "number", default: 3 },
-                    leaf4: { type: "number" } // Defined in formData.
-                  }
-                }
-              }
-            }
-          }
+                    leaf4: { type: "number" }, // Defined in formData.
+                  },
+                },
+              },
+            },
+          },
         };
         expect(
           getDefaultFormState(schema, { level1: { level2: { leaf4: 4 } } })
         ).eql({
-          level1: { level2: { leaf1: 1, leaf2: 2, leaf3: 3, leaf4: 4 } }
+          level1: { level2: { leaf1: 1, leaf2: 2, leaf3: 3, leaf4: 4 } },
         });
       });
 
@@ -168,9 +168,9 @@ describe("utils", () => {
             level1: {
               type: "array",
               default: [1, 2, 3],
-              items: { type: "number" }
-            }
-          }
+              items: { type: "number" },
+            },
+          },
         };
         expect(getDefaultFormState(schema, {})).eql({ level1: [1, 2, 3] });
       });
@@ -182,9 +182,9 @@ describe("utils", () => {
           properties: {
             level1: {
               type: "array",
-              items: { type: "number" }
-            }
-          }
+              items: { type: "number" },
+            },
+          },
         };
         expect(getDefaultFormState(schema, {})).eql({ level1: [1, 2, 3] });
       });
@@ -198,17 +198,17 @@ describe("utils", () => {
               items: [
                 {
                   type: "string",
-                  default: "foo"
+                  default: "foo",
                 },
                 {
-                  type: "number"
-                }
-              ]
-            }
-          }
+                  type: "number",
+                },
+              ],
+            },
+          },
         };
         expect(getDefaultFormState(schema, {})).eql({
-          array: ["foo", undefined]
+          array: ["foo", undefined],
         });
       });
 
@@ -218,16 +218,16 @@ describe("utils", () => {
             testdef: {
               type: "object",
               properties: {
-                foo: { type: "number" }
-              }
-            }
+                foo: { type: "number" },
+              },
+            },
           },
           $ref: "#/definitions/testdef",
-          default: { foo: 42 }
+          default: { foo: 42 },
         };
 
         expect(getDefaultFormState(schema, undefined, schema.definitions)).eql({
-          foo: 42
+          foo: 42,
         });
       });
     });
@@ -298,18 +298,18 @@ describe("utils", () => {
         b: {
           c: 3,
           d: [1, 2, 3],
-          e: { f: { g: 1 } }
+          e: { f: { g: 1 } },
         },
-        c: 2
+        c: 2,
       };
       const obj2 = {
         a: 1,
         b: {
           d: [3, 2, 1],
           e: { f: { h: 2 } },
-          g: 1
+          g: 1,
         },
-        c: 3
+        c: 3,
       };
       const expected = {
         a: 1,
@@ -317,9 +317,9 @@ describe("utils", () => {
           c: 3,
           d: [3, 2, 1],
           e: { f: { g: 1, h: 2 } },
-          g: 1
+          g: 1,
         },
-        c: 3
+        c: 3,
       };
       expect(mergeObjects(obj1, obj2)).eql(expected);
     });
@@ -356,9 +356,9 @@ describe("utils", () => {
         properties: {
           street_address: { type: "string" },
           city: { type: "string" },
-          state: { type: "string" }
+          state: { type: "string" },
         },
-        required: ["street_address", "city", "state"]
+        required: ["street_address", "city", "state"],
       };
       const definitions = { address };
 
@@ -368,17 +368,17 @@ describe("utils", () => {
     it("should priorize local definitions over foreign ones", () => {
       const schema = {
         $ref: "#/definitions/address",
-        title: "foo"
+        title: "foo",
       };
       const address = {
         type: "string",
-        title: "bar"
+        title: "bar",
       };
       const definitions = { address };
 
       expect(retrieveSchema(schema, definitions)).eql({
         ...address,
-        title: "foo"
+        title: "foo",
       });
     });
   });
@@ -414,7 +414,7 @@ describe("utils", () => {
     describe("nested levels comparison checks", () => {
       const initial = {
         props: { myProp: { mySubProp: 1 } },
-        state: { myState: { mySubState: 1 } }
+        state: { myState: { mySubState: 1 } },
       };
 
       it("should detect equivalent props and state", () => {
@@ -453,7 +453,7 @@ describe("utils", () => {
           shouldRender(
             {
               props: { myProp: { mySubProp: fn } },
-              state: { myState: { mySubState: fn } }
+              state: { myState: { mySubState: fn } },
             },
             { myProp: { mySubProp: fn } },
             { myState: { mySubState: fn } }
@@ -477,18 +477,18 @@ describe("utils", () => {
           level1: {
             type: "object",
             properties: {
-              level2: { type: "string" }
-            }
-          }
-        }
+              level2: { type: "string" },
+            },
+          },
+        },
       };
 
       expect(toIdSchema(schema)).eql({
         $id: "root",
         level1: {
           $id: "root_level1",
-          level2: { $id: "root_level1_level2" }
-        }
+          level2: { $id: "root_level1_level2" },
+        },
       });
     });
 
@@ -500,17 +500,17 @@ describe("utils", () => {
             type: "object",
             properties: {
               level1a2a: { type: "string" },
-              level1a2b: { type: "string" }
-            }
+              level1a2b: { type: "string" },
+            },
           },
           level1b: {
             type: "object",
             properties: {
               level1b2a: { type: "string" },
-              level1b2b: { type: "string" }
-            }
-          }
-        }
+              level1b2b: { type: "string" },
+            },
+          },
+        },
       };
 
       expect(toIdSchema(schema)).eql({
@@ -518,13 +518,13 @@ describe("utils", () => {
         level1a: {
           $id: "root_level1a",
           level1a2a: { $id: "root_level1a_level1a2a" },
-          level1a2b: { $id: "root_level1a_level1a2b" }
+          level1a2b: { $id: "root_level1a_level1a2b" },
         },
         level1b: {
           $id: "root_level1b",
           level1b2a: { $id: "root_level1b_level1b2a" },
-          level1b2b: { $id: "root_level1b_level1b2b" }
-        }
+          level1b2b: { $id: "root_level1b_level1b2b" },
+        },
       });
     });
 
@@ -536,19 +536,19 @@ describe("utils", () => {
             type: "object",
             properties: {
               id: {
-                type: "string"
-              }
+                type: "string",
+              },
             },
-            required: ["id"]
-          }
-        }
+            required: ["id"],
+          },
+        },
       };
       expect(toIdSchema(schema)).eql({
         $id: "root",
         metadata: {
           $id: "root_metadata",
-          id: { $id: "root_metadata_id" }
-        }
+          id: { $id: "root_metadata_id" },
+        },
       });
     });
 
@@ -558,14 +558,14 @@ describe("utils", () => {
         items: {
           type: "object",
           properties: {
-            foo: { type: "string" }
-          }
-        }
+            foo: { type: "string" },
+          },
+        },
       };
 
       expect(toIdSchema(schema)).eql({
         $id: "root",
-        foo: { $id: "root_foo" }
+        foo: { $id: "root_foo" },
       });
     });
 
@@ -576,17 +576,17 @@ describe("utils", () => {
             type: "object",
             properties: {
               foo: { type: "string" },
-              bar: { type: "string" }
-            }
-          }
+              bar: { type: "string" },
+            },
+          },
         },
-        $ref: "#/definitions/testdef"
+        $ref: "#/definitions/testdef",
       };
 
       expect(toIdSchema(schema, undefined, schema.definitions)).eql({
         $id: "root",
         foo: { $id: "root_foo" },
-        bar: { $id: "root_bar" }
+        bar: { $id: "root_bar" },
       });
     });
   });
@@ -603,7 +603,7 @@ describe("utils", () => {
         day: -1,
         hour: -1,
         minute: -1,
-        second: -1
+        second: -1,
       });
     });
 
@@ -614,7 +614,7 @@ describe("utils", () => {
         day: -1,
         hour: 0,
         minute: 0,
-        second: 0
+        second: 0,
       });
     });
 
@@ -625,7 +625,7 @@ describe("utils", () => {
         day: 5,
         hour: 14,
         minute: 1,
-        second: 30
+        second: 30,
       });
     });
 
@@ -636,7 +636,7 @@ describe("utils", () => {
         day: 5,
         hour: 0,
         minute: 0,
-        second: 0
+        second: 0,
       });
     });
   });
@@ -650,7 +650,7 @@ describe("utils", () => {
           day: 5,
           hour: 14,
           minute: 1,
-          second: 30
+          second: 30,
         })
       ).eql("2016-04-05T14:01:30.000Z");
     });
@@ -661,7 +661,7 @@ describe("utils", () => {
           {
             year: 2016,
             month: 4,
-            day: 5
+            day: 5,
           },
           false
         )

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -13,8 +13,8 @@ describe("Validation", () => {
         type: "object",
         properties: {
           foo: { type: "string" },
-          [illFormedKey]: { type: "string" }
-        }
+          [illFormedKey]: { type: "string" },
+        },
       };
 
       let errors, errorSchema;
@@ -52,8 +52,8 @@ describe("Validation", () => {
         required: ["pass1", "pass2"],
         properties: {
           pass1: { type: "string" },
-          pass2: { type: "string" }
-        }
+          pass2: { type: "string" },
+        },
       };
 
       beforeEach(() => {
@@ -87,19 +87,19 @@ describe("Validation", () => {
             __errors: ["err1", "err2"],
             a: {
               b: {
-                __errors: ["err3", "err4"]
-              }
+                __errors: ["err3", "err4"],
+              },
             },
             c: {
-              __errors: ["err5"]
-            }
+              __errors: ["err5"],
+            },
           })
         ).eql([
           { stack: "root: err1" },
           { stack: "root: err2" },
           { stack: "b: err3" },
           { stack: "b: err4" },
-          { stack: "c: err5" }
+          { stack: "c: err5" },
         ]);
       });
     });
@@ -110,8 +110,8 @@ describe("Validation", () => {
         type: "object",
         properties: {
           foo: { type: "string" },
-          [illFormedKey]: { type: "string" }
-        }
+          [illFormedKey]: { type: "string" },
+        },
       };
       const newErrorMessage = "Better error message";
       const transformErrors = errors => {
@@ -155,8 +155,8 @@ describe("Validation", () => {
           required: ["foo"],
           properties: {
             foo: { type: "string" },
-            bar: { type: "string" }
-          }
+            bar: { type: "string" },
+          },
         };
 
         var comp, node, onError;
@@ -166,9 +166,9 @@ describe("Validation", () => {
           const compInfo = createFormComponent({
             schema,
             formData: {
-              foo: undefined
+              foo: undefined,
             },
-            onError
+            onError,
           });
           comp = compInfo.comp;
           node = compInfo.node;
@@ -205,9 +205,9 @@ describe("Validation", () => {
           properties: {
             foo: {
               type: "string",
-              minLength: 10
-            }
-          }
+              minLength: 10,
+            },
+          },
         };
 
         var comp, node, onError;
@@ -217,9 +217,9 @@ describe("Validation", () => {
           const compInfo = createFormComponent({
             schema,
             formData: {
-              foo: "123456789"
+              foo: "123456789",
             },
-            onError
+            onError,
           });
           comp = compInfo.comp;
           node = compInfo.node;
@@ -267,12 +267,12 @@ describe("Validation", () => {
         const { comp } = createFormComponent({
           schema,
           validate,
-          liveValidate: true
+          liveValidate: true,
         });
         comp.componentWillReceiveProps({ formData });
 
         expect(comp.state.errorSchema).eql({
-          __errors: ["Invalid"]
+          __errors: ["Invalid"],
         });
       });
 
@@ -292,7 +292,7 @@ describe("Validation", () => {
           schema,
           formData,
           validate,
-          onSubmit
+          onSubmit,
         });
 
         Simulate.submit(node);
@@ -318,7 +318,7 @@ describe("Validation", () => {
           formData,
           validate,
           onSubmit,
-          onError
+          onError,
         });
 
         Simulate.submit(node);
@@ -332,8 +332,8 @@ describe("Validation", () => {
           type: "object",
           properties: {
             pass1: { type: "string", minLength: 3 },
-            pass2: { type: "string", minLength: 3 }
-          }
+            pass2: { type: "string", minLength: 3 },
+          },
         };
 
         const formData = { pass1: "aaa", pass2: "b" };
@@ -349,21 +349,21 @@ describe("Validation", () => {
         const { comp } = createFormComponent({
           schema,
           validate,
-          liveValidate: true
+          liveValidate: true,
         });
         comp.componentWillReceiveProps({ formData });
 
         expect(comp.state.errorSchema).eql({
           __errors: [],
           pass1: {
-            __errors: []
+            __errors: [],
           },
           pass2: {
             __errors: [
               "does not meet minimum length of 3",
-              "Passwords don't match"
-            ]
-          }
+              "Passwords don't match",
+            ],
+          },
         });
       });
 
@@ -371,8 +371,8 @@ describe("Validation", () => {
         const schema = {
           type: "array",
           items: {
-            type: "string"
-          }
+            type: "string",
+          },
         };
 
         const formData = ["aaa", "bbb", "ccc"];
@@ -387,12 +387,12 @@ describe("Validation", () => {
         const { comp } = createFormComponent({
           schema,
           validate,
-          liveValidate: true
+          liveValidate: true,
         });
         comp.componentWillReceiveProps({ formData });
 
         expect(comp.state.errorSchema).eql({
-          __errors: ["Forbidden value: bbb"]
+          __errors: ["Forbidden value: bbb"],
         });
       });
     });
@@ -404,8 +404,8 @@ describe("Validation", () => {
           required: ["foo"],
           properties: {
             foo: { type: "string" },
-            bar: { type: "string" }
-          }
+            bar: { type: "string" },
+          },
         };
 
         var comp, node, onError;
@@ -415,10 +415,10 @@ describe("Validation", () => {
           const compInfo = createFormComponent({
             schema,
             formData: {
-              foo: undefined
+              foo: undefined,
             },
             onError,
-            showErrorList: false
+            showErrorList: false,
           });
           comp = compInfo.comp;
           node = compInfo.node;


### PR DESCRIPTION
- Activate a [git precommit hook](https://github.com/prettier/prettier#pre-commit-hook-for-changed-files) for linting and formatting code against prettier coding style. That way nobody is forced to run the `cs-format` command manually before pushing changes, and/or to configure text editors appropriately.
- Also updated prettier options to use es5 trailing commas.