### PR TITLE
Fixes array without items for custom fields

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -278,12 +278,16 @@ export function orderProperties(properties, order) {
 }
 
 export function isMultiSelect(schema) {
-  return Array.isArray(schema.items.enum) && schema.uniqueItems;
+  return schema.items
+    ? Array.isArray(schema.items.enum) && schema.uniqueItems
+    : false;
 }
 
 export function isFilesArray(schema, uiSchema) {
   return (
-    (schema.items.type === "string" && schema.items.format === "data-url") ||
+    (schema.items &&
+      schema.items.type === "string" &&
+      schema.items.format === "data-url") ||
     uiSchema["ui:widget"] === "files"
   );
 }

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -5,6 +5,7 @@ import {
   dataURItoBlob,
   deepEquals,
   getDefaultFormState,
+  isFilesArray,
   isMultiSelect,
   mergeObjects,
   pad,
@@ -266,6 +267,11 @@ describe("utils", () => {
       expect(isMultiSelect(schema)).to.be.true;
     });
 
+    it("should be false if items is undefined", () => {
+      const schema = {};
+      expect(isMultiSelect(schema)).to.be.false;
+    });
+
     it("should be false if uniqueItems is false", () => {
       const schema = { items: { enum: ["foo", "bar"] }, uniqueItems: false };
       expect(isMultiSelect(schema)).to.be.false;
@@ -274,6 +280,20 @@ describe("utils", () => {
     it("should be false if schema items enum is not an array", () => {
       const schema = { items: {}, uniqueItems: true };
       expect(isMultiSelect(schema)).to.be.false;
+    });
+  });
+
+  describe("isFilesArray()", () => {
+    it("should be true if items have data-url format", () => {
+      const schema = { items: { type: "string", format: "data-url" } };
+      const uiSchema = {};
+      expect(isFilesArray(schema, uiSchema)).to.be.true;
+    });
+
+    it("should be false if items is undefined", () => {
+      const schema = {};
+      const uiSchema = {};
+      expect(isFilesArray(schema, uiSchema)).to.be.false;
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

The jsonschema of an array may omit the `items` property, similarly to #589, with this fix it's possible to create a field for custom arrays without items defined by the schema.
