### PR TITLE
Make BaseInput overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
      - [Custom widget components](#custom-widget-components)
         - [Custom component registration](#custom-component-registration)
         - [Custom widget options](#custom-widget-options)
+        - [Customizing widgets' text input](#customizing-widgets-text-input)
      - [Custom field components](#custom-field-components)
         - [Field props](#field-props)
         - [The registry object](#the-registry-object)
@@ -1037,6 +1038,10 @@ render((
 > Note: This also applies to [registered custom components](#custom-component-registration).
 
 > Note: Since v0.41.0, the `ui:widget` object API, where a widget and options were specified with `"ui:widget": {component, options}` shape, is deprecated. It will be removed in a future release.
+
+#### Customizing widgets' text input
+
+All the widgets that render a text input use the `BaseInput` component internally. If you need to customize all text inputs without customizing all widgets individially, you can provide a `BaseInput` component in the `widgets` property of `Form` (see [Custom component registration](#custom-component-registration).
 
 ### Custom field components
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -66,28 +66,30 @@ function DefaultArrayItem(props) {
             className="btn-group"
             style={{ display: "flex", justifyContent: "space-around" }}>
             {(props.hasMoveUp || props.hasMoveDown) && (
-              <IconBtn
-                icon="arrow-up"
-                className="array-item-move-up"
-                tabIndex="-1"
-                style={btnStyle}
-                disabled={props.disabled || props.readonly || !props.hasMoveUp}
-                onClick={props.onReorderClick(props.index, props.index - 1)}
-              />
-            )}
+                <IconBtn
+                  icon="arrow-up"
+                  className="array-item-move-up"
+                  tabIndex="-1"
+                  style={btnStyle}
+                  disabled={
+                    props.disabled || props.readonly || !props.hasMoveUp
+                  }
+                  onClick={props.onReorderClick(props.index, props.index - 1)}
+                />
+              )}
 
             {(props.hasMoveUp || props.hasMoveDown) && (
-              <IconBtn
-                icon="arrow-down"
-                className="array-item-move-down"
-                tabIndex="-1"
-                style={btnStyle}
-                disabled={
-                  props.disabled || props.readonly || !props.hasMoveDown
-                }
-                onClick={props.onReorderClick(props.index, props.index + 1)}
-              />
-            )}
+                <IconBtn
+                  icon="arrow-down"
+                  className="array-item-move-down"
+                  tabIndex="-1"
+                  style={btnStyle}
+                  disabled={
+                    props.disabled || props.readonly || !props.hasMoveDown
+                  }
+                  onClick={props.onReorderClick(props.index, props.index + 1)}
+                />
+              )}
 
             {props.hasRemove && (
               <IconBtn
@@ -119,12 +121,12 @@ function DefaultFixedArrayFieldTemplate(props) {
       />
 
       {(props.uiSchema["ui:description"] || props.schema.description) && (
-        <div
-          className="field-description"
-          key={`field-description-${props.idSchema.$id}`}>
-          {props.uiSchema["ui:description"] || props.schema.description}
-        </div>
-      )}
+          <div
+            className="field-description"
+            key={`field-description-${props.idSchema.$id}`}>
+            {props.uiSchema["ui:description"] || props.schema.description}
+          </div>
+        )}
 
       <div
         className="row array-item-list"
@@ -154,15 +156,15 @@ function DefaultNormalArrayFieldTemplate(props) {
       />
 
       {(props.uiSchema["ui:description"] || props.schema.description) && (
-        <ArrayFieldDescription
-          key={`array-field-description-${props.idSchema.$id}`}
-          DescriptionField={props.DescriptionField}
-          idSchema={props.idSchema}
-          description={
-            props.uiSchema["ui:description"] || props.schema.description
-          }
-        />
-      )}
+          <ArrayFieldDescription
+            key={`array-field-description-${props.idSchema.$id}`}
+            DescriptionField={props.DescriptionField}
+            idSchema={props.idSchema}
+            description={
+              props.uiSchema["ui:description"] || props.schema.description
+            }
+          />
+        )}
 
       <div
         className="row array-item-list"

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -68,20 +68,20 @@ class ObjectField extends Component {
     return (
       <fieldset>
         {(uiSchema["ui:title"] || title) && (
-          <TitleField
-            id={`${idSchema.$id}__title`}
-            title={uiSchema["ui:title"] || title}
-            required={required}
-            formContext={formContext}
-          />
-        )}
+            <TitleField
+              id={`${idSchema.$id}__title`}
+              title={uiSchema["ui:title"] || title}
+              required={required}
+              formContext={formContext}
+            />
+          )}
         {(uiSchema["ui:description"] || schema.description) && (
-          <DescriptionField
-            id={`${idSchema.$id}__description`}
-            description={uiSchema["ui:description"] || schema.description}
-            formContext={formContext}
-          />
-        )}
+            <DescriptionField
+              id={`${idSchema.$id}__description`}
+              description={uiSchema["ui:description"] || schema.description}
+              formContext={formContext}
+            />
+          )}
         {orderedProperties.map((name, index) => {
           return (
             <SchemaField

--- a/src/components/fields/UnsupportedField.js
+++ b/src/components/fields/UnsupportedField.js
@@ -6,11 +6,11 @@ function UnsupportedField({ schema, idSchema, reason }) {
     <div className="unsupported-field">
       <p>
         Unsupported field schema{idSchema &&
-        idSchema.$id && (
-          <span>
-            {" for"} field <code>{idSchema.$id}</code>
-          </span>
-        )}
+          idSchema.$id && (
+            <span>
+              {" for"} field <code>{idSchema.$id}</code>
+            </span>
+          )}
         {reason && <em>: {reason}</em>}.
       </p>
       {schema && <pre>{JSON.stringify(schema, null, 2)}</pre>}

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -1,10 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import BaseInput from "./BaseInput";
-
 function ColorWidget(props) {
-  const { disabled, readonly } = props;
+  const { disabled, readonly, registry: { widgets: { BaseInput } } } = props;
   return <BaseInput type="color" {...props} disabled={disabled || readonly} />;
 }
 

--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -14,7 +14,7 @@ function toJSONDate(dateString) {
 }
 
 function DateTimeWidget(props) {
-  const { value, onChange } = props;
+  const { value, onChange, registry: { widgets: { BaseInput } } } = props;
   return (
     <BaseInput
       type="datetime-local"

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import BaseInput from "./BaseInput";
 
 function DateWidget(props) {
-  const { onChange } = props;
+  const { onChange, registry: { widgets: { BaseInput } } } = props;
   return (
     <BaseInput
       type="date"

--- a/src/components/widgets/EmailWidget.js
+++ b/src/components/widgets/EmailWidget.js
@@ -1,9 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import BaseInput from "./BaseInput";
-
 function EmailWidget(props) {
+  const { BaseInput } = props.registry.widgets;
   return <BaseInput type="email" {...props} />;
 }
 

--- a/src/components/widgets/PasswordWidget.js
+++ b/src/components/widgets/PasswordWidget.js
@@ -1,9 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import BaseInput from "./BaseInput";
-
 function PasswordWidget(props) {
+  const { BaseInput } = props.registry.widgets;
   return <BaseInput type="password" {...props} />;
 }
 

--- a/src/components/widgets/RangeWidget.js
+++ b/src/components/widgets/RangeWidget.js
@@ -2,10 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { rangeSpec } from "../../utils";
-import BaseInput from "./BaseInput";
 
 function RangeWidget(props) {
-  const { schema, value } = props;
+  const { schema, value, registry: { widgets: { BaseInput } } } = props;
   return (
     <div className="field-range-wrapper">
       <BaseInput type="range" {...props} {...rangeSpec(schema)} />

--- a/src/components/widgets/TextWidget.js
+++ b/src/components/widgets/TextWidget.js
@@ -1,9 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import BaseInput from "./BaseInput";
-
 function TextWidget(props) {
+  const { BaseInput } = props.registry.widgets;
   return <BaseInput {...props} />;
 }
 

--- a/src/components/widgets/URLWidget.js
+++ b/src/components/widgets/URLWidget.js
@@ -1,9 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import BaseInput from "./BaseInput";
-
 function URLWidget(props) {
+  const { BaseInput } = props.registry.widgets;
   return <BaseInput type="url" {...props} />;
 }
 

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -1,5 +1,6 @@
 import AltDateWidget from "./AltDateWidget";
 import AltDateTimeWidget from "./AltDateTimeWidget";
+import BaseInput from "./BaseInput";
 import CheckboxWidget from "./CheckboxWidget";
 import CheckboxesWidget from "./CheckboxesWidget";
 import ColorWidget from "./ColorWidget";
@@ -18,6 +19,7 @@ import URLWidget from "./URLWidget";
 import UpDownWidget from "./UpDownWidget";
 
 export default {
+  BaseInput,
   PasswordWidget,
   RadioWidget,
   UpDownWidget,


### PR DESCRIPTION
### Reasons for making this change

All the other components in registry fields & widgets are overridable. BaseInput shouldn't be an exception. Customizing BaseInput is useful e.g. for propagating changes only on text input blur.

BTW there is something wrong with the npm commit hook - after pushing the first commit I noticed that some files were prettified after pushing, but the prettified changes were in git staging and weren't pushed. 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
