### PR TITLE
Pass more props to ErrorList

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ render((
 The following props are passed to `ErrorList`
 
 - `errors`: An array of the errors.
+- `errorSchema`: The errorSchema constructed by `Form`.
 - `formContext`: The `formContext` object that you passed to Form.
 
 ### Custom widgets and fields

--- a/README.md
+++ b/README.md
@@ -896,6 +896,10 @@ render((
 
 > Note: Your custom `ErrorList` template will only render when `showErrorList` is `true`.
 
+The following props are passed to `ErrorList`
+
+- `errors`: An array of the errors.
+- `formContext`: The `formContext` object that you passed to Form.
 
 ### Custom widgets and fields
 

--- a/README.md
+++ b/README.md
@@ -900,6 +900,8 @@ The following props are passed to `ErrorList`
 
 - `errors`: An array of the errors.
 - `errorSchema`: The errorSchema constructed by `Form`.
+- `schema`: The schema that was passed to `Form`.
+- `uiSchema`: The uiSchema that was passed to `Form`.
 - `formContext`: The `formContext` object that you passed to Form.
 
 ### Custom widgets and fields

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -78,10 +78,10 @@ export default class Form extends Component {
 
   renderErrors() {
     const { status, errors } = this.state;
-    const { ErrorList, showErrorList } = this.props;
+    const { ErrorList, showErrorList, formContext } = this.props;
 
     if (status !== "editing" && errors.length && showErrorList != false) {
-      return <ErrorList errors={errors} />;
+      return <ErrorList errors={errors} formContext={formContext} />;
     }
     return null;
   }

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -77,7 +77,7 @@ export default class Form extends Component {
   }
 
   renderErrors() {
-    const { status, errors, errorSchema } = this.state;
+    const { status, errors, errorSchema, schema, uiSchema } = this.state;
     const { ErrorList, showErrorList, formContext } = this.props;
 
     if (status !== "editing" && errors.length && showErrorList != false) {
@@ -85,6 +85,8 @@ export default class Form extends Component {
         <ErrorList
           errors={errors}
           errorSchema={errorSchema}
+          schema={schema}
+          uiSchema={uiSchema}
           formContext={formContext}
         />
       );

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -77,11 +77,17 @@ export default class Form extends Component {
   }
 
   renderErrors() {
-    const { status, errors } = this.state;
+    const { status, errors, errorSchema } = this.state;
     const { ErrorList, showErrorList, formContext } = this.props;
 
     if (status !== "editing" && errors.length && showErrorList != false) {
-      return <ErrorList errors={errors} formContext={formContext} />;
+      return (
+        <ErrorList
+          errors={errors}
+          errorSchema={errorSchema}
+          formContext={formContext}
+        />
+      );
     }
     return null;
   }

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -515,9 +515,19 @@ describe("Validation", () => {
 
       const formData = 0;
 
-      const CustomErrorList = ({ errors, formContext: { className } }) =>
-        <div className={`CustomErrorList ${className}`}>
-          {errors.length} custom
+      const CustomErrorList = ({
+        errors,
+        errorSchema,
+        formContext: { className },
+      }) =>
+        <div>
+          <div className="CustomErrorList">
+            {errors.length} custom
+          </div>
+          <div className={"ErrorSchema"}>
+            {errorSchema.__errors[0]}
+          </div>
+          <div className={className} />
         </div>;
 
       it("should use CustomErrorList", () => {
@@ -531,6 +541,10 @@ describe("Validation", () => {
         expect(node.querySelectorAll(".CustomErrorList")).to.have.length.of(1);
         expect(node.querySelector(".CustomErrorList").textContent).eql(
           "1 custom"
+        );
+        expect(node.querySelectorAll(".ErrorSchema")).to.have.length.of(1);
+        expect(node.querySelector(".ErrorSchema").textContent).eql(
+          "is required"
         );
         expect(node.querySelectorAll(".foo")).to.have.length.of(1);
       });

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -513,11 +513,17 @@ describe("Validation", () => {
         minLength: 1,
       };
 
+      const uiSchema = {
+        foo: "bar",
+      };
+
       const formData = 0;
 
       const CustomErrorList = ({
         errors,
         errorSchema,
+        schema,
+        uiSchema,
         formContext: { className },
       }) =>
         <div>
@@ -527,12 +533,19 @@ describe("Validation", () => {
           <div className={"ErrorSchema"}>
             {errorSchema.__errors[0]}
           </div>
+          <div className={"Schema"}>
+            {schema.type}
+          </div>
+          <div className={"UiSchema"}>
+            {uiSchema.foo}
+          </div>
           <div className={className} />
         </div>;
 
       it("should use CustomErrorList", () => {
         const { node } = createFormComponent({
           schema,
+          uiSchema,
           liveValidate: true,
           formData,
           ErrorList: CustomErrorList,
@@ -546,6 +559,10 @@ describe("Validation", () => {
         expect(node.querySelector(".ErrorSchema").textContent).eql(
           "is required"
         );
+        expect(node.querySelectorAll(".Schema")).to.have.length.of(1);
+        expect(node.querySelector(".Schema").textContent).eql("string");
+        expect(node.querySelectorAll(".UiSchema")).to.have.length.of(1);
+        expect(node.querySelector(".UiSchema").textContent).eql("bar");
         expect(node.querySelectorAll(".foo")).to.have.length.of(1);
       });
     });

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -515,8 +515,8 @@ describe("Validation", () => {
 
       const formData = 0;
 
-      const CustomErrorList = ({ errors }) =>
-        <div className="CustomErrorList">
+      const CustomErrorList = ({ errors, formContext: { className } }) =>
+        <div className={`CustomErrorList ${className}`}>
           {errors.length} custom
         </div>;
 
@@ -526,11 +526,13 @@ describe("Validation", () => {
           liveValidate: true,
           formData,
           ErrorList: CustomErrorList,
+          formContext: { className: "foo" },
         });
         expect(node.querySelectorAll(".CustomErrorList")).to.have.length.of(1);
         expect(node.querySelector(".CustomErrorList").textContent).eql(
           "1 custom"
         );
+        expect(node.querySelectorAll(".foo")).to.have.length.of(1);
       });
     });
   });


### PR DESCRIPTION
### Reasons for making this change

`formContext` should be passed to every component that renders something for proper on-the-fly localization, styling etc.

EDIT: I passed also `errorSchema`, `schema` and `uiSchema` since they allow you to create a much more powerful & integrated component (you can pick labels from the `schema`, styles & root id from `uiSchema` to create links to the HTML id anchors where the errors are etc).

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
