### PR TITLE
add allowMutation option to formContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1113,6 +1113,8 @@ The registry is passed down the component tree, so you can access it from your c
 
 You can provide a `formContext` object to the Form, which is passed down to all fields and widgets (including [TitleField](#custom-titles) and [DescriptionField](#custom-descriptions)). Useful for implementing context aware fields and widgets.
 
+The `formContext` object has a special property 'allowMutation', when set to `true` the initially provided `formData` will we changed on updates. Normally all changehandlers receive a new `formData` object at each invocation.
+
 ### Custom array field buttons
 
 The `ArrayField` component provides a UI to add, remove and reorder array items, and these buttons use [Bootstrap glyphicons](http://getbootstrap.com/components/#glyphicons). If you don't use glyphicons but still want to provide your own icons or texts for these buttons, you can easily do so using CSS:

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -38,7 +38,13 @@ export default class Form extends Component {
     const liveValidate = props.liveValidate || this.props.liveValidate;
     const mustValidate = edit && !props.noValidate && liveValidate;
     const { definitions } = schema;
-    const formData = getDefaultFormState(schema, props.formData, definitions);
+    const formContext = props.formContext || this.props.formContext || {};
+    const formData = getDefaultFormState(
+      schema,
+      props.formData,
+      definitions,
+      formContext.allowMutation === true
+    );
     const { errors, errorSchema } = mustValidate
       ? this.validate(formData, schema)
       : {

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -231,9 +231,18 @@ class ArrayField extends Component {
       if (event) {
         event.preventDefault();
       }
-      const { formData, onChange } = this.props;
+      const {
+        formData,
+        onChange,
+        registry = getDefaultRegistry(),
+      } = this.props;
+      const { allowMutation } = registry.formContext;
+
+      const newFormData = allowMutation === true ? formData : formData.slice();
+      newFormData.splice(index, 1);
+
       // refs #195: revalidate to ensure properly reindexing errors
-      onChange(formData.filter((_, i) => i !== index), { validate: true });
+      onChange(newFormData, { validate: true });
     };
   };
 
@@ -243,19 +252,18 @@ class ArrayField extends Component {
         event.preventDefault();
         event.target.blur();
       }
-      const { formData, onChange } = this.props;
-      onChange(
-        formData.map((item, i) => {
-          if (i === newIndex) {
-            return formData[index];
-          } else if (i === index) {
-            return formData[newIndex];
-          } else {
-            return item;
-          }
-        }),
-        { validate: true }
-      );
+      const {
+        formData,
+        onChange,
+        registry = getDefaultRegistry(),
+      } = this.props;
+      const { allowMutation } = registry.formContext;
+
+      const newFormData = allowMutation === true ? formData : formData.slice();
+      const removedItems = newFormData.splice(index, 1, newFormData[newIndex]);
+      newFormData[newIndex] = removedItems[0];
+
+      onChange(newFormData, { validate: true });
     };
   };
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -213,15 +213,17 @@ class ArrayField extends Component {
   onAddClick = event => {
     event.preventDefault();
     const { schema, formData, registry = getDefaultRegistry() } = this.props;
-    const { definitions } = registry;
+    const { definitions, formContext } = registry;
+    const { allowMutation } = formContext;
     let itemSchema = schema.items;
     if (isFixedItems(schema) && allowAdditionalItems(schema)) {
       itemSchema = schema.additionalItems;
     }
-    this.props.onChange(
-      [...formData, getDefaultFormState(itemSchema, undefined, definitions)],
-      { validate: false }
-    );
+
+    const newFormData = allowMutation === true ? formData : formData.slice();
+    newFormData.push(getDefaultFormState(itemSchema, undefined, definitions));
+
+    this.props.onChange(newFormData, { validate: false });
   };
 
   onDropIndexClick = index => {
@@ -259,13 +261,19 @@ class ArrayField extends Component {
 
   onChangeForIndex = index => {
     return value => {
-      const { formData, onChange } = this.props;
-      const newFormData = formData.map((item, i) => {
-        // We need to treat undefined items as nulls to have validation.
-        // See https://github.com/tdegrunt/jsonschema/issues/206
-        const jsonValue = typeof value === "undefined" ? null : value;
-        return index === i ? jsonValue : item;
-      });
+      const {
+        formData,
+        onChange,
+        registry = getDefaultRegistry(),
+      } = this.props;
+      const { allowMutation } = registry.formContext;
+      const newFormData = allowMutation === true ? formData : formData.slice();
+
+      // We need to treat undefined items as nulls to have validation.
+      // See https://github.com/tdegrunt/jsonschema/issues/206
+      const jsonValue = typeof value === "undefined" ? null : value;
+      newFormData[index] = jsonValue;
+
       onChange(newFormData, { validate: false });
     };
   };

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -27,7 +27,10 @@ class ObjectField extends Component {
 
   onPropertyChange = name => {
     return (value, options) => {
-      const newFormData = { ...this.props.formData, [name]: value };
+      const { formData, registry = getDefaultRegistry() } = this.props;
+      const { allowMutation } = registry.formContext;
+      const newFormData = allowMutation === true ? formData : { ...formData };
+      newFormData[name] = value;
       this.props.onChange(newFormData, options);
     };
   };

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1297,4 +1297,60 @@ describe("Form", () => {
       expect(node.getAttribute("novalidate")).not.to.be.null;
     });
   });
+
+  describe("Should pass formData when using allowMutation", () => {
+    it("should allow object mutation when specified", () => {
+      const formData = { s: "test" };
+      const schema = {
+        type: "object",
+        properties: {
+          s: {
+            type: "string",
+          },
+        },
+      };
+
+      const { comp, node } = createFormComponent({
+        schema,
+        formData,
+        formContext: {
+          allowMutation: true,
+        },
+      });
+
+      Simulate.change(node.querySelector("input[type=text]"), {
+        target: { value: "TEST" },
+      });
+
+      expect(comp.state.formData === formData).eql(true);
+      expect(comp.state.formData).eql({ s: "TEST" });
+    });
+
+    it("should allow array mutation when specified", () => {
+      const formData = ["test"];
+      const schema = {
+        type: "array",
+        items: {
+          type: "string",
+          default: "bazinga",
+        },
+      };
+
+      const { comp, node } = createFormComponent({
+        schema,
+        formData,
+        formContext: {
+          allowMutation: true,
+        },
+      });
+
+      Simulate.change(node.querySelector("input[type=text]"), {
+        target: { value: "TEST" },
+      });
+      Simulate.click(node.querySelector(".array-item-add button"));
+
+      expect(comp.state.formData === formData).eql(true);
+      expect(comp.state.formData).eql(["TEST", "bazinga"]);
+    });
+  });
 });

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1326,7 +1326,7 @@ describe("Form", () => {
       expect(comp.state.formData).eql({ s: "TEST" });
     });
 
-    it("should allow array mutation when specified", () => {
+    it("should allow array mutation when specified - edit", () => {
       const formData = ["test"];
       const schema = {
         type: "array",
@@ -1347,10 +1347,83 @@ describe("Form", () => {
       Simulate.change(node.querySelector("input[type=text]"), {
         target: { value: "TEST" },
       });
+
+      expect(comp.state.formData === formData).eql(true);
+      expect(comp.state.formData).eql(["TEST"]);
+    });
+
+    it("should allow array mutation when specified - add", () => {
+      const formData = ["test"];
+      const schema = {
+        type: "array",
+        items: {
+          type: "string",
+          default: "bazinga",
+        },
+      };
+
+      const { comp, node } = createFormComponent({
+        schema,
+        formData,
+        formContext: {
+          allowMutation: true,
+        },
+      });
+
       Simulate.click(node.querySelector(".array-item-add button"));
 
       expect(comp.state.formData === formData).eql(true);
-      expect(comp.state.formData).eql(["TEST", "bazinga"]);
+      expect(comp.state.formData).eql(["test", "bazinga"]);
+    });
+
+    it("should allow array mutation when specified - remove", () => {
+      const formData = ["first", "last"];
+      const schema = {
+        type: "array",
+        items: {
+          type: "string",
+          default: "bazinga",
+        },
+      };
+
+      const { comp, node } = createFormComponent({
+        schema,
+        formData,
+        formContext: {
+          allowMutation: true,
+        },
+      });
+
+      const dropBtns = node.querySelectorAll(".array-item-remove");
+      Simulate.click(dropBtns[0]);
+
+      expect(comp.state.formData === formData).eql(true);
+      expect(comp.state.formData).eql(["last"]);
+    });
+
+    it("should allow array mutation when specified - move", () => {
+      const formData = ["first", "last"];
+      const schema = {
+        type: "array",
+        items: {
+          type: "string",
+          default: "bazinga",
+        },
+      };
+
+      const { comp, node } = createFormComponent({
+        schema,
+        formData,
+        formContext: {
+          allowMutation: true,
+        },
+      });
+
+      const moveDownBtns = node.querySelectorAll(".array-item-move-down");
+      Simulate.click(moveDownBtns[0]);
+
+      expect(comp.state.formData === formData).eql(true);
+      expect(comp.state.formData).eql(["last", "first"]);
     });
   });
 });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -391,12 +391,30 @@ describe("utils", () => {
       expect(obj1).eql({ a: 1 });
     });
 
+    it("should mutate the provided objects if explicitly asked for", () => {
+      const obj2 = { b: 2 };
+      mergeObjects({ a: 1 }, obj2, false, true);
+      expect(obj2).eql({ a: 1, b: 2 });
+    });
+
     it("should merge two one-level deep objects", () => {
-      expect(mergeObjects({ a: 1 }, { b: 2 })).eql({ a: 1, b: 2 });
+      const obj1 = { a: 1 };
+      const obj2 = { b: 2 };
+      const expected = { a: 1, b: 2 };
+
+      expect(mergeObjects(obj1, obj2)).eql(expected);
+      mergeObjects(obj1, obj2, false, true);
+      expect(obj2).eql(expected);
     });
 
     it("should override the first object with the values from the second", () => {
-      expect(mergeObjects({ a: 1 }, { a: 2 })).eql({ a: 2 });
+      const obj1 = { a: 1 };
+      const obj2 = { a: 2 };
+      const expected = { a: 2 };
+
+      expect(mergeObjects(obj1, obj2)).eql(expected);
+      mergeObjects(obj1, obj2, false, true);
+      expect(obj2).eql(expected);
     });
 
     it("should recursively merge deeply nested objects", () => {
@@ -428,29 +446,41 @@ describe("utils", () => {
         },
         c: 3,
       };
+
       expect(mergeObjects(obj1, obj2)).eql(expected);
+      mergeObjects(obj1, obj2, false, true);
+      expect(obj2).eql(expected);
     });
 
     describe("concatArrays option", () => {
       it("should not concat arrays by default", () => {
         const obj1 = { a: [1] };
         const obj2 = { a: [2] };
+        const expected = { a: [2] };
 
-        expect(mergeObjects(obj1, obj2)).eql({ a: [2] });
+        expect(mergeObjects(obj1, obj2)).eql(expected);
+        mergeObjects(obj1, obj2, false, true);
+        expect(obj2).eql(expected);
       });
 
       it("should concat arrays when concatArrays is true", () => {
         const obj1 = { a: [1] };
         const obj2 = { a: [2] };
+        const expected = { a: [1, 2] };
 
-        expect(mergeObjects(obj1, obj2, true)).eql({ a: [1, 2] });
+        expect(mergeObjects(obj1, obj2, true)).eql(expected);
+        mergeObjects(obj1, obj2, true, true);
+        expect(obj2).eql(expected);
       });
 
       it("should concat nested arrays when concatArrays is true", () => {
         const obj1 = { a: { b: [1] } };
         const obj2 = { a: { b: [2] } };
+        const expected = { a: { b: [1, 2] } };
 
-        expect(mergeObjects(obj1, obj2, true)).eql({ a: { b: [1, 2] } });
+        expect(mergeObjects(obj1, obj2, true)).eql(expected);
+        mergeObjects(obj1, obj2, true, true);
+        expect(obj2).eql(expected);
       });
     });
   });


### PR DESCRIPTION
### Reasons for making this change

I'd like to integrate MobX and RJSF. MobX is able to track object changes by invisibly adding listeners, getters and setters to regular javascript objects. See https://github.com/mobxjs/mobx and https://github.com/mobxjs/mobx-state-tree.

The issue I hit is that each change to the `formData` object in RJSF will trigger an `onChange` with a __copy__ of the `formData`. For many programs this is really safe, but for me my 'MobX' object is lost and changed into a regular object. 

This change proposes an extra setting. When passing `formContext: { allowMutation: true }` to the form props, your `formData` will be mutated on each change, instead of copied.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
