### PR TITLE
Fix onAddClick signature in ArrayFieldTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,7 +890,7 @@ The following props are passed to each `ArrayFieldTemplate`:
 - `disabled`: A boolean value stating if the array is disabled.
 - `idSchema`: Object
 - `items`: An array of objects representing the items in the array. Each of the items represent a child with properties described below.
-- `onAddClick: (event) => (event) => void`: Returns a function that adds a new item to the array.
+- `onAddClick: (event) => void`: A function that adds a new item to the array.
 - `readonly`: A boolean value stating if the array is read-only.
 - `required`: A boolean value stating if the array is required.
 - `schema`: The schema object for this array.


### PR DESCRIPTION
### Reasons for making this change

According source code `onAddClick` is not returning function as specified in the documentation.
https://github.com/mozilla-services/react-jsonschema-form/blob/master/src/components/fields/ArrayField.js#L224


### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
