### PR TITLE
Add validation of undefined when mergeObjects is called 

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -221,7 +221,7 @@ export function mergeObjects(obj1, obj2, concatArrays = false) {
   // Recursively merge deeply nested objects.
   var acc = Object.assign({}, obj1); // Prevent mutation of source object.
   return Object.keys(obj2).reduce((acc, key) => {
-    const left = obj1[key],
+    const left = obj1 ? obj1[key] : {},
       right = obj2[key];
     if (obj1.hasOwnProperty(key) && isObject(right)) {
       acc[key] = mergeObjects(left, right, concatArrays);


### PR DESCRIPTION
### Reasons for making this change

When I try to send a deeper object in `formData` like: 
`formData = { a: { b: 1, c: 2 } }`
from a custom select widget using `props.onChange` an error occur because `mergeObjects` method try to get an element of an undefined object

If this is related to existing tickets, include links to them as well.

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style

