### PR TITLE
Make form submission example clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ WARNING: If you have situations where your parent component can re-render, make 
 You can pass a function as the `onSubmit` prop of your `Form` component to listen to when the form is submitted and its data are valid. It will be passed a result object having a `formData` attribute, which is the valid form data you're usually after:
 
 ```js
-const onSubmit = ({formData}) => console.log("yay I'm valid!");
+const onSubmit = ({form}) => console.log("Data submitted: "+form.formData);
 
 render((
   <Form schema={schema}


### PR DESCRIPTION
### Reasons for making this change

In the example, the `onSubmit` function receives a `formData` obj. However, the actual data is in `formData.formData`. While this is explained in the docs, I propose making it clearer in the example as well.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
