### PR TITLE
Fix warning on FileWidget

### DIFF
--- a/src/components/widgets/FileWidget.js
+++ b/src/components/widgets/FileWidget.js
@@ -60,10 +60,6 @@ function extractFileInfo(dataURLs) {
 }
 
 class FileWidget extends Component {
-  defaultProps = {
-    multiple: false,
-  };
-
   constructor(props) {
     super(props);
     const { value } = props;


### PR DESCRIPTION
### Reasons for making this change
Following warning is thrown when using FileWidget:

`Warning: Setting defaultProps as an instance property on FileWidget is not supported and will be ignored. Instead, define defaultProps as a static property on FileWidget.`

It seems like default props have been set twice on the FileWidget so I just removed the instance that is causing the warnings. I checked and there are no other instances of this problem.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
