### PR TITLE
Fix ui:description for arrays

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -113,11 +113,11 @@ function DefaultFixedArrayFieldTemplate(props) {
         required={props.required}
       />
 
-      {props.schema.description &&
+      {(props.uiSchema["ui:description"] || props.schema.description) &&
         <div
           className="field-description"
           key={`field-description-${props.idSchema.$id}`}>
-          {props.schema.description}
+          {props.uiSchema["ui:description"] || props.schema.description}
         </div>}
 
       <div
@@ -146,12 +146,14 @@ function DefaultNormalArrayFieldTemplate(props) {
         required={props.required}
       />
 
-      {props.schema.description &&
+      {(props.uiSchema["ui:description"] || props.schema.description) &&
         <ArrayFieldDescription
           key={`array-field-description-${props.idSchema.$id}`}
           DescriptionField={props.DescriptionField}
           idSchema={props.idSchema}
-          description={props.schema.description}
+          description={
+            props.uiSchema["ui:description"] || props.schema.description
+          }
         />}
 
       <div


### PR DESCRIPTION
### Reasons for making this change

`ui:description` was, similarly to `ui:title`, not showing for arrays.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
