### PR TITLE
Support oneOf and anyOf as alternative of enum/enumNames

### DIFF
--- a/playground/samples/alternatives.js
+++ b/playground/samples/alternatives.js
@@ -1,0 +1,64 @@
+module.exports = {
+  schema: {
+    definitions: {
+      Color: {
+        title: "Color",
+        type: "string",
+        anyOf: [
+          {
+            type: "string",
+            enum: ["#ff0000"],
+            title: "Red",
+          },
+          {
+            type: "string",
+            enum: ["#00ff00"],
+            title: "Green",
+          },
+          {
+            type: "string",
+            enum: ["#0000ff"],
+            title: "Blue",
+          },
+        ],
+      },
+    },
+    title: "Image editor",
+    type: "object",
+    required: ["currentColor", "colorMask", "blendMode"],
+    properties: {
+      currentColor: {
+        $ref: "#/definitions/Color",
+        title: "Brush color",
+      },
+      colorMask: {
+        type: "array",
+        uniqueItems: true,
+        items: {
+          $ref: "#/definitions/Color",
+        },
+        title: "Color mask",
+      },
+      colorPalette: {
+        type: "array",
+        title: "Color palette",
+        items: {
+          $ref: "#/definitions/Color",
+        },
+      },
+      blendMode: {
+        title: "Blend mode",
+        type: "string",
+        enum: ["screen", "multiply", "overlay"],
+        enumNames: ["Screen", "Multiply", "Overlay"],
+      },
+    },
+  },
+  uiSchema: {},
+  formData: {
+    currentColor: "#00ff00",
+    colorMask: ["#0000ff"],
+    colorPalette: ["#ff0000"],
+    blendMode: "screen",
+  },
+};

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -13,6 +13,7 @@ import validation from "./validation";
 import files from "./files";
 import single from "./single";
 import customArray from "./customArray";
+import alternatives from "./alternatives";
 
 export const samples = {
   Simple: simple,
@@ -30,4 +31,5 @@ export const samples = {
   Files: files,
   Single: single,
   "Custom Array": customArray,
+  Alternatives: alternatives,
 };

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -265,14 +265,15 @@ class ArrayField extends Component {
   };
 
   render() {
-    const { schema, uiSchema } = this.props;
-    if (isFilesArray(schema, uiSchema)) {
-      return this.renderFiles();
-    }
+    const { schema, uiSchema, registry = getDefaultRegistry() } = this.props;
+    const { definitions } = registry;
     if (isFixedItems(schema)) {
       return this.renderFixedArray();
     }
-    if (isMultiSelect(schema)) {
+    if (isFilesArray(schema, uiSchema, definitions)) {
+      return this.renderFiles();
+    }
+    if (isMultiSelect(schema, definitions)) {
       return this.renderMultiSelect();
     }
     return this.renderNormalArray();

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -161,7 +161,9 @@ function SchemaFieldRender(props) {
   const uiOptions = getUiOptions(uiSchema);
   let { label: displayLabel = true } = uiOptions;
   if (schema.type === "array") {
-    displayLabel = isMultiSelect(schema) || isFilesArray(schema, uiSchema);
+    displayLabel =
+      isMultiSelect(schema, definitions) ||
+      isFilesArray(schema, uiSchema, definitions);
   }
   if (schema.type === "object") {
     displayLabel = false;

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import {
   getWidget,
   getUiOptions,
+  isSelect,
   optionsList,
   getDefaultRegistry,
 } from "../../utils";
@@ -25,7 +26,7 @@ function StringField(props) {
   } = props;
   const { title, format } = schema;
   const { widgets, formContext } = registry;
-  const enumOptions = Array.isArray(schema.enum) && optionsList(schema);
+  const enumOptions = isSelect(schema) && optionsList(schema);
   const defaultWidget = format || (enumOptions ? "select" : "text");
   const { widget = defaultWidget, placeholder = "", ...options } = getUiOptions(
     uiSchema

--- a/src/utils.js
+++ b/src/utils.js
@@ -277,19 +277,22 @@ export function orderProperties(properties, order) {
   return complete;
 }
 
-export function isMultiSelect(schema) {
-  return schema.items
-    ? Array.isArray(schema.items.enum) && schema.uniqueItems
-    : false;
-}
+export function isMultiSelect(schema, definitions = {}) {
+  if (!schema.uniqueItems || !schema.items) {
+    return false;
+  }
+  const itemsSchema = retrieveSchema(schema.items, definitions);
+  return Array.isArray(itemsSchema.enum);
+  }
 
-export function isFilesArray(schema, uiSchema) {
-  return (
-    (schema.items &&
-      schema.items.type === "string" &&
-      schema.items.format === "data-url") ||
-    uiSchema["ui:widget"] === "files"
-  );
+export function isFilesArray(schema, uiSchema, definitions = {}) {
+  if (uiSchema["ui:widget"] === "files") {
+    return true;
+  } else if (schema.items) {
+    const itemsSchema = retrieveSchema(schema.items, definitions);
+    return itemsSchema.type === "string" && itemsSchema.format === "data-url";
+  }
+  return false;
 }
 
 export function isFixedItems(schema) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -298,18 +298,22 @@ export function toConstant(schema) {
   }
 }
 
-export function isMultiSelect(schema, definitions = {}) {
-  if (!schema.uniqueItems || !schema.items) {
-    return false;
-  }
-  const itemsSchema = retrieveSchema(schema.items, definitions);
-  const altSchemas = itemsSchema.oneOf || itemsSchema.anyOf;
-  if (Array.isArray(itemsSchema.enum)) {
+export function isSelect(_schema, definitions = {}) {
+  const schema = retrieveSchema(_schema, definitions);
+  const altSchemas = schema.oneOf || schema.anyOf;
+  if (Array.isArray(schema.enum)) {
     return true;
   } else if (Array.isArray(altSchemas)) {
     return altSchemas.every(altSchemas => isConstant(altSchemas));
   }
   return false;
+}
+
+export function isMultiSelect(schema, definitions = {}) {
+  if (!schema.uniqueItems || !schema.items) {
+    return false;
+  }
+  return isSelect(schema.items, definitions);
 }
 
 export function isFilesArray(schema, uiSchema, definitions = {}) {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -289,6 +289,15 @@ describe("utils", () => {
       const schema = { items: {}, uniqueItems: true };
       expect(isMultiSelect(schema)).to.be.false;
     });
+
+    it("should retrieve reference schema definitions", () => {
+      const schema = {
+        items: { $ref: "#/definitions/FooItem" },
+        uniqueItems: true,
+      };
+      const definitions = { FooItem: { type: "string", enum: ["foo"] } };
+      expect(isMultiSelect(schema, definitions)).to.be.true;
+    });
   });
 
   describe("isFilesArray()", () => {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -6,6 +6,8 @@ import {
   deepEquals,
   getDefaultFormState,
   isFilesArray,
+  isConstant,
+  toConstant,
   isMultiSelect,
   mergeObjects,
   pad,
@@ -266,6 +268,49 @@ describe("utils", () => {
 
     it("should return undefined if the input is empty", () => {
       expect(asNumber("")).eql(undefined);
+    });
+  });
+
+  describe("isConstant", () => {
+    it("should return false when neither enum nor const is defined", () => {
+      const schema = {};
+      expect(isConstant(schema)).to.be.false;
+    });
+
+    it("should return true when schema enum is an array of one item", () => {
+      const schema = { enum: ["foo"] };
+      expect(isConstant(schema)).to.be.true;
+    });
+
+    it("should return false when schema enum contains several items", () => {
+      const schema = { enum: ["foo", "bar", "baz"] };
+      expect(isConstant(schema)).to.be.false;
+    });
+
+    it("should return true when schema const is defined", () => {
+      const schema = { const: "foo" };
+      expect(isConstant(schema)).to.be.true;
+    });
+  });
+
+  describe("toConstant()", () => {
+    describe("schema contains an enum array", () => {
+      it("should return its first value when it contains a unique element", () => {
+        const schema = { enum: ["foo"] };
+        expect(toConstant(schema)).eql("foo");
+      });
+
+      it("should return schema const value when it exists", () => {
+        const schema = { const: "bar" };
+        expect(toConstant(schema)).eql("bar");
+      });
+
+      it("should throw when it contains more than one element", () => {
+        const schema = { enum: ["foo", "bar"] };
+        expect(() => {
+          toConstant(schema);
+        }).to.Throw(Error, "cannot be inferred");
+      });
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

As mentioned by @dlax in #532 enumNames keyword is not in the JSON Schema specification (neither draft-04 nor draft-06).
Another way to support choices schemas is to write them with the following structure :
```js
{
  oneOf: [{
    enum: ["foo"],
    title: "Foo"
  }, {
    enum: ["bar"],
    title: "Bar"
  }]
}
```
or with draft-06's new `const` keyword:
```js
{
  oneOf: [{
    const: "foo",
    title: "Foo"
  }, {
    const: "bar",
    title: "Bar"
  }]
}
```
This PR adds basic support for oneOf/anyOf as an alternative to the non standard `enumNames` keywords.

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
