### PR TITLE
Add `type="button"` to ArrayFieldTemplate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,7 +821,7 @@ function ArrayFieldTemplate(props) {
   return (
     <div>
       {props.items.map(element => element.children)}
-      {props.canAdd && <button onClick={props.onAddClick}></button>}
+      {props.canAdd && <button type="button" onClick={props.onAddClick}></button>}
     </div>
   );
 }


### PR DESCRIPTION
### Reasons for making this change

Without the `type="button"` `Enter` keypresses in any of the input fields cause the button's `onAddClick` to trigger. Just a quick edit to make copy-paste experimentation with this example smoother.

~~If this is related to existing tickets, include links to them as well.~~ (N/A)

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
