### PR TITLE
Add `checked` class name for RadioWidget

### DIFF
--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -39,7 +39,9 @@ function RadioWidget(props) {
         );
 
         return inline ? (
-          <label key={i} className={`radio-inline ${disabledCls} ${checkedCls}`}>
+          <label
+            key={i}
+            className={`radio-inline ${disabledCls} ${checkedCls}`}>
             {radio}
           </label>
         ) : (

--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -21,6 +21,7 @@ function RadioWidget(props) {
       {enumOptions.map((option, i) => {
         const checked = option.value === value;
         const disabledCls = disabled || readonly ? "disabled" : "";
+        const checkedCls = checked ? "checked" : "";
         const radio = (
           <span>
             <input
@@ -38,11 +39,11 @@ function RadioWidget(props) {
         );
 
         return inline ? (
-          <label key={i} className={`radio-inline ${disabledCls}`}>
+          <label key={i} className={`radio-inline ${disabledCls} ${checkedCls}`}>
             {radio}
           </label>
         ) : (
-          <div key={i} className={`radio ${disabledCls}`}>
+          <div key={i} className={`radio ${disabledCls} ${checkedCls}`}>
             <label>{radio}</label>
           </div>
         );


### PR DESCRIPTION
### Reasons for making this change

Add `checked` class name for RadioWidget, just like `disabled` class name it has. 

Sometimes we customize the style for `input[checked]` by hiding the default `input[type=radio]` itself and instead, we use a pseudo element like below: 

```css
input[type=radio] {
    opacity: 0;
}
.radio:before{
    content: "";
    box-sizing:border-box;
    position: relative;
    top: 2px;
    bottom: 0;
    width: 14px;
    height: 14px;
    z-index:2;
    border:1px solid #666;
    border-radius: 100%;
    display: inline-block;
    margin-right:9px;
}
.radio.checked:after{
    content: "";
    position: absolute;
    z-index:3;
    top:16px;
    left:3px;
    width:8px;
    height:8px;
    background: #666;
    border-radius: 100%;
}
```

Therefore, a `checked` class will be useful.

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
