### PR TITLE
Fixed issue where form validation errors stay on the page after user fixed the causes

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -147,10 +147,11 @@ export default class Form extends Component {
       }
     }
 
-    if (this.props.onSubmit) {
-      this.props.onSubmit({ ...this.state, status: "submitted" });
-    }
-    this.setState({ errors: [], errorSchema: {} });
+    setState(this, { errors: [], errorSchema: {} }, () => {
+      if (this.props.onSubmit) {
+        this.props.onSubmit({ ...this.state, status: "submitted" });
+      }
+    });
   };
 
   getRegistry() {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -190,8 +190,15 @@ describe("Form", () => {
   });
 
   describe("Custom submit buttons", () => {
-    it("should submit the form when clicked", () => {
-      const onSubmit = sandbox.spy();
+    it("should submit the form when clicked", done => {
+      let submitCount = 0;
+      const onSubmit = () => {
+        submitCount++;
+        if (submitCount === 2) {
+          done();
+        }
+      };
+
       const comp = renderIntoDocument(
         <Form onSubmit={onSubmit} schema={{}}>
           <button type="submit">Submit</button>
@@ -202,7 +209,6 @@ describe("Form", () => {
       const buttons = node.querySelectorAll("button[type=submit]");
       buttons[0].click();
       buttons[1].click();
-      sinon.assert.calledTwice(onSubmit);
     });
   });
 

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -930,9 +930,10 @@ describe("Form", () => {
       });
 
       it("should reset errors and errorSchema state to initial state after correction and resubmission", () => {
+        const onError = sandbox.spy();
         const { comp, node } = createFormComponent({
           schema,
-          onError: () => {},
+          onError,
         });
 
         Simulate.change(node.querySelector("input[type=text]"), {
@@ -943,6 +944,8 @@ describe("Form", () => {
         expect(comp.state.errorSchema).eql({
           __errors: ["should NOT be shorter than 8 characters"],
         });
+        expect(comp.state.errors.length).eql(1);
+        sinon.assert.calledOnce(onError);
 
         Simulate.change(node.querySelector("input[type=text]"), {
           target: { value: "long enough" },
@@ -951,6 +954,7 @@ describe("Form", () => {
 
         expect(comp.state.errorSchema).eql({});
         expect(comp.state.errors).eql([]);
+        sinon.assert.calledOnce(onError);
       });
     });
 

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -922,6 +922,30 @@ describe("Form", () => {
           })
         );
       });
+
+      it("should reset errors and errorSchema state to initial state after correction and resubmission", () => {
+        const { comp, node } = createFormComponent({
+          schema,
+          onError: () => {},
+        });
+
+        Simulate.change(node.querySelector("input[type=text]"), {
+          target: { value: "short" },
+        });
+        Simulate.submit(node);
+
+        expect(comp.state.errorSchema).eql({
+          __errors: ["should NOT be shorter than 8 characters"],
+        });
+
+        Simulate.change(node.querySelector("input[type=text]"), {
+          target: { value: "long enough" },
+        });
+        Simulate.submit(node);
+
+        expect(comp.state.errorSchema).eql({});
+        expect(comp.state.errors).eql([]);
+      });
     });
 
     describe("root level", () => {


### PR DESCRIPTION
### Reasons for making this change

This pull request should resolve #793 

Expected Behavior:
- During onSubmit, if the form validates successfully the form's state should reflect that by setting `state.errors = []` and `state.errorSchema = {}`

Actual behavior:
- Form.js's this.setState() isn't actually modifying the state of the component, so `state.errors` and `state.errorSchema` aren't modified properly after successful validation of a form.

Fix: Use util.setState and do the `this.props.onSubmit` callback after setting state. This is similar to how things are done in Form.js `onChange()` function.

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
