### PR TITLE
Remove status from Form state (BUG FIX)

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -51,7 +51,6 @@ export default class Form extends Component {
       definitions
     );
     return {
-      status: "initial",
       schema,
       uiSchema,
       idSchema,
@@ -77,10 +76,10 @@ export default class Form extends Component {
   }
 
   renderErrors() {
-    const { status, errors, errorSchema, schema, uiSchema } = this.state;
+    const { errors, errorSchema, schema, uiSchema } = this.state;
     const { ErrorList, showErrorList, formContext } = this.props;
 
-    if (status !== "editing" && errors.length && showErrorList != false) {
+    if (errors.length && showErrorList != false) {
       return (
         <ErrorList
           errors={errors}
@@ -97,7 +96,7 @@ export default class Form extends Component {
   onChange = (formData, options = { validate: false }) => {
     const mustValidate =
       !this.props.noValidate && (this.props.liveValidate || options.validate);
-    let state = { status: "editing", formData };
+    let state = { formData };
     if (mustValidate) {
       const { errors, errorSchema } = this.validate(formData);
       state = { ...state, errors, errorSchema };
@@ -117,7 +116,6 @@ export default class Form extends Component {
 
   onSubmit = event => {
     event.preventDefault();
-    this.setState({ status: "submitted" });
 
     if (!this.props.noValidate) {
       const { errors, errorSchema } = this.validate(this.state.formData);
@@ -136,7 +134,7 @@ export default class Form extends Component {
     if (this.props.onSubmit) {
       this.props.onSubmit(this.state);
     }
-    this.setState({ status: "initial", errors: [], errorSchema: {} });
+    this.setState({ errors: [], errorSchema: {} });
   };
 
   getRegistry() {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -132,7 +132,7 @@ export default class Form extends Component {
     }
 
     if (this.props.onSubmit) {
-      this.props.onSubmit(this.state);
+      this.props.onSubmit({ ...this.state, status: "submitted" });
     }
     this.setState({ errors: [], errorSchema: {} });
   };

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -523,7 +523,7 @@ describe("Form", () => {
 
       Simulate.submit(node);
 
-      sinon.assert.calledWithExactly(onSubmit, comp.state);
+      sinon.assert.calledWithMatch(onSubmit, comp.state);
     });
 
     it("should not call provided submit handler on validation errors", () => {


### PR DESCRIPTION
### Reasons for making this change

This fixes a bug that causes the error list to flicker when formData is edited. 

**To reproduce:** go to the "Errors" tab on the playground, select an input on the Form and start smashing the keyboard (you don't really even have to smash the keyboard, you can see the effect on any single form data change). The error list will flicker.

First I thought the bug was caused by some recent commits regarding the Error List, but actually the flickering is caused by the `status` state property, which will flip between `initial` and `editing` during typing.

The `status` property has been there from the very first commit, but I can't find any real use for it other than causing this bug. I don't understand why we wouldn't show the error list when the Form is edited. Even if there was some kind of buffering that would hide the error list only when the formData is updated in intervals less time than some milliseconds, it would affect the page scrolling position before and after the user stops typing. The only side effect that removing `status` causes that I can think of is that when  `onSubmit` calls `this.props.onSubmit(this.state)`, the `state` won't contain `status: "submitted"` - which seems kind of pointless to me :)

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
