### PR TITLE
removing content from text field result in empty string instead of undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -1294,7 +1294,7 @@ render((
 
 ### The case of empty strings
 
-When a text input is empty, the field in form data is set to `undefined`. String fields that use `enum` and a `select` widget work similarly and will have an empty option at the top of the options list that when selected will result in the field being `undefined`.
+When a text input is empty, the field in form data is set to empty string. String fields that use `enum` and a `select` widget will have an empty option at the top of the options list that when selected will result in the field being `undefined`.
 
 One consequence of this is that if you have an empty string in your `enum` array, selecting that option in the `select` input will cause the field to be set to `undefined`, not an empty string.
 

--- a/README.md
+++ b/README.md
@@ -1294,9 +1294,11 @@ render((
 
 ### The case of empty strings
 
-When a text input is empty, the field in form data is set to empty string. String fields that use `enum` and a `select` widget will have an empty option at the top of the options list that when selected will result in the field being `undefined`.
+When a text input is empty, the field in form data is set to `undefined`. String fields that use `enum` and a `select` widget will have an empty option at the top of the options list that when selected will result in the field being `undefined`.
 
 One consequence of this is that if you have an empty string in your `enum` array, selecting that option in the `select` input will cause the field to be set to `undefined`, not an empty string.
+
+If you want to have the field set to a default value when empty you can provide a `ui:emptyValue` field in the `uiSchema` object.
 
 ## Styling your forms
 

--- a/playground/samples/arrays.js
+++ b/playground/samples/arrays.js
@@ -117,6 +117,9 @@ module.exports = {
     },
   },
   uiSchema: {
+    listOfStrings: {
+      items: { "ui:defaultValue": "" },
+    },
     multipleChoicesList: {
       "ui:widget": "checkboxes",
     },

--- a/playground/samples/arrays.js
+++ b/playground/samples/arrays.js
@@ -118,7 +118,7 @@ module.exports = {
   },
   uiSchema: {
     listOfStrings: {
-      items: { "ui:defaultValue": "" },
+      items: { "ui:emptyValue": "" },
     },
     multipleChoicesList: {
       "ui:widget": "checkboxes",

--- a/playground/samples/simple.js
+++ b/playground/samples/simple.js
@@ -31,7 +31,7 @@ module.exports = {
   uiSchema: {
     firstName: {
       "ui:autofocus": true,
-      "ui:defaultValue": "",
+      "ui:emptyValue": "",
     },
     age: {
       "ui:widget": "updown",

--- a/playground/samples/simple.js
+++ b/playground/samples/simple.js
@@ -31,6 +31,7 @@ module.exports = {
   uiSchema: {
     firstName: {
       "ui:autofocus": true,
+      "ui:defaultValue": "",
     },
     age: {
       "ui:widget": "updown",

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -16,7 +16,7 @@ function BaseInput(props) {
     ...inputProps
   } = props;
   const _onChange = ({ target: { value } }) => {
-    return props.onChange(value);
+    return props.onChange(value === "" ? options.defaultValue : value);
   };
   return (
     <input

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -16,7 +16,7 @@ function BaseInput(props) {
     ...inputProps
   } = props;
   const _onChange = ({ target: { value } }) => {
-    return props.onChange(value === "" ? undefined : value);
+    return props.onChange(value);
   };
   return (
     <input

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -16,7 +16,7 @@ function BaseInput(props) {
     ...inputProps
   } = props;
   const _onChange = ({ target: { value } }) => {
-    return props.onChange(value === "" ? options.defaultValue : value);
+    return props.onChange(value === "" ? options.emptyValue : value);
   };
   return (
     <input

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -14,7 +14,7 @@ function TextareaWidget(props) {
     onBlur,
   } = props;
   const _onChange = ({ target: { value } }) => {
-    return onChange(value === "" ? options.defaultValue : value);
+    return onChange(value === "" ? options.emptyValue : value);
   };
   return (
     <textarea

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -14,7 +14,7 @@ function TextareaWidget(props) {
     onBlur,
   } = props;
   const _onChange = ({ target: { value } }) => {
-    return onChange(value === "" ? undefined : value);
+    return onChange(value === "" ? options.defaultValue : value);
   };
   return (
     <textarea

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -110,7 +110,21 @@ describe("StringField", () => {
         target: { value: "" },
       });
 
-      expect(comp.state.formData).eql("");
+      expect(comp.state.formData).eql(undefined);
+    });
+
+    it("should handle an empty string change event with custom ui:defaultValue", () => {
+      const { comp, node } = createFormComponent({
+        schema: { type: "string" },
+        uiSchema: { "ui:defaultValue": "default" },
+        formData: "x",
+      });
+
+      Simulate.change(node.querySelector("input"), {
+        target: { value: "" },
+      });
+
+      expect(comp.state.formData).eql("default");
     });
 
     it("should fill field with data", () => {
@@ -323,6 +337,20 @@ describe("StringField", () => {
       });
 
       expect(comp.state.formData).eql(undefined);
+    });
+
+    it("should handle an empty string change event with custom ui:defaultValue", () => {
+      const { comp, node } = createFormComponent({
+        schema: { type: "string" },
+        uiSchema: { "ui:widget": "textarea", "ui:defaultValue": "default" },
+        formData: "x",
+      });
+
+      Simulate.change(node.querySelector("textarea"), {
+        target: { value: "" },
+      });
+
+      expect(comp.state.formData).eql("default");
     });
 
     it("should render a textarea field with rows", () => {

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -110,7 +110,7 @@ describe("StringField", () => {
         target: { value: "" },
       });
 
-      expect(comp.state.formData).eql(undefined);
+      expect(comp.state.formData).eql("");
     });
 
     it("should fill field with data", () => {

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -116,7 +116,7 @@ describe("StringField", () => {
     it("should handle an empty string change event with custom ui:defaultValue", () => {
       const { comp, node } = createFormComponent({
         schema: { type: "string" },
-        uiSchema: { "ui:defaultValue": "default" },
+        uiSchema: { "ui:emptyValue": "default" },
         formData: "x",
       });
 
@@ -342,7 +342,7 @@ describe("StringField", () => {
     it("should handle an empty string change event with custom ui:defaultValue", () => {
       const { comp, node } = createFormComponent({
         schema: { type: "string" },
-        uiSchema: { "ui:widget": "textarea", "ui:defaultValue": "default" },
+        uiSchema: { "ui:widget": "textarea", "ui:emptyValue": "default" },
         formData: "x",
       });
 


### PR DESCRIPTION
### Reasons for making this change
As mentioned here before https://github.com/mozilla-services/react-jsonschema-form/pull/476#issuecomment-292175013
The new way of handling empty text fields (setting them to undefined) is undesirable as most of the time we want to keep an empty value.
If we want to delete a field we can do so after the form validation by for emptiness and delete accordingly.

Behavior change:
- sets text field to `""` instead of undefined when you remove everything inside it 

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style

Please take in consideration that I'm fairly new to the repo and might have underestimated the change, I'd like your input if that's the case!

Quentin