### PR TITLE
Fix #681: Warn on invalid array schema provided.

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jsdom": "^8.3.0",
     "lint-staged": "^3.3.1",
     "mocha": "^2.5.3",
-    "prettier": "^1.5.2",
+    "prettier": "^1.5.3",
     "react": "^15.5.0",
     "react-addons-test-utils": "^15.3.2",
     "react-codemirror": "^0.2.3",

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -276,10 +276,21 @@ class ArrayField extends Component {
   };
 
   render() {
-    const { schema, uiSchema, registry = getDefaultRegistry() } = this.props;
+    const {
+      schema,
+      uiSchema,
+      idSchema,
+      registry = getDefaultRegistry(),
+    } = this.props;
     const { definitions } = registry;
     if (!schema.hasOwnProperty("items")) {
-      return <UnsupportedField />;
+      return (
+        <UnsupportedField
+          schema={schema}
+          idSchema={idSchema}
+          reason="Missing items definition"
+        />
+      );
     }
     if (isFixedItems(schema)) {
       return this.renderFixedArray();

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
+import UnsupportedField from "./UnsupportedField";
 import {
   getWidget,
   getDefaultFormState,
@@ -277,6 +278,9 @@ class ArrayField extends Component {
   render() {
     const { schema, uiSchema, registry = getDefaultRegistry() } = this.props;
     const { definitions } = registry;
+    if (!schema.hasOwnProperty("items")) {
+      return <UnsupportedField />;
+    }
     if (isFixedItems(schema)) {
       return this.renderFixedArray();
     }

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -21,7 +21,7 @@ const COMPONENT_TYPES = {
   string: "StringField",
 };
 
-function getFieldComponent(schema, uiSchema, fields) {
+function getFieldComponent(schema, uiSchema, idSchema, fields) {
   const field = uiSchema["ui:field"];
   if (typeof field === "function") {
     return field;
@@ -30,7 +30,17 @@ function getFieldComponent(schema, uiSchema, fields) {
     return fields[field];
   }
   const componentName = COMPONENT_TYPES[schema.type];
-  return componentName in fields ? fields[componentName] : UnsupportedField;
+  return componentName in fields
+    ? fields[componentName]
+    : () => {
+        return (
+          <UnsupportedField
+            schema={schema}
+            idSchema={idSchema}
+            reason={`Unknown field type ${schema.type}`}
+          />
+        );
+      };
 }
 
 function Label(props) {
@@ -159,7 +169,7 @@ function SchemaFieldRender(props) {
     FieldTemplate = DefaultTemplate,
   } = registry;
   const schema = retrieveSchema(props.schema, definitions);
-  const FieldComponent = getFieldComponent(schema, uiSchema, fields);
+  const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);
   const { DescriptionField } = fields;
   const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);
   const readonly = Boolean(props.readonly || uiSchema["ui:readonly"]);

--- a/src/components/fields/UnsupportedField.js
+++ b/src/components/fields/UnsupportedField.js
@@ -5,16 +5,15 @@ function UnsupportedField({ schema, idSchema, reason }) {
   return (
     <div className="unsupported-field">
       <p>
-        Unsupported field schema{idSchema && idSchema.$id
-          ? <span>
-              for field <code>{idSchema.$id}</code>
-            </span>
-          : null}
-        {reason
-          ? <em>
-              : {reason}
-            </em>
-          : null}.
+        Unsupported field schema{idSchema &&
+          idSchema.$id &&
+          <span>
+            {" for"} field <code>{idSchema.$id}</code>
+          </span>}
+        {reason &&
+          <em>
+            : {reason}
+          </em>}.
       </p>
       {schema &&
         <pre>

--- a/src/components/fields/UnsupportedField.js
+++ b/src/components/fields/UnsupportedField.js
@@ -1,10 +1,35 @@
 import React from "react";
+import PropTypes from "prop-types";
 
-export default function UnsupportedField({ schema }) {
-  // XXX render json as string so dev can inspect faulty subschema
+function UnsupportedField({ schema, idSchema, reason }) {
   return (
     <div className="unsupported-field">
-      Unsupported field schema {JSON.stringify(schema, null, 2)}.
+      <p>
+        Unsupported field schema{idSchema && idSchema.$id
+          ? <span>
+              for field <code>{idSchema.$id}</code>
+            </span>
+          : null}
+        {reason
+          ? <em>
+              : {reason}
+            </em>
+          : null}.
+      </p>
+      {schema &&
+        <pre>
+          {JSON.stringify(schema, null, 2)}
+        </pre>}
     </div>
   );
 }
+
+if (process.env.NODE_ENV !== "production") {
+  UnsupportedField.propTypes = {
+    schema: PropTypes.object.isRequired,
+    idSchema: PropTypes.object,
+    reason: PropTypes.string,
+  };
+}
+
+export default UnsupportedField;

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -17,6 +17,16 @@ describe("ArrayField", () => {
     sandbox.restore();
   });
 
+  describe("Unsupported array schema", () => {
+    it("should warn on missing items descriptor", () => {
+      const { node } = createFormComponent({ schema: { type: "array" } });
+
+      expect(
+        node.querySelectorAll(".field-array > .unsupported-field")
+      ).to.have.length.of(1);
+    });
+  });
+
   describe("List of inputs", () => {
     const schema = {
       type: "array",

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -22,8 +22,8 @@ describe("ArrayField", () => {
       const { node } = createFormComponent({ schema: { type: "array" } });
 
       expect(
-        node.querySelectorAll(".field-array > .unsupported-field")
-      ).to.have.length.of(1);
+        node.querySelector(".field-array > .unsupported-field").textContent
+      ).to.contain("Missing items definition");
     });
   });
 

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -20,6 +20,16 @@ describe("SchemaField", () => {
     sandbox.restore();
   });
 
+  describe("Unsupported field", () => {
+    it("should warn on invalid field type", () => {
+      const { node } = createFormComponent({ schema: { type: "invalid" } });
+
+      expect(node.querySelector(".unsupported-field").textContent).to.contain(
+        "Unknown field type invalid"
+      );
+    });
+  });
+
   describe("Custom SchemaField component", () => {
     const CustomSchemaField = function(props) {
       return (


### PR DESCRIPTION
Fix #681.

I've also updated the `UnsupportedField` component to provide more details:

Invalid array schema:

![](http://i.imgur.com/gOavzBp.png)

Invalid schema type:

![](http://i.imgur.com/eKR5DWU.png)