### PR TITLE
Remove p tag surrounding submit button

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -208,11 +208,11 @@ export default class Form extends Component {
         {children ? (
           children
         ) : (
-          <p>
+          <div>
             <button type="submit" className="btn btn-info">
               Submit
             </button>
-          </p>
+          </div>
         )}
       </form>
     );


### PR DESCRIPTION
### Reasons for making this change

- I don't see a need to have a paragraph surrounding a submit button
- having this wrapping p tag can cause unwanted styles (eg typically a margin)
- IMO for a submit button, a div is more semantic than a paragraph tag, since it's not a paragraph 😄 

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
