### PR TITLE
add formData to ArrayFieldTemplate props

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,7 @@ The following props are passed to each `ArrayFieldTemplate`:
 - `uiSchema`: The uiSchema object for this array field.
 - `title`: A string value containing the title for the array.
 - `formContext`: The `formContext` object that you passed to Form.
+- `formData`: The formData for this array.
 
 The following props are part of each element in `items`:
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -340,6 +340,7 @@ class ArrayField extends Component {
       title,
       TitleField,
       formContext,
+      formData,
     };
 
     // Check if a custom render function was passed in


### PR DESCRIPTION
### Reasons for making this change

My use case: i'm rendering an array of objects into a table. I want to render columns only for properties that have data on some formData item. I need to loop the formData to achieve this.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
