### PR TITLE
Add key to stop Array forms scroll up on playground

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -204,6 +204,7 @@ class Editor extends Component {
     const { title, theme } = this.props;
     const icon = this.state.valid ? "ok" : "remove";
     const cls = this.state.valid ? "valid" : "invalid";
+    const uuid = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
     return (
       <div className="panel panel-default">
         <div className="panel-heading">
@@ -211,6 +212,7 @@ class Editor extends Component {
           {" " + title}
         </div>
         <CodeMirror
+          key={uuid}
           value={this.state.code}
           onChange={this.onCodeChange}
           options={Object.assign({}, cmOptions, { theme })}

--- a/playground/app.js
+++ b/playground/app.js
@@ -204,7 +204,13 @@ class Editor extends Component {
     const { title, theme } = this.props;
     const icon = this.state.valid ? "ok" : "remove";
     const cls = this.state.valid ? "valid" : "invalid";
-    const uuid = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+    const uuid =
+      Math.random()
+        .toString(36)
+        .substring(2, 15) +
+      Math.random()
+        .toString(36)
+        .substring(2, 15);
     return (
       <div className="panel panel-default">
         <div className="panel-heading">


### PR DESCRIPTION
### Reasons for making this change

On long forms with Array/Nested forms, onChange, the playground will scroll up. This is weird behavior and bad UX. By setting a key this is solved.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
