### PR TITLE
Add span and class to label required symbol

### DIFF
--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -51,7 +51,8 @@ function Label(props) {
   }
   return (
     <label className="control-label" htmlFor={id}>
-      {required ? label + REQUIRED_FIELD_SYMBOL : label}
+      {label}
+      {required && <span className="required">{REQUIRED_FIELD_SYMBOL}</span>}
     </label>
   );
 }


### PR DESCRIPTION
### Reasons for making this change
Currently a label's required symbol is pure text string. There is no way to style this without creating a custom component/field/widget.

I've added a span and class name to the required symbol.

No unit tests have been added for this new small span element. I wanted to do this, but I don't have the time right now to learn how to do this with the test config/library(s) in use.


### Checklist

* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
