### PR TITLE
Update Radio Widget to use Bootstrap v4

### DIFF
--- a/src/components/widgets/RadioWidget.js
+++ b/src/components/widgets/RadioWidget.js
@@ -14,17 +14,18 @@ function RadioWidget(props) {
   // Generating a unique field name to identify this set of radio buttons
   const name = Math.random().toString();
   const { enumOptions, inline } = options;
+  const inlineCls = inline ? "form-check-inline" : "";
   // checked={checked} has been moved above name={name}, As mentioned in #349;
   // this is a temporary fix for radio button rendering bug in React, facebook/react#7630.
   return (
-    <div className="field-radio-group">
+    <div className={`form-check ${inlineCls}`}>
       {enumOptions.map((option, i) => {
         const checked = option.value === value;
-        const disabledCls = disabled || readonly ? "disabled" : "";
         const radio = (
           <span>
             <input
               type="radio"
+              className="form-check-input"
               checked={checked}
               name={name}
               required={required}
@@ -37,13 +38,9 @@ function RadioWidget(props) {
           </span>
         );
 
-        return inline ? (
-          <label key={i} className={`radio-inline ${disabledCls}`}>
-            {radio}
-          </label>
-        ) : (
-          <div key={i} className={`radio ${disabledCls}`}>
-            <label>{radio}</label>
+        return (
+          <div key={i}>
+            <label className="form-check-label">{radio}</label>
           </div>
         );
       })}

--- a/test/BooleanField_test.js
+++ b/test/BooleanField_test.js
@@ -117,7 +117,7 @@ describe("BooleanField", () => {
     });
 
     const labels = [].map.call(
-      node.querySelectorAll(".field-radio-group label"),
+      node.querySelectorAll(".form-check label"),
       label => label.textContent
     );
     expect(labels).eql(["Yes", "No"]);
@@ -135,7 +135,9 @@ describe("BooleanField", () => {
       },
     });
 
-    expect(node.querySelectorAll(".radio-inline")).to.have.length.of(2);
+    expect(node.querySelectorAll(".form-check-inline input")).to.have.length.of(
+      2
+    );
   });
 
   it("should support enumNames for select", () => {

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -1501,7 +1501,7 @@ describe("uiSchema", () => {
       it("should render boolean option labels", () => {
         const { node } = createFormComponent({ schema, uiSchema });
         const labels = [].map.call(
-          node.querySelectorAll(".field-radio-group label"),
+          node.querySelectorAll(".form-check label"),
           node => node.textContent
         );
 


### PR DESCRIPTION
### Reasons for making this change
Updates the Radio Widget to Support Bootstrap v4 based on their documentation:
https://getbootstrap.com/docs/4.0/components/forms/#checkboxes-and-radios

This change breaks backwards capability. Either the major version should be incremented, or a backwards-compability layer should be added (perhaps adding a bootstrap version prop?)

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
