### PR TITLE
Move to the 3.x series of react-codemirror2

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "prettier": "^1.8.2",
     "react": "^15.5.0",
     "react-addons-test-utils": "^15.3.2",
-    "react-codemirror2": "^2.0.2",
+    "react-codemirror2": "^3.0.0",
     "react-dom": "^15.3.2",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "prettier": "^1.8.2",
     "react": "^15.5.0",
     "react-addons-test-utils": "^15.3.2",
-    "react-codemirror2": "^3.0.0",
+    "react-codemirror2": "^4.1.0",
     "react-dom": "^15.3.2",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",

--- a/playground/app.js
+++ b/playground/app.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { render } from "react-dom";
-import CodeMirror from "react-codemirror2";
+import { UnControlled as CodeMirror } from "react-codemirror2";
 import "codemirror/mode/javascript/javascript";
 
 import { shouldRender } from "../src/utils";
@@ -213,6 +213,7 @@ class Editor extends Component {
         <CodeMirror
           value={this.state.code}
           onChange={this.onCodeChange}
+          autoCursor={false}
           options={Object.assign({}, cmOptions, { theme })}
         />
       </div>


### PR DESCRIPTION
### Reasons for making this change

Fixes #851. Per that issue, this doesn't get us all the way to 4.x due to something that may be a bug upstream or a bug in our use of it.

### Checklist

* (n/a) **I'm updating documentation**
  - (n/a) I've checked the rendering of the Markdown text I've added
  - (n/a) If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - (n/a) I've added and/or updated tests
  - (n/a) I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* (n/a) **I'm adding a new feature**
  - (n/a) I've updated the playground with an example use of the feature
