### PR TITLE
Make the base input widget customizable.

### DIFF
--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -20,12 +20,12 @@ function BaseInput(props) {
   };
   return (
     <input
-      {...inputProps}
       className="form-control"
       readOnly={readonly}
       disabled={disabled}
       autoFocus={autofocus}
       value={value == null ? "" : value}
+      {...inputProps}
       onChange={_onChange}
       onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}
     />


### PR DESCRIPTION
Make it possible to extends the BaseInput widget and override some of its
props (e.g., "className")

resolves #546
