### PR TITLE
Consider maxItems value before rendering the add button

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -200,6 +200,21 @@ class ArrayField extends Component {
     return itemSchema.type !== "null";
   }
 
+  canAddItem(formItems) {
+    const { schema, uiSchema } = this.props;
+    let { addable } = getUiOptions(uiSchema);
+    if (addable !== false) {
+      // if ui:options.addable was not explicitly set to false, we can add
+      // another item if we have not exceeded maxItems yet
+      if (schema.maxItems !== undefined) {
+        addable = formItems.length < schema.maxItems;
+      } else {
+        addable = true;
+      }
+    }
+    return addable;
+  }
+
   onAddClick = event => {
     event.preventDefault();
     const { schema, formData, registry = getDefaultRegistry() } = this.props;
@@ -298,16 +313,8 @@ class ArrayField extends Component {
     const { ArrayFieldTemplate, definitions, fields } = registry;
     const { TitleField, DescriptionField } = fields;
     const itemsSchema = retrieveSchema(schema.items, definitions);
-    let { addable } = getUiOptions(uiSchema);
-    if (addable !== false) {
-      if (schema.maxItems !== undefined) {
-        addable = formData.length < schema.maxItems;
-      } else {
-        addable = true;
-      }
-    }
     const arrayProps = {
-      canAdd: addable,
+      canAdd: this.canAddItem(formData),
       items: formData.map((item, index) => {
         const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
         const itemIdPrefix = idSchema.$id + "_" + index;
@@ -446,19 +453,10 @@ class ArrayField extends Component {
       items = items || [];
       items = items.concat(new Array(itemSchemas.length - items.length));
     }
-    let { addable } = getUiOptions(uiSchema);
-    if (addable !== false) {
-      if (schema.maxItems !== undefined) {
-        addable = items.length < schema.maxItems;
-      } else {
-        addable = true;
-      }
-    }
-    const canAdd = addable && additionalSchema;
 
     // These are the props passed into the render function
     const arrayProps = {
-      canAdd,
+      canAdd: this.canAddItem(items) && additionalSchema,
       className: "field field-array field-array-fixed-items",
       disabled,
       idSchema,

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -298,8 +298,14 @@ class ArrayField extends Component {
     const { ArrayFieldTemplate, definitions, fields } = registry;
     const { TitleField, DescriptionField } = fields;
     const itemsSchema = retrieveSchema(schema.items, definitions);
-    const { addable = true } = getUiOptions(uiSchema);
-
+    let { addable } = getUiOptions(uiSchema);
+    if (addable !== false) {
+      if (schema.maxItems !== undefined) {
+        addable = formData.length < schema.maxItems;
+      } else {
+        addable = true;
+      }
+    }
     const arrayProps = {
       canAdd: addable,
       items: formData.map((item, index) => {

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -440,14 +440,21 @@ class ArrayField extends Component {
     const additionalSchema = allowAdditionalItems(schema)
       ? retrieveSchema(schema.additionalItems, definitions)
       : null;
-    const { addable = true } = getUiOptions(uiSchema);
-    const canAdd = addable && additionalSchema;
 
     if (!items || items.length < itemSchemas.length) {
       // to make sure at least all fixed items are generated
       items = items || [];
       items = items.concat(new Array(itemSchemas.length - items.length));
     }
+    let { addable } = getUiOptions(uiSchema);
+    if (addable !== false) {
+      if (schema.maxItems !== undefined) {
+        addable = items.length < schema.maxItems;
+      } else {
+        addable = true;
+      }
+    }
+    const canAdd = addable && additionalSchema;
 
     // These are the props passed into the render function
     const arrayProps = {

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -117,6 +117,56 @@ describe("ArrayField", () => {
       expect(node.querySelectorAll(".field-string")).to.have.length.of(1);
     });
 
+    it("should not provide an add button if length equals maxItems", () => {
+      const maxItemsSchema = Object.assign({ maxItems: 2 }, schema);
+      const { node } = createFormComponent({
+        schema: maxItemsSchema,
+        formData: ["foo", "bar"],
+      });
+
+      expect(node.querySelector(".array-item-add button")).to.be.null;
+    });
+
+    it("should provide an add button if length is lesser than maxItems", () => {
+      const maxItemsSchema = Object.assign({ maxItems: 2 }, schema);
+      const { node } = createFormComponent({
+        schema: maxItemsSchema,
+        formData: ["foo"],
+      });
+
+      expect(node.querySelector(".array-item-add button")).not.eql(null);
+    });
+
+    it("should not provide an add button if addable is expliclty false regardless maxItems value", () => {
+      const maxItemsSchema = Object.assign({ maxItems: 2 }, schema);
+      const { node } = createFormComponent({
+        schema: maxItemsSchema,
+        formData: ["foo"],
+        uiSchema: {
+          "ui:options": {
+            addable: false,
+          },
+        },
+      });
+
+      expect(node.querySelector(".array-item-add button")).to.be.null;
+    });
+
+    it("should ignore addable value if maxItems constraint is not satisfied", () => {
+      const maxItemsSchema = Object.assign({ maxItems: 2 }, schema);
+      const { node } = createFormComponent({
+        schema: maxItemsSchema,
+        formData: ["foo", "bar"],
+        uiSchema: {
+          "ui:options": {
+            addable: true,
+          },
+        },
+      });
+
+      expect(node.querySelector(".array-item-add button")).to.be.null;
+    });
+
     it("should mark a non-null array item widget as required", () => {
       const { node } = createFormComponent({ schema });
 

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -118,9 +118,8 @@ describe("ArrayField", () => {
     });
 
     it("should not provide an add button if length equals maxItems", () => {
-      const maxItemsSchema = Object.assign({ maxItems: 2 }, schema);
       const { node } = createFormComponent({
-        schema: maxItemsSchema,
+        schema: { maxItems: 2, ...schema },
         formData: ["foo", "bar"],
       });
 
@@ -128,9 +127,8 @@ describe("ArrayField", () => {
     });
 
     it("should provide an add button if length is lesser than maxItems", () => {
-      const maxItemsSchema = Object.assign({ maxItems: 2 }, schema);
       const { node } = createFormComponent({
-        schema: maxItemsSchema,
+        schema: { maxItems: 2, ...schema },
         formData: ["foo"],
       });
 
@@ -138,9 +136,8 @@ describe("ArrayField", () => {
     });
 
     it("should not provide an add button if addable is expliclty false regardless maxItems value", () => {
-      const maxItemsSchema = Object.assign({ maxItems: 2 }, schema);
       const { node } = createFormComponent({
-        schema: maxItemsSchema,
+        schema: { maxItems: 2, ...schema },
         formData: ["foo"],
         uiSchema: {
           "ui:options": {
@@ -153,9 +150,8 @@ describe("ArrayField", () => {
     });
 
     it("should ignore addable value if maxItems constraint is not satisfied", () => {
-      const maxItemsSchema = Object.assign({ maxItems: 2 }, schema);
       const { node } = createFormComponent({
-        schema: maxItemsSchema,
+        schema: { maxItems: 2, ...schema },
         formData: ["foo", "bar"],
         uiSchema: {
           "ui:options": {
@@ -844,40 +840,32 @@ describe("ArrayField", () => {
     });
 
     it("[fixed-noadditional] should not provide an add button regardless maxItems", () => {
-      const maxItemsSchema = Object.assign({ maxItems: 3 }, schema);
-      const { node } = createFormComponent({ schema: maxItemsSchema });
+      const { node } = createFormComponent({
+        schema: { maxItems: 3, ...schema },
+      });
 
       expect(node.querySelector(".array-item-add button")).to.be.null;
     });
 
     it("[fixed] should not provide an add button if length equals maxItems", () => {
-      const maxItemsSchemaAdditional = Object.assign(
-        { maxItems: 2 },
-        schemaAdditional
-      );
       const { node } = createFormComponent({
-        schema: maxItemsSchemaAdditional,
+        schema: { maxItems: 2, ...schemaAdditional },
       });
 
       expect(node.querySelector(".array-item-add button")).to.be.null;
     });
 
     it("[fixed] should provide an add button if length is lesser than maxItems", () => {
-      const maxItemsSchemaAdditional = Object.assign(
-        { maxItems: 3 },
-        schemaAdditional
-      );
       const { node } = createFormComponent({
-        schema: maxItemsSchemaAdditional,
+        schema: { maxItems: 3, ...schemaAdditional },
       });
 
       expect(node.querySelector(".array-item-add button")).not.to.be.null;
     });
 
     it("[fixed] should not provide an add button if addable is expliclty false regardless maxItems value", () => {
-      const maxItemsSchemaAdditional = Object.assign({ maxItems: 3 }, schema);
       const { node } = createFormComponent({
-        schema: maxItemsSchemaAdditional,
+        schema: { maxItems: 2, ...schema },
         uiSchema: {
           "ui:options": {
             addable: false,
@@ -889,9 +877,8 @@ describe("ArrayField", () => {
     });
 
     it("[fixed] should ignore addable value if maxItems constraint is not satisfied", () => {
-      const maxItemsSchemaAdditional = Object.assign({ maxItems: 2 }, schema);
       const { node } = createFormComponent({
-        schema: maxItemsSchemaAdditional,
+        schema: { maxItems: 2, ...schema },
         uiSchema: {
           "ui:options": {
             addable: true,

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -843,6 +843,65 @@ describe("ArrayField", () => {
       expect(node.querySelector(".array-item-add button")).to.be.null;
     });
 
+    it("[fixed-noadditional] should not provide an add button regardless maxItems", () => {
+      const maxItemsSchema = Object.assign({ maxItems: 3 }, schema);
+      const { node } = createFormComponent({ schema: maxItemsSchema });
+
+      expect(node.querySelector(".array-item-add button")).to.be.null;
+    });
+
+    it("[fixed] should not provide an add button if length equals maxItems", () => {
+      const maxItemsSchemaAdditional = Object.assign(
+        { maxItems: 2 },
+        schemaAdditional
+      );
+      const { node } = createFormComponent({
+        schema: maxItemsSchemaAdditional,
+      });
+
+      expect(node.querySelector(".array-item-add button")).to.be.null;
+    });
+
+    it("[fixed] should provide an add button if length is lesser than maxItems", () => {
+      const maxItemsSchemaAdditional = Object.assign(
+        { maxItems: 3 },
+        schemaAdditional
+      );
+      const { node } = createFormComponent({
+        schema: maxItemsSchemaAdditional,
+      });
+
+      expect(node.querySelector(".array-item-add button")).not.to.be.null;
+    });
+
+    it("[fixed] should not provide an add button if addable is expliclty false regardless maxItems value", () => {
+      const maxItemsSchemaAdditional = Object.assign({ maxItems: 3 }, schema);
+      const { node } = createFormComponent({
+        schema: maxItemsSchemaAdditional,
+        uiSchema: {
+          "ui:options": {
+            addable: false,
+          },
+        },
+      });
+
+      expect(node.querySelector(".array-item-add button")).to.be.null;
+    });
+
+    it("[fixed] should ignore addable value if maxItems constraint is not satisfied", () => {
+      const maxItemsSchemaAdditional = Object.assign({ maxItems: 2 }, schema);
+      const { node } = createFormComponent({
+        schema: maxItemsSchemaAdditional,
+        uiSchema: {
+          "ui:options": {
+            addable: true,
+          },
+        },
+      });
+
+      expect(node.querySelector(".array-item-add button")).to.be.null;
+    });
+
     describe("operations for additional items", () => {
       const { comp, node } = createFormComponent({
         schema: schemaAdditional,


### PR DESCRIPTION
jsonschema refuses to validate an array of items when the number of
items is greater than the maxItems constraint. Therefore the UI should
consisder this constraint and not provide an "add" button when the
maximum number of elements is reached.

The "add" button is rendered in the following cases:

- ui:options.addable is not false and items.length < schema.maxItems
- schema.maxItems is unspecified and ui:options.addable is not false

As before, if ui:options.addable is not specified, it is considered as
true by default.

The "add" button is *not* rendered in the following cases:

- ui:options.addable is false,
- items.length >= schema.maxItems, even if ui.options:addable is true

### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
