### PR TITLE
Added feature to define object type field without any properties.

### DIFF
--- a/playground/samples/simple.js
+++ b/playground/samples/simple.js
@@ -31,6 +31,10 @@ module.exports = {
         title: "Telephone",
         minLength: 10,
       },
+      address: {
+        type: "object",
+        title: "Address",
+      },
     },
   },
   uiSchema: {

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -32,6 +32,15 @@ class ObjectField extends Component {
     };
   };
 
+  onTextValueChange = ({ target: { value } }) => {
+    try {
+      const newFormData = JSON.parse(value);
+      this.props.onChange(newFormData);
+    } catch (error) {
+      this.props.onChange(value);
+    }
+  };
+
   render() {
     const {
       uiSchema,
@@ -50,6 +59,33 @@ class ObjectField extends Component {
     const schema = retrieveSchema(this.props.schema, definitions);
     const title = schema.title === undefined ? name : schema.title;
     let orderedProperties;
+
+    if (!schema.properties) {
+      return (
+        <fieldset>
+          {title &&
+            <TitleField
+              id={`${idSchema.$id}__title`}
+              title={title}
+              required={required}
+              formContext={formContext}
+            />}
+          {schema.description &&
+            <DescriptionField
+              id={`${idSchema.$id}__description`}
+              description={schema.description}
+              formContext={formContext}
+            />}
+          <textarea
+            className="form-control"
+            onChange={this.onTextValueChange}
+            value={
+              typeof formData === "object" ? JSON.stringify(formData) : formData
+            }
+          />
+        </fieldset>
+      );
+    }
     try {
       const properties = Object.keys(schema.properties);
       orderedProperties = orderProperties(properties, uiSchema["ui:order"]);

--- a/src/utils.js
+++ b/src/utils.js
@@ -128,16 +128,20 @@ function computeDefaults(schema, parentDefaults, definitions = {}) {
   switch (schema.type) {
     // We need to recur for object schema inner default values.
     case "object":
-      return Object.keys(schema.properties || {}).reduce((acc, key) => {
-        // Compute the defaults for this node, with the parent defaults we might
-        // have from a previous run: defaults[key].
-        acc[key] = computeDefaults(
-          schema.properties[key],
-          (defaults || {})[key],
-          definitions
-        );
-        return acc;
-      }, {});
+      if (schema.properties) {
+        return Object.keys(schema.properties || {}).reduce((acc, key) => {
+          // Compute the defaults for this node, with the parent defaults we might
+          // have from a previous run: defaults[key].
+          acc[key] = computeDefaults(
+            schema.properties[key],
+            (defaults || {})[key],
+            definitions
+          );
+          return acc;
+        }, {});
+      } else {
+        return {};
+      }
 
     case "array":
       if (schema.minItems) {

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -101,6 +101,18 @@ describe("ObjectField", () => {
       ).to.have.length.of(1);
     });
 
+    it("should render a textarea for undefined properties", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "object",
+          title: "my object",
+          description: "my description",
+        },
+      });
+
+      expect(node.querySelectorAll(".field textarea")).to.have.length.of(1);
+    });
+
     it("should handle a default object value", () => {
       const { node } = createFormComponent({ schema });
 


### PR DESCRIPTION
### Reasons for making this change
Fixed this issue https://github.com/mozilla-services/react-jsonschema-form/issues/44

### Checklist

* [ ] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
