### PR TITLE
Expose Ajv in order to support alternate schemas

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -7,9 +7,11 @@ import {
   shouldRender,
   toIdSchema,
   setState,
-  getDefaultRegistry,
+  getDefaultRegistry
 } from "../utils";
-import validateFormData from "../validate";
+import { getValidator, validateFormData } from "../validate";
+
+export { getValidator };
 
 export default class Form extends Component {
   static defaultProps = {
@@ -18,7 +20,7 @@ export default class Form extends Component {
     liveValidate: false,
     safeRenderCompletion: false,
     noHtml5Validate: false,
-    ErrorList: DefaultErrorList,
+    ErrorList: DefaultErrorList
   };
 
   constructor(props) {
@@ -43,7 +45,7 @@ export default class Form extends Component {
       ? this.validate(formData, schema)
       : {
           errors: state.errors || [],
-          errorSchema: state.errorSchema || {},
+          errorSchema: state.errorSchema || {}
         };
     const idSchema = toIdSchema(
       schema,
@@ -58,7 +60,7 @@ export default class Form extends Component {
       formData,
       edit,
       errors,
-      errorSchema,
+      errorSchema
     };
   }
 
@@ -155,7 +157,7 @@ export default class Form extends Component {
       ObjectFieldTemplate: this.props.ObjectFieldTemplate,
       FieldTemplate: this.props.FieldTemplate,
       definitions: this.props.schema.definitions || {},
-      formContext: this.props.formContext || {},
+      formContext: this.props.formContext || {}
     };
   }
 
@@ -172,7 +174,7 @@ export default class Form extends Component {
       autocomplete,
       enctype,
       acceptcharset,
-      noHtml5Validate,
+      noHtml5Validate
     } = this.props;
 
     const { schema, uiSchema, formData, errorSchema, idSchema } = this.state;
@@ -191,7 +193,8 @@ export default class Form extends Component {
         encType={enctype}
         acceptCharset={acceptcharset}
         noValidate={noHtml5Validate}
-        onSubmit={this.onSubmit}>
+        onSubmit={this.onSubmit}
+      >
         {this.renderErrors()}
         <_SchemaField
           schema={schema}
@@ -251,6 +254,6 @@ if (process.env.NODE_ENV !== "production") {
     validate: PropTypes.func,
     transformErrors: PropTypes.func,
     safeRenderCompletion: PropTypes.bool,
-    formContext: PropTypes.object,
+    formContext: PropTypes.object
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 import Form from "./components/Form";
+import { getValidator } from "./components/Form";
 
+export { getValidator };
 export default Form;

--- a/src/validate.js
+++ b/src/validate.js
@@ -2,7 +2,7 @@ import toPath from "lodash.topath";
 import Ajv from "ajv";
 const ajv = new Ajv({
   errorDataPath: "property",
-  allErrors: true,
+  allErrors: true
 });
 // add custom formats
 ajv.addFormat(
@@ -71,7 +71,7 @@ export function toErrorList(errorSchema, fieldName = "root") {
     errorList = errorList.concat(
       errorSchema.__errors.map(stack => {
         return {
-          stack: `${fieldName}: ${stack}`,
+          stack: `${fieldName}: ${stack}`
         };
       })
     );
@@ -92,7 +92,7 @@ function createErrorHandler(formData) {
     __errors: [],
     addError(message) {
       this.__errors.push(message);
-    },
+    }
   };
   if (isObject(formData)) {
     return Object.keys(formData).reduce((acc, key) => {
@@ -137,9 +137,13 @@ function transformAjvErrors(errors = []) {
       property,
       message,
       params, // specific to ajv
-      stack: `${property} ${message}`.trim(),
+      stack: `${property} ${message}`.trim()
     };
   });
+}
+
+function getValidator() {
+  return ajv;
 }
 
 /**
@@ -176,3 +180,5 @@ export default function validateFormData(
 
   return { errors: newErrors, errorSchema: newErrorSchema };
 }
+
+export { getValidator, validateFormData };


### PR DESCRIPTION
### Reasons for making this change

`react-jsonschema-form` does not expose its Ajv implementation so that users can configure Ajv with different schemas and whatnot. a la #783

My use case: implementing ASP.Net React Forms via https://github.com/RSuter/NJsonSchema

This is probably not _the way_ to do it, but I figured I'd offer my implementation. This implementation allows a dev to do this:

```js
import Form from "react-jsonschema-form";
import { getValidator } from "react-jsonschema-form";
  
const validator = getValidator();
validator.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
```

I might rather something like the following, but I'm also using TypeScript and it cried when I attempted to implement this so it tells me it might not be the way to go.

```js
import Form from "react-jsonschema-form";

const validator = Form.getValidator();
validator.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
```

I might even go so far as to say the following is the _real way_, but I really have no idea which is the React way as I'm just learning it.

```js
            return <Form
                method="POST"
                action={this.props.lead.action}
                schema={this.props.lead.schema}
                uiSchema={this.props.lead.uiSchema}
                formData={this.props.lead.formData}
                fields={fields}
                validateAgainst={require('ajv/lib/refs/json-schema-draft-04.json')}
            />;
```

Either way, I'd like feedback before implementing anything further than I have.

P.S., I think Prettier is making formatting-only changes behind my back, but I apologize if I've misconfigured something resulting in the comma removal below. I tried to roll it back, but it didn't do anything 😢

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
