### PR TITLE
UpDownWidget not correctly using BaseInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "publish-to-gh-pages": "npm run build:playground && gh-pages --dist build/",
     "publish-to-npm": "npm run build:readme && npm run dist && npm publish",
     "start": "node devServer.js",
-    "tdd": "cross-env NODE_ENV=test  mocha --compilers js:babel-register --watch --require ./test/setup-jsdom.js test/**/*_test.js",
-    "test": "cross-env NODE_ENV=test   mocha --compilers js:babel-register --require ./test/setup-jsdom.js test/**/*_test.js"
+    "tdd": "cross-env NODE_ENV=test mocha --compilers js:babel-register --watch --require ./test/setup-jsdom.js test/**/*_test.js",
+    "test": "cross-env NODE_ENV=test mocha --compilers js:babel-register --require ./test/setup-jsdom.js test/**/*_test.js"
   },
   "prettierOptions": "--jsx-bracket-same-line --trailing-comma es5 --semi",
   "lint-staged": {

--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -1,8 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import BaseInput from "./BaseInput";
-
 function fromJSONDate(jsonDate) {
   return jsonDate ? jsonDate.slice(0, 19) : "";
 }

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -1,8 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import BaseInput from "./BaseInput";
-
 function DateWidget(props) {
   const { onChange, registry: { widgets: { BaseInput } } } = props;
   return (

--- a/src/components/widgets/UpDownWidget.js
+++ b/src/components/widgets/UpDownWidget.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { rangeSpec } from "../../utils";
-import BaseInput from "./BaseInput";
 
 function UpDownWidget(props) {
   const { registry: { widgets: { BaseInput } } } = props;

--- a/src/components/widgets/UpDownWidget.js
+++ b/src/components/widgets/UpDownWidget.js
@@ -5,6 +5,7 @@ import { rangeSpec } from "../../utils";
 import BaseInput from "./BaseInput";
 
 function UpDownWidget(props) {
+  const { registry: { widgets: { BaseInput } } } = props;
   return <BaseInput type="number" {...props} {...rangeSpec(props.schema)} />;
 }
 

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -482,6 +482,20 @@ describe("StringField", () => {
 
       expect(node.querySelector("#custom")).to.exist;
     });
+
+    it("should allow overriding of BaseInput", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "date-time",
+        },
+        widgets: {
+          BaseInput: CustomWidget,
+        },
+      });
+
+      expect(node.querySelector("#custom")).to.exist;
+    });
   });
 
   describe("DateWidget", () => {
@@ -619,6 +633,20 @@ describe("StringField", () => {
         },
         widgets: {
           DateWidget: CustomWidget,
+        },
+      });
+
+      expect(node.querySelector("#custom")).to.exist;
+    });
+
+    it("should allow overriding of BaseInput", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "date",
+        },
+        widgets: {
+          BaseInput: CustomWidget,
         },
       });
 
@@ -1544,6 +1572,22 @@ describe("StringField", () => {
         },
         widgets: {
           FileWidget: CustomWidget,
+        },
+      });
+
+      expect(node.querySelector("#custom")).to.exist;
+    });
+  });
+
+  describe("UpDownWidget", () => {
+    it("should allow overriding of BaseInput", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "number",
+          format: "updown",
+        },
+        widgets: {
+          BaseInput: CustomWidget,
         },
       });
 


### PR DESCRIPTION
### Reasons for making this change

Whilst attempting to override the BaseInput, I noticed it wasn't being applied for the UpDownWidget.
This change adds a test case for all widgets that use BaseInput to make sure they can be overridden successfully.

I've also removed all instances where BaseInput was required directly, and instead made it always come from the registry for consistency.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
