### PR TITLE
Fix example of conditional fields so that it doesn't mutate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1411,7 +1411,7 @@ This component follows [JSON Schema](http://json-schema.org/documentation.html) 
  - Custom field template: https://jsfiddle.net/hdp1kgn6/1/
  - Multi-step wizard: https://jsfiddle.net/sn4bnw9h/1/
  - Using classNames with uiSchema: https://jsfiddle.net/gfwp25we/1/
- - Conditional fields: https://jsfiddle.net/69z2wepo/68259/
+ - Conditional fields: https://jsfiddle.net/69z2wepo/83018/
  - Use radio list for enums: https://jsfiddle.net/f2y3fq7L/2/
  - Reading file input data: https://jsfiddle.net/f9vcb6pL/1/
  - Custom errors messages with transformErrors : https://jsfiddle.net/revolunet/5r3swnr4/


### PR DESCRIPTION
The original example mutated schema.properties. This update links to a new version of the jsbin which adds the following line:

        schema.properties = Object.assign({},schema.properties)


See #638

### Reasons for making this change

The example does not currently work correctly.

If this is related to existing tickets, include links to them as well.

### Checklist

* [X] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
