### PR TITLE
handle errors from ajv.validate to correctly display schema errors in form

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -153,7 +153,12 @@ export default function validateFormData(
   customValidate,
   transformErrors
 ) {
-  ajv.validate(schema, formData);
+  try {
+    ajv.validate(schema, formData);
+  } catch (e) {
+    // swallow errors thrown in ajv due to invalid schemas, these
+    // still get displayed
+  }
 
   let errors = transformAjvErrors(ajv.errors);
 

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -134,6 +134,42 @@ describe("Validation", () => {
         expect(errors[0].message).to.equal(newErrorMessage);
       });
     });
+
+    describe("Invalid schema", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string",
+            required: "invalid_type_non_array",
+          },
+        },
+      };
+
+      let errors, errorSchema;
+
+      beforeEach(() => {
+        const result = validateFormData({ foo: 42 }, schema);
+        errors = result.errors;
+        errorSchema = result.errorSchema;
+      });
+
+      it("should return an error list", () => {
+        expect(errors).to.have.length.of(1);
+        expect(errors[0].name).eql("type");
+        expect(errors[0].property).eql(".properties['foo'].required");
+        expect(errors[0].message).eql("should be array");
+      });
+
+      it("should return an errorSchema", () => {
+        expect(errorSchema.properties.foo.required.__errors).to.have.length.of(
+          1
+        );
+        expect(errorSchema.properties.foo.required.__errors[0]).eql(
+          "should be array"
+        );
+      });
+    });
   });
 
   describe("Form integration", () => {


### PR DESCRIPTION
### Reasons for making this change

Schema errors not being displayed in form.

Fixes #863 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ x ] **I'm adding or updating code**
  - [ x ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ x ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
