### PR TITLE
Fix ui:title for objects (#665)

### DIFF
--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -72,7 +72,7 @@ class ObjectField extends Component {
         {(uiSchema["ui:title"] || title) &&
           <TitleField
             id={`${idSchema.$id}__title`}
-            title={title || uiSchema["ui:title"]}
+            title={uiSchema["ui:title"] || title}
             required={required}
             formContext={formContext}
           />}


### PR DESCRIPTION
### Reasons for making this change

ui:title was not being applied to object properties. (#665)

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [X] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
