### PR TITLE
Fixes default value for object missing properties

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -128,7 +128,7 @@ function computeDefaults(schema, parentDefaults, definitions = {}) {
   switch (schema.type) {
     // We need to recur for object schema inner default values.
     case "object":
-      return Object.keys(schema.properties).reduce((acc, key) => {
+      return Object.keys(schema.properties || {}).reduce((acc, key) => {
         // Compute the defaults for this node, with the parent defaults we might
         // have from a previous run: defaults[key].
         acc[key] = computeDefaults(

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -43,6 +43,14 @@ describe("utils", () => {
         ).to.eql({ string: "foo" });
       });
 
+      it("should default to empty object if no properties are defined", () => {
+        expect(
+          getDefaultFormState({
+            type: "object",
+          })
+        ).to.eql({});
+      });
+
       it("should recursively map schema object default to form state", () => {
         expect(
           getDefaultFormState({


### PR DESCRIPTION
### Reasons for making this change

When the schema of a field of type object is missing the `properties` key, it raises an exception: `Cannot convert undefined or null to object`. This PR fixes it by defaulting the value to an empty object, this way, we can use custom fields to render objects without defined properties.