### PR TITLE
Add allOf schema dependency support

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -466,21 +466,32 @@ function withDependentSchema(
   dependencyKey,
   dependencyValue
 ) {
-  let { oneOf, ...dependentSchema } = retrieveSchema(
+  let { oneOf, allOf, ...dependentSchema } = retrieveSchema(
     dependencyValue,
     definitions,
     formData
   );
   schema = mergeSchemas(schema, dependentSchema);
-  return oneOf === undefined
-    ? schema
-    : withExactlyOneSubschema(
-        schema,
-        definitions,
-        formData,
-        dependencyKey,
-        oneOf
-      );
+
+  if (oneOf !== undefined) {
+    return withExactlyOneSubschema(
+      schema,
+      definitions,
+      formData,
+      dependencyKey,
+      oneOf
+    );
+  } else if (allOf !== undefined) {
+    return withMultipleSubschemas(
+      schema,
+      definitions,
+      formData,
+      dependencyKey,
+      allOf
+    );
+  } else {
+    return schema;
+  }
 }
 
 function withExactlyOneSubschema(
@@ -495,29 +506,14 @@ function withExactlyOneSubschema(
       `invalid oneOf: it is some ${typeof oneOf} instead of an array`
     );
   }
-  const validSubschemas = oneOf.filter(subschema => {
-    if (!subschema.properties) {
-      return false;
-    }
-    const { [dependencyKey]: conditionPropertySchema } = subschema.properties;
-    if (conditionPropertySchema) {
-      const conditionSchema = {
-        type: "object",
-        properties: {
-          [dependencyKey]: conditionPropertySchema,
-        },
-      };
-      const { errors } = validateFormData(formData, conditionSchema);
-      return errors.length === 0;
-    }
-  });
-  if (validSubschemas.length !== 1) {
+  const subschemas = validSubschemas(oneOf, formData, dependencyKey);
+  if (subschemas.length !== 1) {
     console.warn(
       "ignoring oneOf in dependencies because there isn't exactly one subschema that is valid"
     );
     return schema;
   }
-  const subschema = validSubschemas[0];
+  const subschema = subschemas[0];
   const {
     [dependencyKey]: conditionPropertySchema,
     ...dependentSubschema
@@ -527,6 +523,64 @@ function withExactlyOneSubschema(
     schema,
     retrieveSchema(dependentSchema, definitions, formData)
   );
+}
+
+function withMultipleSubschemas(
+  schema,
+  definitions,
+  formData,
+  dependencyKey,
+  allOf
+) {
+  if (!Array.isArray(allOf)) {
+    throw new Error(
+      `invalid allOf: it is some ${typeof allOf} instead of an array`
+    );
+  }
+  const subschemas = validSubschemas(allOf, formData, dependencyKey);
+  if (subschemas.length !== allOf.length) {
+    console.warn(
+      "ignoring allOf in dependencies because not all subschemas are valid"
+    );
+    return schema;
+  }
+  const reducer = (schema, subschema) => {
+    const {
+      [dependencyKey]: conditionPropertySchema,
+      ...dependentSubschema
+    } = subschema.properties;
+    const dependentSchema = { ...subschema, properties: dependentSubschema };
+    return mergeSchemas(
+      schema,
+      retrieveSchema(dependentSchema, definitions, formData)
+    );
+  };
+  return subschemas.reduce(reducer, schema);
+}
+
+function validSubschemas(dependencies, formData, dependencyKey) {
+  return dependencies
+    .map(subschema => {
+      return subschema.oneOf
+        ? validSubschemas(subschema.oneOf, formData, dependencyKey)[0]
+        : subschema;
+    })
+    .filter(subschema => {
+      if (!subschema.properties) {
+        return false;
+      }
+      const { [dependencyKey]: conditionPropertySchema } = subschema.properties;
+      if (conditionPropertySchema) {
+        const conditionSchema = {
+          type: "object",
+          properties: {
+            [dependencyKey]: conditionPropertySchema,
+          },
+        };
+        const { errors } = validateFormData(formData, conditionSchema);
+        return errors.length === 0;
+      }
+    });
 }
 
 function mergeSchemas(schema1, schema2) {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -777,6 +777,129 @@ describe("utils", () => {
           });
         });
 
+        describe("multiple conditions", () => {
+          it("should add 'first' properties given 'first' data", () => {
+            const schema = {
+              type: "object",
+              properties: {
+                a: {
+                  type: "array",
+                  items: { type: "string", enum: ["int", "bool"] },
+                },
+              },
+              dependencies: {
+                a: {
+                  allOf: [
+                    {
+                      oneOf: [
+                        {
+                          properties: {
+                            a: { not: { contains: { enum: ["int"] } } },
+                          },
+                        },
+                        {
+                          properties: {
+                            a: { contains: { enum: ["int"] } },
+                            b: { type: "integer" },
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      oneOf: [
+                        {
+                          properties: {
+                            a: { not: { contains: { enum: ["bool"] } } },
+                          },
+                        },
+                        {
+                          properties: {
+                            a: { contains: { enum: ["bool"] } },
+                            c: { type: "boolean" },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            };
+            const definitions = {};
+            const formData = { a: ["int"] };
+            expect(retrieveSchema(schema, definitions, formData)).eql({
+              type: "object",
+              properties: {
+                a: {
+                  type: "array",
+                  items: { type: "string", enum: ["int", "bool"] },
+                },
+                b: { type: "integer" },
+              },
+            });
+          });
+
+          it("should add 'first' and 'second' properties given 'first' and 'second' data", () => {
+            const schema = {
+              type: "object",
+              properties: {
+                a: {
+                  type: "array",
+                  items: { type: "string", enum: ["int", "bool"] },
+                },
+              },
+              dependencies: {
+                a: {
+                  allOf: [
+                    {
+                      oneOf: [
+                        {
+                          properties: {
+                            a: { not: { contains: { enum: ["int"] } } },
+                          },
+                        },
+                        {
+                          properties: {
+                            a: { contains: { enum: ["int"] } },
+                            b: { type: "integer" },
+                          },
+                        },
+                      ],
+                    },
+                    {
+                      oneOf: [
+                        {
+                          properties: {
+                            a: { not: { contains: { enum: ["bool"] } } },
+                          },
+                        },
+                        {
+                          properties: {
+                            a: { contains: { enum: ["bool"] } },
+                            c: { type: "boolean" },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            };
+            const definitions = {};
+            const formData = { a: ["bool", "int"] };
+            expect(retrieveSchema(schema, definitions, formData)).eql({
+              type: "object",
+              properties: {
+                a: {
+                  type: "array",
+                  items: { type: "string", enum: ["int", "bool"] },
+                },
+                b: { type: "integer" },
+                c: { type: "boolean" },
+              },
+            });
+          });
+        });
+
         describe("with $ref in dependency", () => {
           it("should retrieve the referenced schema", () => {
             const schema = {


### PR DESCRIPTION
### Reasons for making this change

The `oneOf` schema dependency support is nice when you've got one condition. But if there are multiple, non-mutually exclusive dependencies on a single field, then you also need `allOf`.

For example, if Field1 were an array with 3 options: A, B, and C. And Field2 was supposed to appear if option B were selected, and Field3 was supposed to appear if A and C were selected, _and_ you wanted both Field2 and Field3 to appear if A, B, and C were selected, then this would accomplish that.

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
