### PR TITLE
Updated README to mention the support for JSON Schema compliant enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,51 @@ This will be rendered using a select box that way:
 
 Note that string representations of numbers will be cast back and reflected as actual numbers into form state.
 
+#### Alternative JSON-Schema compliant approach
+
+The JSON Schema team concluded an alternative approach instead of enumNames and react-jsonschema-form supports it as well.
+
+```js
+const schema = {
+  "type": "number",
+  "anyOf": [
+    {
+      "type": "number",
+      "title": "one",
+      "enum": [
+        1
+      ]
+    },
+    {
+      "type": "number",
+      "title": "two",
+      "enum": [
+        2
+      ]
+    },
+    {
+      "type": "number",
+      "title": "three",
+      "enum": [
+        3
+      ]
+    }
+  ]
+};
+```
+
+As above this will be rendered using a select box as so:
+
+```html
+<select>
+  <option value="1">one</option>
+  <option value="2">two</option>
+  <option value="3">three</option>
+</select>
+```
+
+A live example of both approaches side-by-side can be found in the **Alternatives** playground preset.
+
 ### Disabled attribute for `enum` fields
 
 This library supports the 'disabled' attribute for `enum` options. Enum disabled allows disabling options for 'enum' fields.This attribute can be added as a part of uiSchema.


### PR DESCRIPTION
Updated README to mention the support for JSON Schema compliant drop-down enums

### Reasons for making this change

PR #581 brought in support for `anyOf`-powered enums and added an Alternatives example in the playground but it still requires one to be aware of the difference in enums in that example or to find Issue #532 to understand how to use them so I added a section to the README.

Notably this was a task "I've updated docs if needed" on #581 that was left undone and this is trying to make that task done. :)

Although I added a new sub-section I did not add it to the Table of Contents as it still applies to the header present in the ToC but if you feel that would be good to do then I totally can. In that case I think we should probably add a sub-section title to the existing enumNames approach for clarity but I'm not sure what it should be called.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
