### PR TITLE
Change field separator to double-underscore, defined as a constant

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -14,6 +14,7 @@ import {
   retrieveSchema,
   toIdSchema,
   getDefaultRegistry,
+  FIELD_SEPARATOR,
 } from "../../utils";
 
 function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
@@ -339,7 +340,7 @@ class ArrayField extends Component {
       canAdd: this.canAddItem(formData),
       items: formData.map((item, index) => {
         const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
-        const itemIdPrefix = idSchema.$id + "_" + index;
+        const itemIdPrefix = idSchema.$id + FIELD_SEPARATOR + index;
         const itemIdSchema = toIdSchema(itemsSchema, itemIdPrefix, definitions);
         return this.renderArrayFieldItem({
           index,
@@ -492,7 +493,7 @@ class ArrayField extends Component {
       items: items.map((item, index) => {
         const additional = index >= itemSchemas.length;
         const itemSchema = additional ? additionalSchema : itemSchemas[index];
-        const itemIdPrefix = idSchema.$id + "_" + index;
+        const itemIdPrefix = idSchema.$id + FIELD_SEPARATOR + index;
         const itemIdSchema = toIdSchema(itemSchema, itemIdPrefix, definitions);
         const itemUiSchema = additional
           ? uiSchema.additionalItems || {}

--- a/src/components/widgets/AltDateWidget.js
+++ b/src/components/widgets/AltDateWidget.js
@@ -1,7 +1,13 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
-import { shouldRender, parseDateString, toDateString, pad } from "../../utils";
+import {
+  shouldRender,
+  parseDateString,
+  toDateString,
+  pad,
+  FIELD_SEPARATOR,
+} from "../../utils";
 
 function rangeOptions(start, stop) {
   let options = [];
@@ -28,7 +34,7 @@ function DateElement(props) {
     registry,
     onBlur,
   } = props;
-  const id = rootId + "_" + type;
+  const id = rootId + FIELD_SEPARATOR + type;
   const { SelectWidget } = registry.widgets;
   return (
     <SelectWidget

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,8 @@
 import React from "react";
 import "setimmediate";
 
+export const FIELD_SEPARATOR = "__";
+
 const widgetMap = {
   boolean: {
     checkbox: "CheckboxWidget",
@@ -509,7 +511,7 @@ export function toIdSchema(schema, id, definitions) {
   }
   for (const name in schema.properties || {}) {
     const field = schema.properties[name];
-    const fieldId = idSchema.$id + "_" + name;
+    const fieldId = idSchema.$id + FIELD_SEPARATOR + name;
     idSchema[name] = toIdSchema(field, fieldId, definitions);
   }
   return idSchema;

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -337,7 +337,7 @@ describe("ArrayField", () => {
         formData,
       });
 
-      Simulate.change(node.querySelector("#root_1"), {
+      Simulate.change(node.querySelector("#root__1"), {
         target: { value: "" },
       });
 
@@ -352,8 +352,8 @@ describe("ArrayField", () => {
       });
 
       const inputs = node.querySelectorAll("input[type=text]");
-      expect(inputs[0].id).eql("root_0");
-      expect(inputs[1].id).eql("root_1");
+      expect(inputs[0].id).eql("root__0");
+      expect(inputs[1].id).eql("root__1");
     });
 
     it("should render nested input widgets with the expected ids", () => {
@@ -380,10 +380,10 @@ describe("ArrayField", () => {
       });
 
       const inputs = node.querySelectorAll("input[type=text]");
-      expect(inputs[0].id).eql("root_foo_0_bar");
-      expect(inputs[1].id).eql("root_foo_0_baz");
-      expect(inputs[2].id).eql("root_foo_1_bar");
-      expect(inputs[3].id).eql("root_foo_1_baz");
+      expect(inputs[0].id).eql("root__foo__0__bar");
+      expect(inputs[1].id).eql("root__foo__0__baz");
+      expect(inputs[2].id).eql("root__foo__1__bar");
+      expect(inputs[3].id).eql("root__foo__1__baz");
     });
 
     it("should render enough inputs with proper defaults to match minItems in schema when no formData is set", () => {
@@ -898,8 +898,8 @@ describe("ArrayField", () => {
       const numInput = node.querySelector(
         "fieldset .field-number input[type=text]"
       );
-      expect(strInput.id).eql("root_0");
-      expect(numInput.id).eql("root_1");
+      expect(strInput.id).eql("root__0");
+      expect(numInput.id).eql("root__1");
     });
 
     it("should mark non-null item widgets as required", () => {
@@ -949,7 +949,7 @@ describe("ArrayField", () => {
       const addInput = node.querySelector(
         "fieldset .field-string input[type=text]"
       );
-      expect(addInput.id).eql("root_2");
+      expect(addInput.id).eql("root__2");
       expect(addInput.value).eql("bar");
     });
 

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -135,7 +135,7 @@ describe("Form", () => {
     });
 
     it("should pass description as the provided React element", () => {
-      expect(node.querySelector("#root_foo__description").textContent).eql(
+      expect(node.querySelector("#root__foo__description").textContent).eql(
         "this is description"
       );
     });
@@ -361,11 +361,11 @@ describe("Form", () => {
 
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelector("#root_children_0_name")).to.not.exist;
+      expect(node.querySelector("#root__children__0__name")).to.not.exist;
 
       Simulate.click(node.querySelector(".array-item-add button"));
 
-      expect(node.querySelector("#root_children_0_name")).to.exist;
+      expect(node.querySelector("#root__children__0__name")).to.exist;
     });
 
     it("should priorize definition over schema type property", () => {
@@ -1232,7 +1232,7 @@ describe("Form", () => {
         formData: { bar: "bar" },
       });
 
-      Simulate.change(node.querySelector("#root_bar"), {
+      Simulate.change(node.querySelector("#root__bar"), {
         target: { value: "baz" },
       });
 
@@ -1253,7 +1253,7 @@ describe("Form", () => {
         formData: { foo: "foo", baz: "bar" },
       });
 
-      Simulate.change(node.querySelector("#root_baz"), {
+      Simulate.change(node.querySelector("#root__baz"), {
         target: { value: "baz" },
       });
 

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -172,8 +172,8 @@ describe("ObjectField", () => {
     it("should render the widget with the expected id", () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelector("input[type=text]").id).eql("root_foo");
-      expect(node.querySelector("input[type=checkbox]").id).eql("root_bar");
+      expect(node.querySelector("input[type=text]").id).eql("root__foo");
+      expect(node.querySelector("input[type=checkbox]").id).eql("root__bar");
     });
   });
 
@@ -336,7 +336,7 @@ describe("ObjectField", () => {
         node.querySelectorAll("input[type=text]"),
         node => node.id
       );
-      expect(ids).eql(["root_bar", "root_foo"]);
+      expect(ids).eql(["root__bar", "root__foo"]);
     });
   });
 

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -220,9 +220,9 @@ describe("SchemaField", () => {
     it("should render description if available from the schema", () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelectorAll("#root_foo__description")).to.have.length.of(
-        1
-      );
+      expect(
+        node.querySelectorAll("#root__foo__description")
+      ).to.have.length.of(1);
     });
 
     it("should render description if available from a referenced schema", () => {
@@ -242,7 +242,7 @@ describe("SchemaField", () => {
       };
       const { node } = createFormComponent({ schema: schemaWithReference });
 
-      const matches = node.querySelectorAll("#root_foo__description");
+      const matches = node.querySelectorAll("#root__foo__description");
       expect(matches).to.have.length.of(1);
       expect(matches[0].textContent).to.equal("A Foo field");
     });
@@ -250,9 +250,9 @@ describe("SchemaField", () => {
     it("should not render description if not available from schema", () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelectorAll("#root_bar__description")).to.have.length.of(
-        0
-      );
+      expect(
+        node.querySelectorAll("#root__bar__description")
+      ).to.have.length.of(0);
     });
 
     it("should render a customized description field", () => {

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -677,22 +677,22 @@ describe("StringField", () => {
         uiSchema,
       });
 
-      Simulate.change(node.querySelector("#root_year"), {
+      Simulate.change(node.querySelector("#root__year"), {
         target: { value: 2012 },
       });
-      Simulate.change(node.querySelector("#root_month"), {
+      Simulate.change(node.querySelector("#root__month"), {
         target: { value: 10 },
       });
-      Simulate.change(node.querySelector("#root_day"), {
+      Simulate.change(node.querySelector("#root__day"), {
         target: { value: 2 },
       });
-      Simulate.change(node.querySelector("#root_hour"), {
+      Simulate.change(node.querySelector("#root__hour"), {
         target: { value: 1 },
       });
-      Simulate.change(node.querySelector("#root_minute"), {
+      Simulate.change(node.querySelector("#root__minute"), {
         target: { value: 2 },
       });
-      Simulate.change(node.querySelector("#root_second"), {
+      Simulate.change(node.querySelector("#root__second"), {
         target: { value: 3 },
       });
 
@@ -724,12 +724,12 @@ describe("StringField", () => {
       const ids = [].map.call(node.querySelectorAll("select"), node => node.id);
 
       expect(ids).eql([
-        "root_year",
-        "root_month",
-        "root_day",
-        "root_hour",
-        "root_minute",
-        "root_second",
+        "root__year",
+        "root__month",
+        "root__day",
+        "root__hour",
+        "root__minute",
+        "root__second",
       ]);
     });
 
@@ -755,7 +755,7 @@ describe("StringField", () => {
         60 + 1,
         60 + 1,
       ]);
-      const monthOptions = node.querySelectorAll("select#root_month option");
+      const monthOptions = node.querySelectorAll("select#root__month option");
       const monthOptionsValues = [].map.call(monthOptions, o => o.value);
       expect(monthOptionsValues).eql([
         "",
@@ -783,7 +783,7 @@ describe("StringField", () => {
         uiSchema,
       });
 
-      const monthOptions = node.querySelectorAll("select#root_month option");
+      const monthOptions = node.querySelectorAll("select#root__month option");
       const monthOptionsLabels = [].map.call(monthOptions, o => o.text);
       expect(monthOptionsLabels).eql([
         "month",
@@ -938,13 +938,13 @@ describe("StringField", () => {
         uiSchema,
       });
 
-      Simulate.change(node.querySelector("#root_year"), {
+      Simulate.change(node.querySelector("#root__year"), {
         target: { value: 2012 },
       });
-      Simulate.change(node.querySelector("#root_month"), {
+      Simulate.change(node.querySelector("#root__month"), {
         target: { value: 10 },
       });
-      Simulate.change(node.querySelector("#root_day"), {
+      Simulate.change(node.querySelector("#root__day"), {
         target: { value: 2 },
       });
 
@@ -976,7 +976,7 @@ describe("StringField", () => {
 
       const ids = [].map.call(node.querySelectorAll("select"), node => node.id);
 
-      expect(ids).eql(["root_year", "root_month", "root_day"]);
+      expect(ids).eql(["root__year", "root__month", "root__day"]);
     });
 
     it("should render the widgets with the expected options' values", () => {
@@ -998,7 +998,7 @@ describe("StringField", () => {
         12 + 1,
         31 + 1,
       ]);
-      const monthOptions = node.querySelectorAll("select#root_month option");
+      const monthOptions = node.querySelectorAll("select#root__month option");
       const monthOptionsValues = [].map.call(monthOptions, o => o.value);
       expect(monthOptionsValues).eql([
         "",
@@ -1026,7 +1026,7 @@ describe("StringField", () => {
         uiSchema,
       });
 
-      const monthOptions = node.querySelectorAll("select#root_month option");
+      const monthOptions = node.querySelectorAll("select#root__month option");
       const monthOptionsLabels = [].map.call(monthOptions, o => o.text);
       expect(monthOptionsLabels).eql([
         "month",

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -71,8 +71,8 @@ describe("Rendering performance optimizations", () => {
 
       setProps(comp, { schema, formData: { const: "0", var: "1" } });
 
-      sinon.assert.notCalled(fields.root_const.render);
-      sinon.assert.calledOnce(fields.root_var.render);
+      sinon.assert.notCalled(fields.root__const.render);
+      sinon.assert.calledOnce(fields.root__var.render);
     });
 
     it("should only render changed array items", () => {
@@ -97,8 +97,8 @@ describe("Rendering performance optimizations", () => {
 
       setProps(comp, { schema, formData: ["const", "var1"] });
 
-      sinon.assert.notCalled(fields.root_0.render);
-      sinon.assert.calledOnce(fields.root_1.render);
+      sinon.assert.notCalled(fields.root__0.render);
+      sinon.assert.calledOnce(fields.root__1.render);
     });
   });
 
@@ -114,7 +114,7 @@ describe("Rendering performance optimizations", () => {
         foo: { type: "string" },
       },
     };
-    const idSchema = { $id: "root", foo: { $id: "root_plop" } };
+    const idSchema = { $id: "root", foo: { $id: "root__plop" } };
 
     it("should not render if next props are equivalent", () => {
       const props = {

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -1449,7 +1449,7 @@ describe("uiSchema", () => {
         node.querySelectorAll("input[type=text]"),
         node => node.id
       );
-      expect(ids).eql(["myform_foo", "myform_bar"]);
+      expect(ids).eql(["myform__foo", "myform__bar"]);
     });
 
     it("should use a custom root field id for arrays", () => {
@@ -1468,7 +1468,7 @@ describe("uiSchema", () => {
         node.querySelectorAll("input[type=text]"),
         node => node.id
       );
-      expect(ids).eql(["myform_0", "myform_1"]);
+      expect(ids).eql(["myform__0", "myform__1"]);
     });
 
     it("should use a custom root field id for array of objects", () => {
@@ -1494,10 +1494,10 @@ describe("uiSchema", () => {
         node => node.id
       );
       expect(ids).eql([
-        "myform_0_foo",
-        "myform_0_bar",
-        "myform_1_foo",
-        "myform_1_bar",
+        "myform__0__foo",
+        "myform__0__bar",
+        "myform__1__foo",
+        "myform__1__bar",
       ]);
     });
   });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -601,8 +601,8 @@ describe("utils", () => {
       expect(toIdSchema(schema)).eql({
         $id: "root",
         level1: {
-          $id: "root_level1",
-          level2: { $id: "root_level1_level2" },
+          $id: "root__level1",
+          level2: { $id: "root__level1__level2" },
         },
       });
     });
@@ -631,14 +631,14 @@ describe("utils", () => {
       expect(toIdSchema(schema)).eql({
         $id: "root",
         level1a: {
-          $id: "root_level1a",
-          level1a2a: { $id: "root_level1a_level1a2a" },
-          level1a2b: { $id: "root_level1a_level1a2b" },
+          $id: "root__level1a",
+          level1a2a: { $id: "root__level1a__level1a2a" },
+          level1a2b: { $id: "root__level1a__level1a2b" },
         },
         level1b: {
-          $id: "root_level1b",
-          level1b2a: { $id: "root_level1b_level1b2a" },
-          level1b2b: { $id: "root_level1b_level1b2b" },
+          $id: "root__level1b",
+          level1b2a: { $id: "root__level1b__level1b2a" },
+          level1b2b: { $id: "root__level1b__level1b2b" },
         },
       });
     });
@@ -661,8 +661,8 @@ describe("utils", () => {
       expect(toIdSchema(schema)).eql({
         $id: "root",
         metadata: {
-          $id: "root_metadata",
-          id: { $id: "root_metadata_id" },
+          $id: "root__metadata",
+          id: { $id: "root__metadata__id" },
         },
       });
     });
@@ -680,7 +680,7 @@ describe("utils", () => {
 
       expect(toIdSchema(schema)).eql({
         $id: "root",
-        foo: { $id: "root_foo" },
+        foo: { $id: "root__foo" },
       });
     });
 
@@ -700,8 +700,8 @@ describe("utils", () => {
 
       expect(toIdSchema(schema, undefined, schema.definitions)).eql({
         $id: "root",
-        foo: { $id: "root_foo" },
-        bar: { $id: "root_bar" },
+        foo: { $id: "root__foo" },
+        bar: { $id: "root__bar" },
       });
     });
   });


### PR DESCRIPTION
### Reasons for making this change

`idSchema.$id` currently uses `_` to separate fields. Some apps need to parse id (e.g. to navigate a redux global state tree). 

Problem: Having a single underscore as field separator prevents form field names from containing underscore -- non-field-separating underscores are confused with actual field separators. 

While JS style is camelCase, may be too rigid a constraint. E.g. for our current project, we are attempting to port a python app which liberally uses underscores, and forcing field name changes to exclude underscore is too imposing.

### Proposed solution

Replace single underscore with double underscore. Although a double-underscore is still somewhat arbitrary, it should accommodate the majority of cases.

### Changes made

This is an internal change. Thus, the primary goal was to ensure all existing tests pass. 

Besides the double-underscore change, the only other diffs were formatting changes introduced by Prettier (`npm run cs-format`). Seems strange that it would cause so many formatting diffs? 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
