### PR TITLE
Allows injecting custom jsonschema Validator instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1303,6 +1303,33 @@ render((
 >   received as second argument.
 > - The `validate()` function is called **after** the JSON schema validation.
 
+
+You can also provide a JSON schema validator, for more information see the [jsonschema docs](https://github.com/tdegrunt/jsonschema)
+
+```js
+const validator = Validator();
+
+validator.attributes.contains = function validateContains(instance, schema, options, ctx) {
+  if(typeof instance!='string') return;
+  if(typeof schema.contains!='string') throw new jsonschema.SchemaError('"contains" expects a string', schema);
+  if(instance.indexOf(schema.contains)<0){
+    return 'does not contain the string ' + JSON.stringify(schema.contains);
+  }
+}
+
+const schema = {
+  type: "object",
+  properties: {
+    foo: { type: "string", contains: "i am" },
+  }
+};
+
+render((
+  <Form schema={schema}
+        jsonValidator={validator} />
+), document.getElementById("app"));
+```
+
 ### Custom error messages
 
 Validation error messages are provided by the JSON Schema validation by default. If you need to change these messages or make any other modifications to the errors from the JSON Schema validation, you can define a transform function that receives the list of JSON Schema errors and returns a new list.

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { Validator as JsonValidator } from "jsonschema";
 
 import { default as DefaultErrorList } from "./ErrorList";
 import {
@@ -67,12 +68,13 @@ export default class Form extends Component {
   }
 
   validate(formData, schema) {
-    const { validate, transformErrors } = this.props;
+    const { validate, transformErrors, jsonValidator } = this.props;
     return validateFormData(
       formData,
       schema || this.props.schema,
       validate,
-      transformErrors
+      transformErrors,
+      jsonValidator
     );
   }
 
@@ -231,6 +233,7 @@ if (process.env.NODE_ENV !== "production") {
     noHtml5Validate: PropTypes.bool,
     liveValidate: PropTypes.bool,
     validate: PropTypes.func,
+    jsonValidator: PropTypes.instanceOf(JsonValidator),
     transformErrors: PropTypes.func,
     safeRenderCompletion: PropTypes.bool,
     formContext: PropTypes.object,

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,5 +1,5 @@
 import toPath from "lodash.topath";
-import { validate as jsonValidate } from "jsonschema";
+import { Validator as JsonValidator } from "jsonschema";
 
 import { isObject, mergeObjects } from "./utils";
 
@@ -107,9 +107,12 @@ export default function validateFormData(
   formData,
   schema,
   customValidate,
-  transformErrors
+  transformErrors,
+  customJsonValidator
 ) {
-  let { errors } = jsonValidate(formData, schema);
+  const validator = customJsonValidator || new JsonValidator();
+
+  let { errors } = validator.validate(formData, schema);
   if (typeof transformErrors === "function") {
     errors = transformErrors(errors);
   }


### PR DESCRIPTION
The current custom validation does not have access to the schema
in the same way that a jsonschema validator does, by allowing
user to specify the validator many validation tasks become much
simpler.

This is related to #79 which was closed when the custom field validation was implemented,
however that is not as powerful as a jsonschema validator can be.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
