### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Please note that while standardized, `datetime-local` and `date` input elements 
   * `radio`: a radio button group with enum values. **can only be used when `enum` values are specified for this input**
   * by default, a regular `input[type=text]` element is used.
 
-> Note: for numbers, `min`, `max` and `step` input attributes values will be handled according to JSONSchema's `minimum`, `maximium` and `multipleOf` values when they're defined.
+> Note: for numbers, `min`, `max` and `step` input attributes values will be handled according to JSONSchema's `minimum`, `maximum` and `multipleOf` values when they're defined.
 
 #### Disabled fields
 


### PR DESCRIPTION
### Reasons for making this change

There is a typo in README, the `maximum` is actually works instead of `maximium`

### Checklist

* [X] **I'm updating documentation**
  - [X] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
