### PR TITLE
add prop-types package and add respective imports b/c it was deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "mocha": "^2.5.3",
     "prettier": "^1.0.0",
     "prettier-check": "^1.0.0",
+    "prop-types": "^15.5.8",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.3.2",
     "react-codemirror": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "prettier": "^1.0.0",
     "prettier-check": "^1.0.0",
     "prop-types": "^15.5.8",
-    "react": "^15.0.0",
+    "react": "^15.5.0",
     "react-addons-test-utils": "^15.3.2",
     "react-codemirror": "^0.2.3",
     "react-dom": "^15.3.2",

--- a/playground/app.js
+++ b/playground/app.js
@@ -292,7 +292,7 @@ class CopyLink extends Component {
       <div className="input-group">
         <input
           type="text"
-          ref={input => this.input = input}
+          ref={input => (this.input = input)}
           className="form-control"
           defaultValue={shareURL}
         />

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import {
   getWidget,

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import {
   getWidget,

--- a/src/components/fields/DescriptionField.js
+++ b/src/components/fields/DescriptionField.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 function DescriptionField(props) {
   const { id, description } = props;

--- a/src/components/fields/DescriptionField.js
+++ b/src/components/fields/DescriptionField.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 function DescriptionField(props) {
   const { id, description } = props;

--- a/src/components/fields/NumberField.js
+++ b/src/components/fields/NumberField.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import { asNumber } from "../../utils";
 

--- a/src/components/fields/NumberField.js
+++ b/src/components/fields/NumberField.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import { asNumber } from "../../utils";
 

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import {
   isMultiSelect,

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import {
   isMultiSelect,

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import {
   getWidget,

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import {
   getWidget,

--- a/src/components/fields/TitleField.js
+++ b/src/components/fields/TitleField.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 const REQUIRED_FIELD_SYMBOL = "*";
 

--- a/src/components/fields/TitleField.js
+++ b/src/components/fields/TitleField.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 const REQUIRED_FIELD_SYMBOL = "*";
 

--- a/src/components/widgets/AltDateTimeWidget.js
+++ b/src/components/widgets/AltDateTimeWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 function AltDateTimeWidget(props) {
   const { AltDateWidget } = props.registry.widgets;

--- a/src/components/widgets/AltDateTimeWidget.js
+++ b/src/components/widgets/AltDateTimeWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 function AltDateTimeWidget(props) {
   const { AltDateWidget } = props.registry.widgets;

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 function BaseInput(props) {
   // Note: since React 15.2.0 we can't forward unknown element attributes, so we

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 function BaseInput(props) {
   // Note: since React 15.2.0 we can't forward unknown element attributes, so we

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 import DescriptionField from "../fields/DescriptionField.js";
 
 function CheckboxWidget(props) {

--- a/src/components/widgets/CheckboxWidget.js
+++ b/src/components/widgets/CheckboxWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 import DescriptionField from "../fields/DescriptionField.js";
 
 function CheckboxWidget(props) {

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 function selectValue(value, selected, all) {
   const at = all.indexOf(value);

--- a/src/components/widgets/CheckboxesWidget.js
+++ b/src/components/widgets/CheckboxesWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 function selectValue(value, selected, all) {
   const at = all.indexOf(value);

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/EmailWidget.js
+++ b/src/components/widgets/EmailWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/EmailWidget.js
+++ b/src/components/widgets/EmailWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/FileWidget.js
+++ b/src/components/widgets/FileWidget.js
@@ -98,7 +98,7 @@ class FileWidget extends Component {
       <div>
         <p>
           <input
-            ref={ref => this.inputRef = ref}
+            ref={ref => (this.inputRef = ref)}
             id={id}
             type="file"
             disabled={readonly || disabled}

--- a/src/components/widgets/HiddenWidget.js
+++ b/src/components/widgets/HiddenWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 function HiddenWidget({ id, value }) {
   return (

--- a/src/components/widgets/HiddenWidget.js
+++ b/src/components/widgets/HiddenWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 function HiddenWidget({ id, value }) {
   return (

--- a/src/components/widgets/PasswordWidget.js
+++ b/src/components/widgets/PasswordWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/PasswordWidget.js
+++ b/src/components/widgets/PasswordWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 function RadioWidget(props) {
   const {

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 function RadioWidget(props) {
   const {

--- a/src/components/widgets/RangeWidget.js
+++ b/src/components/widgets/RangeWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import { rangeSpec } from "../../utils";
 import BaseInput from "./BaseInput";

--- a/src/components/widgets/RangeWidget.js
+++ b/src/components/widgets/RangeWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import { rangeSpec } from "../../utils";
 import BaseInput from "./BaseInput";

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import { asNumber } from "../../utils";
 

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import { asNumber } from "../../utils";
 

--- a/src/components/widgets/SelectWidget.js
+++ b/src/components/widgets/SelectWidget.js
@@ -11,7 +11,9 @@ function processValue({ type, items }, value) {
   if (value === "") {
     return undefined;
   } else if (
-    type === "array" && items && ["number", "integer"].includes(items.type)
+    type === "array" &&
+    items &&
+    ["number", "integer"].includes(items.type)
   ) {
     return value.map(asNumber);
   } else if (type === "boolean") {

--- a/src/components/widgets/TextWidget.js
+++ b/src/components/widgets/TextWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/TextWidget.js
+++ b/src/components/widgets/TextWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 function TextareaWidget(props) {
   const {

--- a/src/components/widgets/TextareaWidget.js
+++ b/src/components/widgets/TextareaWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 function TextareaWidget(props) {
   const {

--- a/src/components/widgets/URLWidget.js
+++ b/src/components/widgets/URLWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/URLWidget.js
+++ b/src/components/widgets/URLWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import BaseInput from "./BaseInput";
 

--- a/src/components/widgets/UpDownWidget.js
+++ b/src/components/widgets/UpDownWidget.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Proptypes from "prop-types";
+import PropTypes from "prop-types";
 
 import { rangeSpec } from "../../utils";
 import BaseInput from "./BaseInput";

--- a/src/components/widgets/UpDownWidget.js
+++ b/src/components/widgets/UpDownWidget.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import Proptypes from "prop-types";
 
 import { rangeSpec } from "../../utils";
 import BaseInput from "./BaseInput";


### PR DESCRIPTION
### Reasons for making this change

Utilizing in a React 15.5 project and getting the console warning:

> Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.

So, just adding the prop-types package and importing as Proptypes from the prop-types package where Proptypes were previously imported from React.

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
