### PR TITLE
pass raw errors to  field widgets

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -13,7 +13,7 @@ import {
   optionsList,
   retrieveSchema,
   toIdSchema,
-  getDefaultRegistry,
+  getDefaultRegistry
 } from "../../utils";
 
 function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
@@ -40,7 +40,8 @@ function IconBtn(props) {
     <button
       type="button"
       className={`btn btn-${type} ${className}`}
-      {...otherProps}>
+      {...otherProps}
+    >
       <i className={`glyphicon glyphicon-${icon}`} />
     </button>
   );
@@ -52,7 +53,7 @@ function DefaultArrayItem(props) {
     flex: 1,
     paddingLeft: 6,
     paddingRight: 6,
-    fontWeight: "bold",
+    fontWeight: "bold"
   };
   return (
     <div key={props.index} className={props.className}>
@@ -64,7 +65,8 @@ function DefaultArrayItem(props) {
         <div className="col-xs-3 array-item-toolbox">
           <div
             className="btn-group"
-            style={{ display: "flex", justifyContent: "space-around" }}>
+            style={{ display: "flex", justifyContent: "space-around" }}
+          >
             {(props.hasMoveUp || props.hasMoveDown) && (
               <IconBtn
                 icon="arrow-up"
@@ -121,14 +123,16 @@ function DefaultFixedArrayFieldTemplate(props) {
       {(props.uiSchema["ui:description"] || props.schema.description) && (
         <div
           className="field-description"
-          key={`field-description-${props.idSchema.$id}`}>
+          key={`field-description-${props.idSchema.$id}`}
+        >
           {props.uiSchema["ui:description"] || props.schema.description}
         </div>
       )}
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}>
+        key={`array-item-list-${props.idSchema.$id}`}
+      >
         {props.items && props.items.map(DefaultArrayItem)}
       </div>
 
@@ -166,7 +170,8 @@ function DefaultNormalArrayFieldTemplate(props) {
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}>
+        key={`array-item-list-${props.idSchema.$id}`}
+      >
         {props.items && props.items.map(p => DefaultArrayItem(p))}
       </div>
 
@@ -188,7 +193,7 @@ class ArrayField extends Component {
     required: false,
     disabled: false,
     readonly: false,
-    autofocus: false,
+    autofocus: false
   };
 
   get itemTitle() {
@@ -231,7 +236,7 @@ class ArrayField extends Component {
     }
     this.props.onChange([
       ...formData,
-      getDefaultFormState(itemSchema, undefined, definitions),
+      getDefaultFormState(itemSchema, undefined, definitions)
     ]);
   };
 
@@ -311,7 +316,7 @@ class ArrayField extends Component {
         errorSchema &&
           this.props.errorSchema && {
             ...this.props.errorSchema,
-            [index]: errorSchema,
+            [index]: errorSchema
           }
       );
     };
@@ -326,7 +331,7 @@ class ArrayField extends Component {
       schema,
       uiSchema,
       idSchema,
-      registry = getDefaultRegistry(),
+      registry = getDefaultRegistry()
     } = this.props;
     const { definitions } = registry;
     if (!schema.hasOwnProperty("items")) {
@@ -366,7 +371,7 @@ class ArrayField extends Component {
       formContext,
       onBlur,
       onFocus,
-      idPrefix,
+      idPrefix
     } = this.props;
     const title = schema.title === undefined ? name : schema.title;
     const { ArrayFieldTemplate, definitions, fields } = registry;
@@ -396,7 +401,7 @@ class ArrayField extends Component {
           itemUiSchema: uiSchema.items,
           autofocus: autofocus && index === 0,
           onBlur,
-          onFocus,
+          onFocus
         });
       }),
       className: `field field-array field-array-of-${itemsSchema.type}`,
@@ -411,7 +416,7 @@ class ArrayField extends Component {
       title,
       TitleField,
       formContext,
-      formData,
+      formData
     };
 
     // Check if a custom render function was passed in
@@ -430,8 +435,7 @@ class ArrayField extends Component {
       autofocus,
       onBlur,
       onFocus,
-      registry = getDefaultRegistry(),
-      rawErrors,
+      registry = getDefaultRegistry()
     } = this.props;
     const items = this.props.formData;
     const { widgets, definitions, formContext } = registry;
@@ -439,7 +443,7 @@ class ArrayField extends Component {
     const enumOptions = optionsList(itemsSchema);
     const { widget = "select", ...options } = {
       ...getUiOptions(uiSchema),
-      enumOptions,
+      enumOptions
     };
     const Widget = getWidget(schema, widget, widgets);
     return (
@@ -456,7 +460,6 @@ class ArrayField extends Component {
         readonly={readonly}
         formContext={formContext}
         autofocus={autofocus}
-        rawErrors={rawErrors}
       />
     );
   }
@@ -472,8 +475,7 @@ class ArrayField extends Component {
       autofocus,
       onBlur,
       onFocus,
-      registry = getDefaultRegistry(),
-      rawErrors,
+      registry = getDefaultRegistry()
     } = this.props;
     const title = schema.title || name;
     const items = this.props.formData;
@@ -495,7 +497,6 @@ class ArrayField extends Component {
         readonly={readonly}
         formContext={formContext}
         autofocus={autofocus}
-        rawErrors={rawErrors}
       />
     );
   }
@@ -515,7 +516,7 @@ class ArrayField extends Component {
       autofocus,
       registry = getDefaultRegistry(),
       onBlur,
-      onFocus,
+      onFocus
     } = this.props;
     const title = schema.title || name;
     let items = this.props.formData;
@@ -573,7 +574,7 @@ class ArrayField extends Component {
           itemErrorSchema,
           autofocus: autofocus && index === 0,
           onBlur,
-          onFocus,
+          onFocus
         });
       }),
       onAddClick: this.onAddClick,
@@ -582,7 +583,7 @@ class ArrayField extends Component {
       schema,
       uiSchema,
       title,
-      TitleField,
+      TitleField
     };
 
     // Check if a custom template template was passed in
@@ -603,24 +604,24 @@ class ArrayField extends Component {
       itemErrorSchema,
       autofocus,
       onBlur,
-      onFocus,
+      onFocus
     } = props;
     const {
       disabled,
       readonly,
       uiSchema,
-      registry = getDefaultRegistry(),
+      registry = getDefaultRegistry()
     } = this.props;
     const { fields: { SchemaField } } = registry;
     const { orderable, removable } = {
       orderable: true,
       removable: true,
-      ...uiSchema["ui:options"],
+      ...uiSchema["ui:options"]
     };
     const has = {
       moveUp: orderable && canMoveUp,
       moveDown: orderable && canMoveDown,
-      remove: removable && canRemove,
+      remove: removable && canRemove
     };
     has.toolbar = Object.keys(has).some(key => has[key]);
 
@@ -651,7 +652,7 @@ class ArrayField extends Component {
       index,
       onDropIndexClick: this.onDropIndexClick,
       onReorderClick: this.onReorderClick,
-      readonly,
+      readonly
     };
   }
 }
@@ -680,8 +681,8 @@ if (process.env.NODE_ENV !== "production") {
       "ui:options": PropTypes.shape({
         addable: PropTypes.bool,
         orderable: PropTypes.bool,
-        removable: PropTypes.bool,
-      }),
+        removable: PropTypes.bool
+      })
     }),
     idSchema: PropTypes.object,
     errorSchema: PropTypes.object,
@@ -699,9 +700,8 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired,
-    }),
-    rawErrors: PropTypes.arrayOf(PropTypes.string),
+      formContext: PropTypes.object.isRequired
+    })
   };
 }
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -13,7 +13,7 @@ import {
   optionsList,
   retrieveSchema,
   toIdSchema,
-  getDefaultRegistry,
+  getDefaultRegistry
 } from "../../utils";
 
 function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
@@ -40,7 +40,8 @@ function IconBtn(props) {
     <button
       type="button"
       className={`btn btn-${type} ${className}`}
-      {...otherProps}>
+      {...otherProps}
+    >
       <i className={`glyphicon glyphicon-${icon}`} />
     </button>
   );
@@ -52,7 +53,7 @@ function DefaultArrayItem(props) {
     flex: 1,
     paddingLeft: 6,
     paddingRight: 6,
-    fontWeight: "bold",
+    fontWeight: "bold"
   };
   return (
     <div key={props.index} className={props.className}>
@@ -64,7 +65,8 @@ function DefaultArrayItem(props) {
         <div className="col-xs-3 array-item-toolbox">
           <div
             className="btn-group"
-            style={{ display: "flex", justifyContent: "space-around" }}>
+            style={{ display: "flex", justifyContent: "space-around" }}
+          >
             {(props.hasMoveUp || props.hasMoveDown) && (
               <IconBtn
                 icon="arrow-up"
@@ -121,14 +123,16 @@ function DefaultFixedArrayFieldTemplate(props) {
       {(props.uiSchema["ui:description"] || props.schema.description) && (
         <div
           className="field-description"
-          key={`field-description-${props.idSchema.$id}`}>
+          key={`field-description-${props.idSchema.$id}`}
+        >
           {props.uiSchema["ui:description"] || props.schema.description}
         </div>
       )}
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}>
+        key={`array-item-list-${props.idSchema.$id}`}
+      >
         {props.items && props.items.map(DefaultArrayItem)}
       </div>
 
@@ -166,7 +170,8 @@ function DefaultNormalArrayFieldTemplate(props) {
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}>
+        key={`array-item-list-${props.idSchema.$id}`}
+      >
         {props.items && props.items.map(p => DefaultArrayItem(p))}
       </div>
 
@@ -188,7 +193,7 @@ class ArrayField extends Component {
     required: false,
     disabled: false,
     readonly: false,
-    autofocus: false,
+    autofocus: false
   };
 
   get itemTitle() {
@@ -231,7 +236,7 @@ class ArrayField extends Component {
     }
     this.props.onChange([
       ...formData,
-      getDefaultFormState(itemSchema, undefined, definitions),
+      getDefaultFormState(itemSchema, undefined, definitions)
     ]);
   };
 
@@ -311,7 +316,7 @@ class ArrayField extends Component {
         errorSchema &&
           this.props.errorSchema && {
             ...this.props.errorSchema,
-            [index]: errorSchema,
+            [index]: errorSchema
           }
       );
     };
@@ -326,7 +331,7 @@ class ArrayField extends Component {
       schema,
       uiSchema,
       idSchema,
-      registry = getDefaultRegistry(),
+      registry = getDefaultRegistry()
     } = this.props;
     const { definitions } = registry;
     if (!schema.hasOwnProperty("items")) {
@@ -366,7 +371,7 @@ class ArrayField extends Component {
       formContext,
       onBlur,
       onFocus,
-      idPrefix,
+      idPrefix
     } = this.props;
     const title = schema.title === undefined ? name : schema.title;
     const { ArrayFieldTemplate, definitions, fields } = registry;
@@ -396,7 +401,7 @@ class ArrayField extends Component {
           itemUiSchema: uiSchema.items,
           autofocus: autofocus && index === 0,
           onBlur,
-          onFocus,
+          onFocus
         });
       }),
       className: `field field-array field-array-of-${itemsSchema.type}`,
@@ -411,7 +416,7 @@ class ArrayField extends Component {
       title,
       TitleField,
       formContext,
-      formData,
+      formData
     };
 
     // Check if a custom render function was passed in
@@ -431,6 +436,7 @@ class ArrayField extends Component {
       onBlur,
       onFocus,
       registry = getDefaultRegistry(),
+      rawErrors
     } = this.props;
     const items = this.props.formData;
     const { widgets, definitions, formContext } = registry;
@@ -438,7 +444,7 @@ class ArrayField extends Component {
     const enumOptions = optionsList(itemsSchema);
     const { widget = "select", ...options } = {
       ...getUiOptions(uiSchema),
-      enumOptions,
+      enumOptions
     };
     const Widget = getWidget(schema, widget, widgets);
     return (
@@ -455,6 +461,7 @@ class ArrayField extends Component {
         readonly={readonly}
         formContext={formContext}
         autofocus={autofocus}
+        rawErrors={rawErrors}
       />
     );
   }
@@ -471,6 +478,7 @@ class ArrayField extends Component {
       onBlur,
       onFocus,
       registry = getDefaultRegistry(),
+      rawErrors
     } = this.props;
     const title = schema.title || name;
     const items = this.props.formData;
@@ -492,6 +500,7 @@ class ArrayField extends Component {
         readonly={readonly}
         formContext={formContext}
         autofocus={autofocus}
+        rawErrors={rawErrors}
       />
     );
   }
@@ -511,7 +520,7 @@ class ArrayField extends Component {
       autofocus,
       registry = getDefaultRegistry(),
       onBlur,
-      onFocus,
+      onFocus
     } = this.props;
     const title = schema.title || name;
     let items = this.props.formData;
@@ -569,7 +578,7 @@ class ArrayField extends Component {
           itemErrorSchema,
           autofocus: autofocus && index === 0,
           onBlur,
-          onFocus,
+          onFocus
         });
       }),
       onAddClick: this.onAddClick,
@@ -578,7 +587,7 @@ class ArrayField extends Component {
       schema,
       uiSchema,
       title,
-      TitleField,
+      TitleField
     };
 
     // Check if a custom template template was passed in
@@ -599,24 +608,24 @@ class ArrayField extends Component {
       itemErrorSchema,
       autofocus,
       onBlur,
-      onFocus,
+      onFocus
     } = props;
     const {
       disabled,
       readonly,
       uiSchema,
-      registry = getDefaultRegistry(),
+      registry = getDefaultRegistry()
     } = this.props;
     const { fields: { SchemaField } } = registry;
     const { orderable, removable } = {
       orderable: true,
       removable: true,
-      ...uiSchema["ui:options"],
+      ...uiSchema["ui:options"]
     };
     const has = {
       moveUp: orderable && canMoveUp,
       moveDown: orderable && canMoveDown,
-      remove: removable && canRemove,
+      remove: removable && canRemove
     };
     has.toolbar = Object.keys(has).some(key => has[key]);
 
@@ -647,7 +656,7 @@ class ArrayField extends Component {
       index,
       onDropIndexClick: this.onDropIndexClick,
       onReorderClick: this.onReorderClick,
-      readonly,
+      readonly
     };
   }
 }
@@ -676,8 +685,8 @@ if (process.env.NODE_ENV !== "production") {
       "ui:options": PropTypes.shape({
         addable: PropTypes.bool,
         orderable: PropTypes.bool,
-        removable: PropTypes.bool,
-      }),
+        removable: PropTypes.bool
+      })
     }),
     idSchema: PropTypes.object,
     errorSchema: PropTypes.object,
@@ -695,8 +704,9 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired,
+      formContext: PropTypes.object.isRequired
     }),
+    rawErrors: PropTypes.arrayOf(PropTypes.string)
   };
 }
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -13,7 +13,7 @@ import {
   optionsList,
   retrieveSchema,
   toIdSchema,
-  getDefaultRegistry
+  getDefaultRegistry,
 } from "../../utils";
 
 function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
@@ -40,8 +40,7 @@ function IconBtn(props) {
     <button
       type="button"
       className={`btn btn-${type} ${className}`}
-      {...otherProps}
-    >
+      {...otherProps}>
       <i className={`glyphicon glyphicon-${icon}`} />
     </button>
   );
@@ -53,7 +52,7 @@ function DefaultArrayItem(props) {
     flex: 1,
     paddingLeft: 6,
     paddingRight: 6,
-    fontWeight: "bold"
+    fontWeight: "bold",
   };
   return (
     <div key={props.index} className={props.className}>
@@ -65,8 +64,7 @@ function DefaultArrayItem(props) {
         <div className="col-xs-3 array-item-toolbox">
           <div
             className="btn-group"
-            style={{ display: "flex", justifyContent: "space-around" }}
-          >
+            style={{ display: "flex", justifyContent: "space-around" }}>
             {(props.hasMoveUp || props.hasMoveDown) && (
               <IconBtn
                 icon="arrow-up"
@@ -123,16 +121,14 @@ function DefaultFixedArrayFieldTemplate(props) {
       {(props.uiSchema["ui:description"] || props.schema.description) && (
         <div
           className="field-description"
-          key={`field-description-${props.idSchema.$id}`}
-        >
+          key={`field-description-${props.idSchema.$id}`}>
           {props.uiSchema["ui:description"] || props.schema.description}
         </div>
       )}
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}
-      >
+        key={`array-item-list-${props.idSchema.$id}`}>
         {props.items && props.items.map(DefaultArrayItem)}
       </div>
 
@@ -170,8 +166,7 @@ function DefaultNormalArrayFieldTemplate(props) {
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}
-      >
+        key={`array-item-list-${props.idSchema.$id}`}>
         {props.items && props.items.map(p => DefaultArrayItem(p))}
       </div>
 
@@ -193,7 +188,7 @@ class ArrayField extends Component {
     required: false,
     disabled: false,
     readonly: false,
-    autofocus: false
+    autofocus: false,
   };
 
   get itemTitle() {
@@ -236,7 +231,7 @@ class ArrayField extends Component {
     }
     this.props.onChange([
       ...formData,
-      getDefaultFormState(itemSchema, undefined, definitions)
+      getDefaultFormState(itemSchema, undefined, definitions),
     ]);
   };
 
@@ -316,7 +311,7 @@ class ArrayField extends Component {
         errorSchema &&
           this.props.errorSchema && {
             ...this.props.errorSchema,
-            [index]: errorSchema
+            [index]: errorSchema,
           }
       );
     };
@@ -331,7 +326,7 @@ class ArrayField extends Component {
       schema,
       uiSchema,
       idSchema,
-      registry = getDefaultRegistry()
+      registry = getDefaultRegistry(),
     } = this.props;
     const { definitions } = registry;
     if (!schema.hasOwnProperty("items")) {
@@ -371,7 +366,7 @@ class ArrayField extends Component {
       formContext,
       onBlur,
       onFocus,
-      idPrefix
+      idPrefix,
     } = this.props;
     const title = schema.title === undefined ? name : schema.title;
     const { ArrayFieldTemplate, definitions, fields } = registry;
@@ -401,7 +396,7 @@ class ArrayField extends Component {
           itemUiSchema: uiSchema.items,
           autofocus: autofocus && index === 0,
           onBlur,
-          onFocus
+          onFocus,
         });
       }),
       className: `field field-array field-array-of-${itemsSchema.type}`,
@@ -416,7 +411,7 @@ class ArrayField extends Component {
       title,
       TitleField,
       formContext,
-      formData
+      formData,
     };
 
     // Check if a custom render function was passed in
@@ -435,7 +430,7 @@ class ArrayField extends Component {
       autofocus,
       onBlur,
       onFocus,
-      registry = getDefaultRegistry()
+      registry = getDefaultRegistry(),
     } = this.props;
     const items = this.props.formData;
     const { widgets, definitions, formContext } = registry;
@@ -443,7 +438,7 @@ class ArrayField extends Component {
     const enumOptions = optionsList(itemsSchema);
     const { widget = "select", ...options } = {
       ...getUiOptions(uiSchema),
-      enumOptions
+      enumOptions,
     };
     const Widget = getWidget(schema, widget, widgets);
     return (
@@ -475,7 +470,7 @@ class ArrayField extends Component {
       autofocus,
       onBlur,
       onFocus,
-      registry = getDefaultRegistry()
+      registry = getDefaultRegistry(),
     } = this.props;
     const title = schema.title || name;
     const items = this.props.formData;
@@ -516,7 +511,7 @@ class ArrayField extends Component {
       autofocus,
       registry = getDefaultRegistry(),
       onBlur,
-      onFocus
+      onFocus,
     } = this.props;
     const title = schema.title || name;
     let items = this.props.formData;
@@ -574,7 +569,7 @@ class ArrayField extends Component {
           itemErrorSchema,
           autofocus: autofocus && index === 0,
           onBlur,
-          onFocus
+          onFocus,
         });
       }),
       onAddClick: this.onAddClick,
@@ -583,7 +578,7 @@ class ArrayField extends Component {
       schema,
       uiSchema,
       title,
-      TitleField
+      TitleField,
     };
 
     // Check if a custom template template was passed in
@@ -604,24 +599,24 @@ class ArrayField extends Component {
       itemErrorSchema,
       autofocus,
       onBlur,
-      onFocus
+      onFocus,
     } = props;
     const {
       disabled,
       readonly,
       uiSchema,
-      registry = getDefaultRegistry()
+      registry = getDefaultRegistry(),
     } = this.props;
     const { fields: { SchemaField } } = registry;
     const { orderable, removable } = {
       orderable: true,
       removable: true,
-      ...uiSchema["ui:options"]
+      ...uiSchema["ui:options"],
     };
     const has = {
       moveUp: orderable && canMoveUp,
       moveDown: orderable && canMoveDown,
-      remove: removable && canRemove
+      remove: removable && canRemove,
     };
     has.toolbar = Object.keys(has).some(key => has[key]);
 
@@ -652,7 +647,7 @@ class ArrayField extends Component {
       index,
       onDropIndexClick: this.onDropIndexClick,
       onReorderClick: this.onReorderClick,
-      readonly
+      readonly,
     };
   }
 }
@@ -681,8 +676,8 @@ if (process.env.NODE_ENV !== "production") {
       "ui:options": PropTypes.shape({
         addable: PropTypes.bool,
         orderable: PropTypes.bool,
-        removable: PropTypes.bool
-      })
+        removable: PropTypes.bool,
+      }),
     }),
     idSchema: PropTypes.object,
     errorSchema: PropTypes.object,
@@ -700,8 +695,8 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired
-    })
+      formContext: PropTypes.object.isRequired,
+    }),
   };
 }
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -13,7 +13,7 @@ import {
   optionsList,
   retrieveSchema,
   toIdSchema,
-  getDefaultRegistry
+  getDefaultRegistry,
 } from "../../utils";
 
 function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
@@ -40,8 +40,7 @@ function IconBtn(props) {
     <button
       type="button"
       className={`btn btn-${type} ${className}`}
-      {...otherProps}
-    >
+      {...otherProps}>
       <i className={`glyphicon glyphicon-${icon}`} />
     </button>
   );
@@ -53,7 +52,7 @@ function DefaultArrayItem(props) {
     flex: 1,
     paddingLeft: 6,
     paddingRight: 6,
-    fontWeight: "bold"
+    fontWeight: "bold",
   };
   return (
     <div key={props.index} className={props.className}>
@@ -65,8 +64,7 @@ function DefaultArrayItem(props) {
         <div className="col-xs-3 array-item-toolbox">
           <div
             className="btn-group"
-            style={{ display: "flex", justifyContent: "space-around" }}
-          >
+            style={{ display: "flex", justifyContent: "space-around" }}>
             {(props.hasMoveUp || props.hasMoveDown) && (
               <IconBtn
                 icon="arrow-up"
@@ -123,16 +121,14 @@ function DefaultFixedArrayFieldTemplate(props) {
       {(props.uiSchema["ui:description"] || props.schema.description) && (
         <div
           className="field-description"
-          key={`field-description-${props.idSchema.$id}`}
-        >
+          key={`field-description-${props.idSchema.$id}`}>
           {props.uiSchema["ui:description"] || props.schema.description}
         </div>
       )}
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}
-      >
+        key={`array-item-list-${props.idSchema.$id}`}>
         {props.items && props.items.map(DefaultArrayItem)}
       </div>
 
@@ -170,8 +166,7 @@ function DefaultNormalArrayFieldTemplate(props) {
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}
-      >
+        key={`array-item-list-${props.idSchema.$id}`}>
         {props.items && props.items.map(p => DefaultArrayItem(p))}
       </div>
 
@@ -193,7 +188,7 @@ class ArrayField extends Component {
     required: false,
     disabled: false,
     readonly: false,
-    autofocus: false
+    autofocus: false,
   };
 
   get itemTitle() {
@@ -236,7 +231,7 @@ class ArrayField extends Component {
     }
     this.props.onChange([
       ...formData,
-      getDefaultFormState(itemSchema, undefined, definitions)
+      getDefaultFormState(itemSchema, undefined, definitions),
     ]);
   };
 
@@ -316,7 +311,7 @@ class ArrayField extends Component {
         errorSchema &&
           this.props.errorSchema && {
             ...this.props.errorSchema,
-            [index]: errorSchema
+            [index]: errorSchema,
           }
       );
     };
@@ -331,7 +326,7 @@ class ArrayField extends Component {
       schema,
       uiSchema,
       idSchema,
-      registry = getDefaultRegistry()
+      registry = getDefaultRegistry(),
     } = this.props;
     const { definitions } = registry;
     if (!schema.hasOwnProperty("items")) {
@@ -371,7 +366,7 @@ class ArrayField extends Component {
       formContext,
       onBlur,
       onFocus,
-      idPrefix
+      idPrefix,
     } = this.props;
     const title = schema.title === undefined ? name : schema.title;
     const { ArrayFieldTemplate, definitions, fields } = registry;
@@ -401,7 +396,7 @@ class ArrayField extends Component {
           itemUiSchema: uiSchema.items,
           autofocus: autofocus && index === 0,
           onBlur,
-          onFocus
+          onFocus,
         });
       }),
       className: `field field-array field-array-of-${itemsSchema.type}`,
@@ -416,7 +411,7 @@ class ArrayField extends Component {
       title,
       TitleField,
       formContext,
-      formData
+      formData,
     };
 
     // Check if a custom render function was passed in
@@ -436,7 +431,7 @@ class ArrayField extends Component {
       onBlur,
       onFocus,
       registry = getDefaultRegistry(),
-      rawErrors
+      rawErrors,
     } = this.props;
     const items = this.props.formData;
     const { widgets, definitions, formContext } = registry;
@@ -444,7 +439,7 @@ class ArrayField extends Component {
     const enumOptions = optionsList(itemsSchema);
     const { widget = "select", ...options } = {
       ...getUiOptions(uiSchema),
-      enumOptions
+      enumOptions,
     };
     const Widget = getWidget(schema, widget, widgets);
     return (
@@ -478,7 +473,7 @@ class ArrayField extends Component {
       onBlur,
       onFocus,
       registry = getDefaultRegistry(),
-      rawErrors
+      rawErrors,
     } = this.props;
     const title = schema.title || name;
     const items = this.props.formData;
@@ -520,7 +515,7 @@ class ArrayField extends Component {
       autofocus,
       registry = getDefaultRegistry(),
       onBlur,
-      onFocus
+      onFocus,
     } = this.props;
     const title = schema.title || name;
     let items = this.props.formData;
@@ -578,7 +573,7 @@ class ArrayField extends Component {
           itemErrorSchema,
           autofocus: autofocus && index === 0,
           onBlur,
-          onFocus
+          onFocus,
         });
       }),
       onAddClick: this.onAddClick,
@@ -587,7 +582,7 @@ class ArrayField extends Component {
       schema,
       uiSchema,
       title,
-      TitleField
+      TitleField,
     };
 
     // Check if a custom template template was passed in
@@ -608,24 +603,24 @@ class ArrayField extends Component {
       itemErrorSchema,
       autofocus,
       onBlur,
-      onFocus
+      onFocus,
     } = props;
     const {
       disabled,
       readonly,
       uiSchema,
-      registry = getDefaultRegistry()
+      registry = getDefaultRegistry(),
     } = this.props;
     const { fields: { SchemaField } } = registry;
     const { orderable, removable } = {
       orderable: true,
       removable: true,
-      ...uiSchema["ui:options"]
+      ...uiSchema["ui:options"],
     };
     const has = {
       moveUp: orderable && canMoveUp,
       moveDown: orderable && canMoveDown,
-      remove: removable && canRemove
+      remove: removable && canRemove,
     };
     has.toolbar = Object.keys(has).some(key => has[key]);
 
@@ -656,7 +651,7 @@ class ArrayField extends Component {
       index,
       onDropIndexClick: this.onDropIndexClick,
       onReorderClick: this.onReorderClick,
-      readonly
+      readonly,
     };
   }
 }
@@ -685,8 +680,8 @@ if (process.env.NODE_ENV !== "production") {
       "ui:options": PropTypes.shape({
         addable: PropTypes.bool,
         orderable: PropTypes.bool,
-        removable: PropTypes.bool
-      })
+        removable: PropTypes.bool,
+      }),
     }),
     idSchema: PropTypes.object,
     errorSchema: PropTypes.object,
@@ -704,9 +699,9 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired
+      formContext: PropTypes.object.isRequired,
     }),
-    rawErrors: PropTypes.arrayOf(PropTypes.string)
+    rawErrors: PropTypes.arrayOf(PropTypes.string),
   };
 }
 

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -5,7 +5,7 @@ import {
   getWidget,
   getUiOptions,
   optionsList,
-  getDefaultRegistry
+  getDefaultRegistry,
 } from "../../utils";
 
 function BooleanField(props) {
@@ -21,7 +21,7 @@ function BooleanField(props) {
     readonly,
     autofocus,
     onChange,
-    rawErrors
+    rawErrors,
   } = props;
   const { title } = schema;
   const { widgets, formContext } = registry;
@@ -29,7 +29,7 @@ function BooleanField(props) {
   const Widget = getWidget(schema, widget, widgets);
   const enumOptions = optionsList({
     enum: [true, false],
-    enumNames: schema.enumNames || ["yes", "no"]
+    enumNames: schema.enumNames || ["yes", "no"],
   });
   return (
     <Widget
@@ -67,9 +67,9 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired
+      formContext: PropTypes.object.isRequired,
     }),
-    rawErrors: PropTypes.arrayOf(PropTypes.string)
+    rawErrors: PropTypes.arrayOf(PropTypes.string),
   };
 }
 
@@ -77,7 +77,7 @@ BooleanField.defaultProps = {
   uiSchema: {},
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 export default BooleanField;

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -5,7 +5,7 @@ import {
   getWidget,
   getUiOptions,
   optionsList,
-  getDefaultRegistry,
+  getDefaultRegistry
 } from "../../utils";
 
 function BooleanField(props) {
@@ -21,6 +21,7 @@ function BooleanField(props) {
     readonly,
     autofocus,
     onChange,
+    rawErrors
   } = props;
   const { title } = schema;
   const { widgets, formContext } = registry;
@@ -28,7 +29,7 @@ function BooleanField(props) {
   const Widget = getWidget(schema, widget, widgets);
   const enumOptions = optionsList({
     enum: [true, false],
-    enumNames: schema.enumNames || ["yes", "no"],
+    enumNames: schema.enumNames || ["yes", "no"]
   });
   return (
     <Widget
@@ -44,6 +45,7 @@ function BooleanField(props) {
       registry={registry}
       formContext={formContext}
       autofocus={autofocus}
+      rawErrors={rawErrors}
     />
   );
 }
@@ -65,8 +67,9 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired,
+      formContext: PropTypes.object.isRequired
     }),
+    rawErrors: PropTypes.arrayOf(PropTypes.string)
   };
 }
 
@@ -74,7 +77,7 @@ BooleanField.defaultProps = {
   uiSchema: {},
   disabled: false,
   readonly: false,
-  autofocus: false,
+  autofocus: false
 };
 
 export default BooleanField;

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -8,7 +8,7 @@ import {
   getUiOptions,
   isFilesArray,
   deepEquals,
-  getSchemaType,
+  getSchemaType
 } from "../../utils";
 import UnsupportedField from "./UnsupportedField";
 
@@ -19,7 +19,7 @@ const COMPONENT_TYPES = {
   integer: "NumberField",
   number: "NumberField",
   object: "ObjectField",
-  string: "StringField",
+  string: "StringField"
 };
 
 function getFieldComponent(schema, uiSchema, idSchema, fields) {
@@ -103,7 +103,7 @@ function DefaultTemplate(props) {
     description,
     hidden,
     required,
-    displayLabel,
+    displayLabel
   } = props;
   if (hidden) {
     return children;
@@ -113,7 +113,9 @@ function DefaultTemplate(props) {
     <div className={classNames}>
       {displayLabel && <Label label={label} required={required} id={id} />}
       {displayLabel && description ? description : null}
-      {children}
+      {React.Children.map(children, child => {
+        return React.cloneElement(child, { rawErrors: props.rawErrors });
+      })}
       {errors}
       {help}
     </div>
@@ -137,7 +139,7 @@ if (process.env.NODE_ENV !== "production") {
     readonly: PropTypes.bool,
     displayLabel: PropTypes.bool,
     fields: PropTypes.object,
-    formContext: PropTypes.object,
+    formContext: PropTypes.object
   };
 }
 
@@ -145,7 +147,7 @@ DefaultTemplate.defaultProps = {
   hidden: false,
   readonly: false,
   required: false,
-  displayLabel: true,
+  displayLabel: true
 };
 
 function SchemaFieldRender(props) {
@@ -156,13 +158,13 @@ function SchemaFieldRender(props) {
     idSchema,
     name,
     required,
-    registry = getDefaultRegistry(),
+    registry = getDefaultRegistry()
   } = props;
   const {
     definitions,
     fields,
     formContext,
-    FieldTemplate = DefaultTemplate,
+    FieldTemplate = DefaultTemplate
   } = registry;
   const schema = retrieveSchema(props.schema, definitions, formData);
   const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);
@@ -225,7 +227,7 @@ function SchemaFieldRender(props) {
     "field",
     `field-${type}`,
     errors && errors.length > 0 ? "field-error has-error has-danger" : "",
-    uiSchema.classNames,
+    uiSchema.classNames
   ]
     .join(" ")
     .trim();
@@ -254,7 +256,7 @@ function SchemaFieldRender(props) {
     formContext,
     fields,
     schema,
-    uiSchema,
+    uiSchema
   };
 
   return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
@@ -281,7 +283,7 @@ SchemaField.defaultProps = {
   idSchema: {},
   disabled: false,
   readonly: false,
-  autofocus: false,
+  autofocus: false
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -300,8 +302,8 @@ if (process.env.NODE_ENV !== "production") {
       ArrayFieldTemplate: PropTypes.func,
       ObjectFieldTemplate: PropTypes.func,
       FieldTemplate: PropTypes.func,
-      formContext: PropTypes.object.isRequired,
-    }),
+      formContext: PropTypes.object.isRequired
+    })
   };
 }
 

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -8,7 +8,7 @@ import {
   getUiOptions,
   isFilesArray,
   deepEquals,
-  getSchemaType
+  getSchemaType,
 } from "../../utils";
 import UnsupportedField from "./UnsupportedField";
 
@@ -19,7 +19,7 @@ const COMPONENT_TYPES = {
   integer: "NumberField",
   number: "NumberField",
   object: "ObjectField",
-  string: "StringField"
+  string: "StringField",
 };
 
 function getFieldComponent(schema, uiSchema, idSchema, fields) {
@@ -103,7 +103,7 @@ function DefaultTemplate(props) {
     description,
     hidden,
     required,
-    displayLabel
+    displayLabel,
   } = props;
   if (hidden) {
     return children;
@@ -137,7 +137,7 @@ if (process.env.NODE_ENV !== "production") {
     readonly: PropTypes.bool,
     displayLabel: PropTypes.bool,
     fields: PropTypes.object,
-    formContext: PropTypes.object
+    formContext: PropTypes.object,
   };
 }
 
@@ -145,7 +145,7 @@ DefaultTemplate.defaultProps = {
   hidden: false,
   readonly: false,
   required: false,
-  displayLabel: true
+  displayLabel: true,
 };
 
 function SchemaFieldRender(props) {
@@ -156,13 +156,13 @@ function SchemaFieldRender(props) {
     idSchema,
     name,
     required,
-    registry = getDefaultRegistry()
+    registry = getDefaultRegistry(),
   } = props;
   const {
     definitions,
     fields,
     formContext,
-    FieldTemplate = DefaultTemplate
+    FieldTemplate = DefaultTemplate,
   } = registry;
   const schema = retrieveSchema(props.schema, definitions, formData);
   const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);
@@ -226,7 +226,7 @@ function SchemaFieldRender(props) {
     "field",
     `field-${type}`,
     errors && errors.length > 0 ? "field-error has-error has-danger" : "",
-    uiSchema.classNames
+    uiSchema.classNames,
   ]
     .join(" ")
     .trim();
@@ -255,7 +255,7 @@ function SchemaFieldRender(props) {
     formContext,
     fields,
     schema,
-    uiSchema
+    uiSchema,
   };
 
   return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
@@ -282,7 +282,7 @@ SchemaField.defaultProps = {
   idSchema: {},
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -301,8 +301,8 @@ if (process.env.NODE_ENV !== "production") {
       ArrayFieldTemplate: PropTypes.func,
       ObjectFieldTemplate: PropTypes.func,
       FieldTemplate: PropTypes.func,
-      formContext: PropTypes.object.isRequired
-    })
+      formContext: PropTypes.object.isRequired,
+    }),
   };
 }
 

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -8,7 +8,7 @@ import {
   getUiOptions,
   isFilesArray,
   deepEquals,
-  getSchemaType,
+  getSchemaType
 } from "../../utils";
 import UnsupportedField from "./UnsupportedField";
 
@@ -19,7 +19,7 @@ const COMPONENT_TYPES = {
   integer: "NumberField",
   number: "NumberField",
   object: "ObjectField",
-  string: "StringField",
+  string: "StringField"
 };
 
 function getFieldComponent(schema, uiSchema, idSchema, fields) {
@@ -103,7 +103,7 @@ function DefaultTemplate(props) {
     description,
     hidden,
     required,
-    displayLabel,
+    displayLabel
   } = props;
   if (hidden) {
     return children;
@@ -113,9 +113,7 @@ function DefaultTemplate(props) {
     <div className={classNames}>
       {displayLabel && <Label label={label} required={required} id={id} />}
       {displayLabel && description ? description : null}
-      {React.Children.map(children, child => {
-        return React.cloneElement(child, { rawErrors: props.rawErrors });
-      })}
+      {children}
       {errors}
       {help}
     </div>
@@ -139,7 +137,7 @@ if (process.env.NODE_ENV !== "production") {
     readonly: PropTypes.bool,
     displayLabel: PropTypes.bool,
     fields: PropTypes.object,
-    formContext: PropTypes.object,
+    formContext: PropTypes.object
   };
 }
 
@@ -147,7 +145,7 @@ DefaultTemplate.defaultProps = {
   hidden: false,
   readonly: false,
   required: false,
-  displayLabel: true,
+  displayLabel: true
 };
 
 function SchemaFieldRender(props) {
@@ -158,13 +156,13 @@ function SchemaFieldRender(props) {
     idSchema,
     name,
     required,
-    registry = getDefaultRegistry(),
+    registry = getDefaultRegistry()
   } = props;
   const {
     definitions,
     fields,
     formContext,
-    FieldTemplate = DefaultTemplate,
+    FieldTemplate = DefaultTemplate
   } = registry;
   const schema = retrieveSchema(props.schema, definitions, formData);
   const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);
@@ -208,6 +206,7 @@ function SchemaFieldRender(props) {
       autofocus={autofocus}
       errorSchema={fieldErrorSchema}
       formContext={formContext}
+      rawErrors={__errors}
     />
   );
 
@@ -227,7 +226,7 @@ function SchemaFieldRender(props) {
     "field",
     `field-${type}`,
     errors && errors.length > 0 ? "field-error has-error has-danger" : "",
-    uiSchema.classNames,
+    uiSchema.classNames
   ]
     .join(" ")
     .trim();
@@ -256,7 +255,7 @@ function SchemaFieldRender(props) {
     formContext,
     fields,
     schema,
-    uiSchema,
+    uiSchema
   };
 
   return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
@@ -283,7 +282,7 @@ SchemaField.defaultProps = {
   idSchema: {},
   disabled: false,
   readonly: false,
-  autofocus: false,
+  autofocus: false
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -302,8 +301,8 @@ if (process.env.NODE_ENV !== "production") {
       ArrayFieldTemplate: PropTypes.func,
       ObjectFieldTemplate: PropTypes.func,
       FieldTemplate: PropTypes.func,
-      formContext: PropTypes.object.isRequired,
-    }),
+      formContext: PropTypes.object.isRequired
+    })
   };
 }
 

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -8,7 +8,7 @@ import {
   getUiOptions,
   isFilesArray,
   deepEquals,
-  getSchemaType
+  getSchemaType,
 } from "../../utils";
 import UnsupportedField from "./UnsupportedField";
 
@@ -19,7 +19,7 @@ const COMPONENT_TYPES = {
   integer: "NumberField",
   number: "NumberField",
   object: "ObjectField",
-  string: "StringField"
+  string: "StringField",
 };
 
 function getFieldComponent(schema, uiSchema, idSchema, fields) {
@@ -103,7 +103,7 @@ function DefaultTemplate(props) {
     description,
     hidden,
     required,
-    displayLabel
+    displayLabel,
   } = props;
   if (hidden) {
     return children;
@@ -139,7 +139,7 @@ if (process.env.NODE_ENV !== "production") {
     readonly: PropTypes.bool,
     displayLabel: PropTypes.bool,
     fields: PropTypes.object,
-    formContext: PropTypes.object
+    formContext: PropTypes.object,
   };
 }
 
@@ -147,7 +147,7 @@ DefaultTemplate.defaultProps = {
   hidden: false,
   readonly: false,
   required: false,
-  displayLabel: true
+  displayLabel: true,
 };
 
 function SchemaFieldRender(props) {
@@ -158,13 +158,13 @@ function SchemaFieldRender(props) {
     idSchema,
     name,
     required,
-    registry = getDefaultRegistry()
+    registry = getDefaultRegistry(),
   } = props;
   const {
     definitions,
     fields,
     formContext,
-    FieldTemplate = DefaultTemplate
+    FieldTemplate = DefaultTemplate,
   } = registry;
   const schema = retrieveSchema(props.schema, definitions, formData);
   const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);
@@ -227,7 +227,7 @@ function SchemaFieldRender(props) {
     "field",
     `field-${type}`,
     errors && errors.length > 0 ? "field-error has-error has-danger" : "",
-    uiSchema.classNames
+    uiSchema.classNames,
   ]
     .join(" ")
     .trim();
@@ -256,7 +256,7 @@ function SchemaFieldRender(props) {
     formContext,
     fields,
     schema,
-    uiSchema
+    uiSchema,
   };
 
   return <FieldTemplate {...fieldProps}>{field}</FieldTemplate>;
@@ -283,7 +283,7 @@ SchemaField.defaultProps = {
   idSchema: {},
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -302,8 +302,8 @@ if (process.env.NODE_ENV !== "production") {
       ArrayFieldTemplate: PropTypes.func,
       ObjectFieldTemplate: PropTypes.func,
       FieldTemplate: PropTypes.func,
-      formContext: PropTypes.object.isRequired
-    })
+      formContext: PropTypes.object.isRequired,
+    }),
   };
 }
 

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -6,7 +6,7 @@ import {
   getUiOptions,
   isSelect,
   optionsList,
-  getDefaultRegistry,
+  getDefaultRegistry
 } from "../../utils";
 
 function StringField(props) {
@@ -24,6 +24,7 @@ function StringField(props) {
     onBlur,
     onFocus,
     registry = getDefaultRegistry(),
+    rawErrors
   } = props;
   const { title, format } = schema;
   const { widgets, formContext } = registry;
@@ -51,6 +52,7 @@ function StringField(props) {
       autofocus={autofocus}
       registry={registry}
       placeholder={placeholder}
+      rawErrors={rawErrors}
     />
   );
 }
@@ -70,13 +72,14 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired,
+      formContext: PropTypes.object.isRequired
     }),
     formContext: PropTypes.object.isRequired,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
     readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
+    rawErrors: PropTypes.arrayOf(PropTypes.string)
   };
 }
 
@@ -84,7 +87,7 @@ StringField.defaultProps = {
   uiSchema: {},
   disabled: false,
   readonly: false,
-  autofocus: false,
+  autofocus: false
 };
 
 export default StringField;

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -6,7 +6,7 @@ import {
   getUiOptions,
   isSelect,
   optionsList,
-  getDefaultRegistry
+  getDefaultRegistry,
 } from "../../utils";
 
 function StringField(props) {
@@ -24,7 +24,7 @@ function StringField(props) {
     onBlur,
     onFocus,
     registry = getDefaultRegistry(),
-    rawErrors
+    rawErrors,
   } = props;
   const { title, format } = schema;
   const { widgets, formContext } = registry;
@@ -72,14 +72,14 @@ if (process.env.NODE_ENV !== "production") {
       ).isRequired,
       fields: PropTypes.objectOf(PropTypes.func).isRequired,
       definitions: PropTypes.object.isRequired,
-      formContext: PropTypes.object.isRequired
+      formContext: PropTypes.object.isRequired,
     }),
     formContext: PropTypes.object.isRequired,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
     readonly: PropTypes.bool,
     autofocus: PropTypes.bool,
-    rawErrors: PropTypes.arrayOf(PropTypes.string)
+    rawErrors: PropTypes.arrayOf(PropTypes.string),
   };
 }
 
@@ -87,7 +87,7 @@ StringField.defaultProps = {
   uiSchema: {},
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 export default StringField;

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -46,7 +46,7 @@ BaseInput.defaultProps = {
   required: false,
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -60,7 +60,7 @@ if (process.env.NODE_ENV !== "production") {
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
-    onFocus: PropTypes.func
+    onFocus: PropTypes.func,
   };
 }
 

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -45,7 +45,7 @@ BaseInput.defaultProps = {
   required: false,
   disabled: false,
   readonly: false,
-  autofocus: false
+  autofocus: false,
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -59,7 +59,7 @@ if (process.env.NODE_ENV !== "production") {
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
-    onFocus: PropTypes.func
+    onFocus: PropTypes.func,
   };
 }
 

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -23,8 +23,7 @@ function BaseInput(props) {
     return props.onChange(value === "" ? options.emptyValue : value);
   };
 
-  const cleanProps = { ...inputProps };
-  delete cleanProps.rawErrors;
+  const { rawErrors, ...cleanProps } = inputProps;
 
   return (
     <input
@@ -46,7 +45,7 @@ BaseInput.defaultProps = {
   required: false,
   disabled: false,
   readonly: false,
-  autofocus: false,
+  autofocus: false
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -60,7 +59,7 @@ if (process.env.NODE_ENV !== "production") {
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
-    onFocus: PropTypes.func,
+    onFocus: PropTypes.func
   };
 }
 

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -22,6 +22,10 @@ function BaseInput(props) {
   const _onChange = ({ target: { value } }) => {
     return props.onChange(value === "" ? options.emptyValue : value);
   };
+
+  const cleanProps = { ...inputProps };
+  delete cleanProps.rawErrors;
+
   return (
     <input
       className="form-control"
@@ -29,7 +33,7 @@ function BaseInput(props) {
       disabled={disabled}
       autoFocus={autofocus}
       value={value == null ? "" : value}
-      {...inputProps}
+      {...cleanProps}
       onChange={_onChange}
       onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}
       onFocus={onFocus && (event => onFocus(inputProps.id, event.target.value))}
@@ -42,7 +46,7 @@ BaseInput.defaultProps = {
   required: false,
   disabled: false,
   readonly: false,
-  autofocus: false,
+  autofocus: false
 };
 
 if (process.env.NODE_ENV !== "production") {
@@ -56,7 +60,7 @@ if (process.env.NODE_ENV !== "production") {
     autofocus: PropTypes.bool,
     onChange: PropTypes.func,
     onBlur: PropTypes.func,
-    onFocus: PropTypes.func,
+    onFocus: PropTypes.func
   };
 }
 

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -43,7 +43,7 @@ describe("SchemaField", () => {
       const fields = { SchemaField: CustomSchemaField };
       const { node } = createFormComponent({
         schema: { type: "string" },
-        fields,
+        fields
       });
 
       expect(
@@ -67,8 +67,8 @@ describe("SchemaField", () => {
       type: "object",
       properties: {
         foo: { type: "string" },
-        bar: { type: "string" },
-      },
+        bar: { type: "string" }
+      }
     };
 
     it("should use provided direct custom component for object", () => {
@@ -83,7 +83,7 @@ describe("SchemaField", () => {
 
     it("should use provided direct custom component for specific property", () => {
       const uiSchema = {
-        foo: { "ui:field": MyObject },
+        foo: { "ui:field": MyObject }
       };
 
       const { node } = createFormComponent({ schema, uiSchema });
@@ -108,8 +108,8 @@ describe("SchemaField", () => {
             render() {
               return <div />;
             }
-          },
-        },
+          }
+        }
       });
 
       const { registry } = receivedProps;
@@ -137,11 +137,11 @@ describe("SchemaField", () => {
             type: "object",
             properties: {
               foo: { type: "string" },
-              bar: { type: "string" },
-            },
-          },
+              bar: { type: "string" }
+            }
+          }
         },
-        $ref: "#/definitions/foobar",
+        $ref: "#/definitions/foobar"
       };
       const uiSchema = { "ui:field": "myobject" };
       const fields = { myobject: MyObject };
@@ -162,11 +162,11 @@ describe("SchemaField", () => {
       };
 
       const schema = {
-        type: "string",
+        type: "string"
       };
       const uiSchema = {
         "ui:field": "customSchemaField",
-        classNames: "foo",
+        classNames: "foo"
       };
       const fields = { customSchemaField: CustomSchemaField };
 
@@ -180,8 +180,8 @@ describe("SchemaField", () => {
     const schema = {
       type: "object",
       properties: {
-        foo: { type: "string" },
-      },
+        foo: { type: "string" }
+      }
     };
 
     it("should render label by default", () => {
@@ -191,7 +191,7 @@ describe("SchemaField", () => {
 
     it("should render label if ui:options label is set to true", () => {
       const uiSchema = {
-        foo: { "ui:options": { label: true } },
+        foo: { "ui:options": { label: true } }
       };
 
       const { node } = createFormComponent({ schema, uiSchema });
@@ -200,7 +200,7 @@ describe("SchemaField", () => {
 
     it("should not render label if ui:options label is set to false", () => {
       const uiSchema = {
-        foo: { "ui:options": { label: false } },
+        foo: { "ui:options": { label: false } }
       };
 
       const { node } = createFormComponent({ schema, uiSchema });
@@ -213,8 +213,8 @@ describe("SchemaField", () => {
       type: "object",
       properties: {
         foo: { type: "string", description: "A Foo field" },
-        bar: { type: "string" },
-      },
+        bar: { type: "string" }
+      }
     };
 
     it("should render description if available from the schema", () => {
@@ -231,14 +231,14 @@ describe("SchemaField", () => {
         type: "object",
         properties: {
           foo: { $ref: "#/definitions/foo" },
-          bar: { type: "string" },
+          bar: { type: "string" }
         },
         definitions: {
           foo: {
             type: "string",
-            description: "A Foo field",
-          },
-        },
+            description: "A Foo field"
+          }
+        }
       };
       const { node } = createFormComponent({ schema: schemaWithReference });
 
@@ -263,8 +263,8 @@ describe("SchemaField", () => {
       const { node } = createFormComponent({
         schema,
         fields: {
-          DescriptionField: CustomDescriptionField,
-        },
+          DescriptionField: CustomDescriptionField
+        }
       });
 
       expect(node.querySelector("#custom").textContent).to.eql("A Foo field");
@@ -275,15 +275,15 @@ describe("SchemaField", () => {
     const schema = {
       type: "object",
       properties: {
-        foo: { type: "string" },
-      },
+        foo: { type: "string" }
+      }
     };
 
     const uiSchema = {
       "ui:field": props => {
         const { uiSchema, ...fieldProps } = props; //eslint-disable-line
         return <SchemaField {...fieldProps} />;
-      },
+      }
     };
 
     function validate(formData, errors) {
@@ -320,6 +320,26 @@ describe("SchemaField", () => {
       );
       expect(matches).to.have.length.of(1);
       expect(matches[0].textContent).to.contain("test");
+    });
+
+    describe("Custom error rendering", () => {
+      const customStringWidget = props => {
+        return <div className="custom-text-widget">{props.rawErrors}</div>;
+      };
+
+      it("should pass rawErrors down to custom widgets", () => {
+        const { node } = createFormComponent({
+          schema,
+          uiSchema,
+          validate,
+          widgets: { BaseInput: customStringWidget }
+        });
+        submit(node);
+
+        const matches = node.querySelectorAll(".custom-text-widget");
+        expect(matches).to.have.length.of(1);
+        expect(matches[0].textContent).to.eql("test");
+      });
     });
   });
 });

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -43,7 +43,7 @@ describe("SchemaField", () => {
       const fields = { SchemaField: CustomSchemaField };
       const { node } = createFormComponent({
         schema: { type: "string" },
-        fields
+        fields,
       });
 
       expect(
@@ -67,8 +67,8 @@ describe("SchemaField", () => {
       type: "object",
       properties: {
         foo: { type: "string" },
-        bar: { type: "string" }
-      }
+        bar: { type: "string" },
+      },
     };
 
     it("should use provided direct custom component for object", () => {
@@ -83,7 +83,7 @@ describe("SchemaField", () => {
 
     it("should use provided direct custom component for specific property", () => {
       const uiSchema = {
-        foo: { "ui:field": MyObject }
+        foo: { "ui:field": MyObject },
       };
 
       const { node } = createFormComponent({ schema, uiSchema });
@@ -108,8 +108,8 @@ describe("SchemaField", () => {
             render() {
               return <div />;
             }
-          }
-        }
+          },
+        },
       });
 
       const { registry } = receivedProps;
@@ -137,11 +137,11 @@ describe("SchemaField", () => {
             type: "object",
             properties: {
               foo: { type: "string" },
-              bar: { type: "string" }
-            }
-          }
+              bar: { type: "string" },
+            },
+          },
         },
-        $ref: "#/definitions/foobar"
+        $ref: "#/definitions/foobar",
       };
       const uiSchema = { "ui:field": "myobject" };
       const fields = { myobject: MyObject };
@@ -162,11 +162,11 @@ describe("SchemaField", () => {
       };
 
       const schema = {
-        type: "string"
+        type: "string",
       };
       const uiSchema = {
         "ui:field": "customSchemaField",
-        classNames: "foo"
+        classNames: "foo",
       };
       const fields = { customSchemaField: CustomSchemaField };
 
@@ -180,8 +180,8 @@ describe("SchemaField", () => {
     const schema = {
       type: "object",
       properties: {
-        foo: { type: "string" }
-      }
+        foo: { type: "string" },
+      },
     };
 
     it("should render label by default", () => {
@@ -191,7 +191,7 @@ describe("SchemaField", () => {
 
     it("should render label if ui:options label is set to true", () => {
       const uiSchema = {
-        foo: { "ui:options": { label: true } }
+        foo: { "ui:options": { label: true } },
       };
 
       const { node } = createFormComponent({ schema, uiSchema });
@@ -200,7 +200,7 @@ describe("SchemaField", () => {
 
     it("should not render label if ui:options label is set to false", () => {
       const uiSchema = {
-        foo: { "ui:options": { label: false } }
+        foo: { "ui:options": { label: false } },
       };
 
       const { node } = createFormComponent({ schema, uiSchema });
@@ -213,8 +213,8 @@ describe("SchemaField", () => {
       type: "object",
       properties: {
         foo: { type: "string", description: "A Foo field" },
-        bar: { type: "string" }
-      }
+        bar: { type: "string" },
+      },
     };
 
     it("should render description if available from the schema", () => {
@@ -231,14 +231,14 @@ describe("SchemaField", () => {
         type: "object",
         properties: {
           foo: { $ref: "#/definitions/foo" },
-          bar: { type: "string" }
+          bar: { type: "string" },
         },
         definitions: {
           foo: {
             type: "string",
-            description: "A Foo field"
-          }
-        }
+            description: "A Foo field",
+          },
+        },
       };
       const { node } = createFormComponent({ schema: schemaWithReference });
 
@@ -263,8 +263,8 @@ describe("SchemaField", () => {
       const { node } = createFormComponent({
         schema,
         fields: {
-          DescriptionField: CustomDescriptionField
-        }
+          DescriptionField: CustomDescriptionField,
+        },
       });
 
       expect(node.querySelector("#custom").textContent).to.eql("A Foo field");
@@ -275,15 +275,15 @@ describe("SchemaField", () => {
     const schema = {
       type: "object",
       properties: {
-        foo: { type: "string" }
-      }
+        foo: { type: "string" },
+      },
     };
 
     const uiSchema = {
       "ui:field": props => {
         const { uiSchema, ...fieldProps } = props; //eslint-disable-line
         return <SchemaField {...fieldProps} />;
-      }
+      },
     };
 
     function validate(formData, errors) {
@@ -332,7 +332,7 @@ describe("SchemaField", () => {
           schema,
           uiSchema,
           validate,
-          widgets: { BaseInput: customStringWidget }
+          widgets: { BaseInput: customStringWidget },
         });
         submit(node);
 


### PR DESCRIPTION
### Reasons for making this change

See issue #727 

The current implementation of ArrayField, BooleanField, and StringField don't pass the error schema down to the widgets they render. This makes rendering errors as part of a custom control tricky. 

This PR solves this by passing the raw errors down, but maintaining the default implementation for displaying errors with the libraries built in widgets.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ x] **I'm adding or updating code**
  - [ x] I've added and/or updated tests
  - [x ] I've updated docs if needed
  - [ x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
