### PR TITLE
Fix multipleOf IEEE-754 floats issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react": "^15.0.0"
   },
   "dependencies": {
-    "jsonschema": "^1.0.2",
+    "jsonschema": "^1.2.0",
     "lodash.topath": "^4.5.2",
     "prop-types": "^15.5.8",
     "setimmediate": "^1.0.5"


### PR DESCRIPTION
Bump `jsonschema` dependency version to include fix to this issue.
Fixed by https://github.com/tdegrunt/jsonschema/pull/228
No test changes here, as the json schema validation tests are in `jsonschema`.

### Reasons for making this change
`multipleOf` and `divisibleBy` validation for number fields did not work where the divisor was certain floating point values, due to limitations of binary representation of decimal values in IEEE-754 floats, e.g. 2.4 was not a multiple of 0.1.

relates to #342 

### Checklist

* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
