### PR TITLE
Removed throwing error when there's an extraneous property in ui:order

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -275,28 +275,26 @@ export function orderProperties(properties, order) {
       ? `properties '${arr.join("', '")}'`
       : `property '${arr[0]}'`;
   const propertyHash = arrayToHash(properties);
-  const orderHash = arrayToHash(order);
-  const extraneous = order.filter(prop => prop !== "*" && !propertyHash[prop]);
-  if (extraneous.length) {
-    throw new Error(
-      `uiSchema order list contains extraneous ${errorPropList(extraneous)}`
-    );
-  }
+  const orderFiltered = order.filter(
+    prop => prop === "*" || propertyHash[prop]
+  );
+  const orderHash = arrayToHash(orderFiltered);
+
   const rest = properties.filter(prop => !orderHash[prop]);
-  const restIndex = order.indexOf("*");
+  const restIndex = orderFiltered.indexOf("*");
   if (restIndex === -1) {
     if (rest.length) {
       throw new Error(
         `uiSchema order list does not contain ${errorPropList(rest)}`
       );
     }
-    return order;
+    return orderFiltered;
   }
-  if (restIndex !== order.lastIndexOf("*")) {
+  if (restIndex !== orderFiltered.lastIndexOf("*")) {
     throw new Error("uiSchema order list contains more than one wildcard item");
   }
 
-  const complete = [...order];
+  const complete = [...orderFiltered];
   complete.splice(restIndex, 1, ...rest);
   return complete;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -275,6 +275,12 @@ export function orderProperties(properties, order) {
       ? `properties '${arr.join("', '")}'`
       : `property '${arr[0]}'`;
   const propertyHash = arrayToHash(properties);
+  const extraneous = order.filter(prop => prop !== "*" && !propertyHash[prop]);
+  if (extraneous.length) {
+    console.warn(
+      `uiSchema order list contains extraneous ${errorPropList(extraneous)}`
+    );
+  }
   const orderFiltered = order.filter(
     prop => prop === "*" || propertyHash[prop]
   );

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -218,19 +218,6 @@ describe("ObjectField", () => {
       expect(labels).eql(["baz", "bar", "qux", "foo"]);
     });
 
-    it("should throw when order list contains an extraneous property", () => {
-      const { node } = createFormComponent({
-        schema,
-        uiSchema: {
-          "ui:order": ["baz", "qux", "bar", "wut?", "foo", "huh?"],
-        },
-      });
-
-      expect(node.querySelector(".config-error").textContent).to.match(
-        /contains extraneous properties 'wut\?', 'huh\?'/
-      );
-    });
-
     it("should throw when order list misses an existing property", () => {
       const { node } = createFormComponent({
         schema,

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -218,6 +218,22 @@ describe("ObjectField", () => {
       expect(labels).eql(["baz", "bar", "qux", "foo"]);
     });
 
+    it("should use provided order also if order list contains extraneous properties", () => {
+      const { node } = createFormComponent({
+        schema,
+        uiSchema: {
+          "ui:order": ["baz", "qux", "bar", "wut?", "foo", "huh?"],
+        },
+      });
+
+      const labels = [].map.call(
+        node.querySelectorAll(".field > label"),
+        l => l.textContent
+      );
+
+      expect(labels).eql(["baz", "qux", "bar", "foo"]);
+    });
+
     it("should throw when order list misses an existing property", () => {
       const { node } = createFormComponent({
         schema,

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -2,6 +2,7 @@ import { expect } from "chai";
 
 import {
   asNumber,
+  orderProperties,
   dataURItoBlob,
   deepEquals,
   getDefaultFormState,
@@ -268,6 +269,37 @@ describe("utils", () => {
 
     it("should return undefined if the input is empty", () => {
       expect(asNumber("")).eql(undefined);
+    });
+  });
+
+  describe("orderProperties()", () => {
+    it("should remove from order elements that are not in properties", () => {
+      const properties = ["foo", "baz"];
+      const order = ["foo", "bar", "baz", "qux"];
+      expect(orderProperties(properties, order)).eql(["foo", "baz"]);
+    });
+
+    it("should order properties according to the order", () => {
+      const properties = ["bar", "foo"];
+      const order = ["foo", "bar"];
+      expect(orderProperties(properties, order)).eql(["foo", "bar"]);
+    });
+
+    it("should replace * with properties that are absent in order", () => {
+      const properties = ["foo", "bar", "baz"];
+      const order = ["*", "foo"];
+      expect(orderProperties(properties, order)).eql(["bar", "baz", "foo"]);
+    });
+
+    it("should handle more complex ordering case correctly", () => {
+      const properties = ["foo", "baz", "qux", "bar"];
+      const order = ["quux", "foo", "*", "corge", "baz"];
+      expect(orderProperties(properties, order)).eql([
+        "foo",
+        "qux",
+        "bar",
+        "baz",
+      ]);
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

In current implementation if you use dynamic schema dependencies, you cannot specify dependent fields in 'ui:order' list. It's because if you list such field in 'ui:order' and it is currently not displayed according to it's dependency condition, the error is thrown: 'uiSchema order list does not contain <field>'.

I do not see why we should throw an error instead of just filtering 'ui:order' array to contain fields that are present according to dependency condition. If you cannot order conditional fields along with unconditional, it significantly reduces usefulness of dynamic schema dependency feature.

My solution is to give user the ability to specify all properties in 'ui:order' and just sort them as needed.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
