### PR TITLE
Check if object in mergeObjects

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -210,6 +210,8 @@ export function isObject(thing) {
 }
 
 export function mergeObjects(obj1, obj2, concatArrays = false) {
+  obj1 = obj1 instanceof Object ? obj1 : {};
+  obj2 = obj2 instanceof Object ? obj2 : {};
   // Recursively merge deeply nested objects.
   var acc = Object.assign({}, obj1); // Prevent mutation of source object.
   return Object.keys(obj2).reduce((acc, key) => {


### PR DESCRIPTION
### Reasons for making this change
Merge objects should check that both inputs are in fact objects and if not should make them be empty objects. This allows for merging objects such as the following:

`obj1 = {a: {b: 1}}` and `obj2={a: undefined}`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [X] I've updated docs if needed
  - [X] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
