### PR TITLE
Fixed customObject sample to fix "Objects are not valid as a React ch…

### DIFF
--- a/playground/samples/customObject.js
+++ b/playground/samples/customObject.js
@@ -6,7 +6,7 @@ function ObjectFieldTemplate({ TitleField, properties, title, description }) {
       <TitleField title={title} />
       <div className="row">
         {properties.map(prop => (
-          <div className="col-lg-2 col-md-4 col-sm-6 col-xs-12">{prop}</div>
+          <div className="col-lg-2 col-md-4 col-sm-6 col-xs-12" key={prop.content.key}>{prop.content}</div>
         ))}
       </div>
       {description}


### PR DESCRIPTION
…ild" error for react 15.6.1 and to avoid "https://fb.me/react-warning-keys" warning

### Reasons for making this change

The sample for customObject.js had few defects. React 15.6.1 throws an no-keys-defined warning as well as 'child-can-not-be-objects' exception. The code has been changed to fix these issues

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
