### PR TITLE
Allow overriding of unsupported field

### DIFF
--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -7,7 +7,7 @@ import {
   getDefaultRegistry,
   getUiOptions,
   isFilesArray,
-  deepEquals
+  deepEquals,
 } from "../../utils";
 
 const REQUIRED_FIELD_SYMBOL = "*";
@@ -17,7 +17,7 @@ const COMPONENT_TYPES = {
   integer: "NumberField",
   number: "NumberField",
   object: "ObjectField",
-  string: "StringField"
+  string: "StringField",
 };
 
 function getFieldComponent(schema, uiSchema, idSchema, fields) {
@@ -100,7 +100,7 @@ function DefaultTemplate(props) {
     description,
     hidden,
     required,
-    displayLabel
+    displayLabel,
   } = props;
   if (hidden) {
     return children;
@@ -134,7 +134,7 @@ if (process.env.NODE_ENV !== "production") {
     readonly: PropTypes.bool,
     displayLabel: PropTypes.bool,
     fields: PropTypes.object,
-    formContext: PropTypes.object
+    formContext: PropTypes.object,
   };
 }
 
@@ -142,7 +142,7 @@ DefaultTemplate.defaultProps = {
   hidden: false,
   readonly: false,
   required: false,
-  displayLabel: true
+  displayLabel: true,
 };
 
 function SchemaFieldRender(props) {
@@ -152,13 +152,13 @@ function SchemaFieldRender(props) {
     idSchema,
     name,
     required,
-    registry = getDefaultRegistry()
+    registry = getDefaultRegistry(),
   } = props;
   const {
     definitions,
     fields,
     formContext,
-    FieldTemplate = DefaultTemplate
+    FieldTemplate = DefaultTemplate,
   } = registry;
   const schema = retrieveSchema(props.schema, definitions);
   const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);
@@ -221,7 +221,7 @@ function SchemaFieldRender(props) {
     "field",
     `field-${type}`,
     errors && errors.length > 0 ? "field-error has-error has-danger" : "",
-    uiSchema.classNames
+    uiSchema.classNames,
   ]
     .join(" ")
     .trim();
@@ -249,7 +249,7 @@ function SchemaFieldRender(props) {
     formContext,
     fields,
     schema,
-    uiSchema
+    uiSchema,
   };
 
   return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
@@ -276,7 +276,7 @@ SchemaField.defaultProps = {
   idSchema: {},
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -294,8 +294,8 @@ if (process.env.NODE_ENV !== "production") {
       definitions: PropTypes.object.isRequired,
       ArrayFieldTemplate: PropTypes.func,
       FieldTemplate: PropTypes.func,
-      formContext: PropTypes.object.isRequired
-    })
+      formContext: PropTypes.object.isRequired,
+    }),
   };
 }
 

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -7,9 +7,8 @@ import {
   getDefaultRegistry,
   getUiOptions,
   isFilesArray,
-  deepEquals,
+  deepEquals
 } from "../../utils";
-import UnsupportedField from "./UnsupportedField";
 
 const REQUIRED_FIELD_SYMBOL = "*";
 const COMPONENT_TYPES = {
@@ -18,7 +17,7 @@ const COMPONENT_TYPES = {
   integer: "NumberField",
   number: "NumberField",
   object: "ObjectField",
-  string: "StringField",
+  string: "StringField"
 };
 
 function getFieldComponent(schema, uiSchema, idSchema, fields) {
@@ -33,8 +32,9 @@ function getFieldComponent(schema, uiSchema, idSchema, fields) {
   return componentName in fields
     ? fields[componentName]
     : () => {
+        const UF = fields["UnsupportedField"];
         return (
-          <UnsupportedField
+          <UF
             schema={schema}
             idSchema={idSchema}
             reason={`Unknown field type ${schema.type}`}
@@ -100,7 +100,7 @@ function DefaultTemplate(props) {
     description,
     hidden,
     required,
-    displayLabel,
+    displayLabel
   } = props;
   if (hidden) {
     return children;
@@ -134,7 +134,7 @@ if (process.env.NODE_ENV !== "production") {
     readonly: PropTypes.bool,
     displayLabel: PropTypes.bool,
     fields: PropTypes.object,
-    formContext: PropTypes.object,
+    formContext: PropTypes.object
   };
 }
 
@@ -142,7 +142,7 @@ DefaultTemplate.defaultProps = {
   hidden: false,
   readonly: false,
   required: false,
-  displayLabel: true,
+  displayLabel: true
 };
 
 function SchemaFieldRender(props) {
@@ -152,13 +152,13 @@ function SchemaFieldRender(props) {
     idSchema,
     name,
     required,
-    registry = getDefaultRegistry(),
+    registry = getDefaultRegistry()
   } = props;
   const {
     definitions,
     fields,
     formContext,
-    FieldTemplate = DefaultTemplate,
+    FieldTemplate = DefaultTemplate
   } = registry;
   const schema = retrieveSchema(props.schema, definitions);
   const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);
@@ -221,7 +221,7 @@ function SchemaFieldRender(props) {
     "field",
     `field-${type}`,
     errors && errors.length > 0 ? "field-error has-error has-danger" : "",
-    uiSchema.classNames,
+    uiSchema.classNames
   ]
     .join(" ")
     .trim();
@@ -249,7 +249,7 @@ function SchemaFieldRender(props) {
     formContext,
     fields,
     schema,
-    uiSchema,
+    uiSchema
   };
 
   return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
@@ -276,7 +276,7 @@ SchemaField.defaultProps = {
   idSchema: {},
   disabled: false,
   readonly: false,
-  autofocus: false,
+  autofocus: false
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -294,8 +294,8 @@ if (process.env.NODE_ENV !== "production") {
       definitions: PropTypes.object.isRequired,
       ArrayFieldTemplate: PropTypes.func,
       FieldTemplate: PropTypes.func,
-      formContext: PropTypes.object.isRequired,
-    }),
+      formContext: PropTypes.object.isRequired
+    })
   };
 }
 


### PR DESCRIPTION
### Reasons for making this change

I would like to be able to create a custom component to display unsupported field errors. 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
