### PR TITLE
Fix minItems bug with multiSelect and formData

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -140,9 +140,13 @@ function computeDefaults(schema, parentDefaults, definitions = {}) {
 
     case "array":
       if (schema.minItems) {
-        return new Array(schema.minItems).fill(
-          computeDefaults(schema.items, defaults, definitions)
-        );
+        if (!isMultiSelect(schema, definitions)) {
+          return new Array(schema.minItems).fill(
+            computeDefaults(schema.items, defaults, definitions)
+          );
+        } else {
+          return [];
+        }
       }
   }
   return defaults;

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -410,6 +410,40 @@ describe("ArrayField", () => {
       expect(inputs[1].value).eql("Default name");
     });
 
+    it("should not add minItems extra formData entries when schema item is a multiselect", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          multipleChoicesList: {
+            type: "array",
+            minItems: 3,
+            uniqueItems: true,
+            items: {
+              type: "string",
+              enum: ["Aramis", "Athos", "Porthos", "d'Artagnan"],
+            },
+          },
+        },
+      };
+      const uiSchema = {
+        multipleChoicesList: {
+          "ui:widget": "checkboxes",
+        },
+      };
+      const form = createFormComponent({
+        schema: schema,
+        uiSchema: uiSchema,
+        formData: {},
+        liveValidate: true,
+      }).comp;
+
+      expect(form.state.formData).to.have.property("multipleChoicesList");
+      expect(form.state.formData.multipleChoicesList).to.be.empty;
+      expect(form.state.errors.length).to.equal(1);
+      expect(form.state.errors[0].name).to.equal("minItems");
+      expect(form.state.errors[0].argument).to.equal(3);
+    });
+
     it("should honor given formData, even when it does not meet ths minItems-requirement", () => {
       const complexSchema = {
         type: "object",


### PR DESCRIPTION
### Reasons for making this change

Check to see whether the field is a multiselect (select or checkboxes widget) before adding extra items up to minLength in the defaults.
This was causing extra, invalid items to be added into formData and breaking the minItems validation when no formData is initially present.

Fixes #534 

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
