### PR TITLE
Make .editorconfig valid

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+[*]
+
 indent_style = space
 indent_size = 2
 charset = utf-8


### PR DESCRIPTION
### Reasons for making this change

The .editorconfig is not a valid editorconfig.

This fixes for example the EditorConfigVim plugin, 

When you look at http://editorconfig.org/#file-format-details, in the example, the way to have some rule applied to all files is by using the `[*]` filename

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
