### PR TITLE
Support Nested Forms (Forms in Forms)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       "git add"
     ]
   },
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "files": [
     "dist",
     "lib"

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -189,7 +189,7 @@ export default class Form extends Component {
     const _SchemaField = registry.fields.SchemaField;
 
     return (
-      <form
+      <div
         className={className ? className : "rjsf"}
         id={id}
         name={name}
@@ -200,7 +200,7 @@ export default class Form extends Component {
         encType={enctype}
         acceptCharset={acceptcharset}
         noValidate={noHtml5Validate}
-        onSubmit={this.onSubmit}>
+        >
         {this.renderErrors()}
         <_SchemaField
           schema={schema}
@@ -218,12 +218,12 @@ export default class Form extends Component {
           children
         ) : (
           <p>
-            <button type="submit" className="btn btn-info">
+            <button type="submit" className="btn btn-info" onClick={this.onSubmit} >
               Submit
             </button>
           </p>
         )}
-      </form>
+      </div>
     );
   }
 }


### PR DESCRIPTION
### Reasons for making this change
This allows nested forms because a form in a form is bad DOM

Use case:
* A form that has an link new record button that creates a new form (nested) that allow one to create this new record and then returns the record id to the first form for linking.  In my case the record is an uploaded picture.

### Checklist
* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
