### PR TITLE
Fixed multiplicative errors on schema dependencies

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -70,11 +70,13 @@ export default class Form extends Component {
     return shouldRender(this, nextProps, nextState);
   }
 
-  validate(formData, schema) {
+  validate(formData, schema = this.props.schema) {
     const { validate, transformErrors } = this.props;
+    const { definitions } = this.getRegistry();
+    const resolvedSchema = retrieveSchema(schema, definitions, formData);
     return validateFormData(
       formData,
-      schema || this.props.schema,
+      resolvedSchema,
       validate,
       transformErrors
     );


### PR DESCRIPTION
### Reasons for making this change

When schema have dependencies with multiple branches, passing whole schema to validator will generate extraneous errors.
Here we are stripping schema from branches that we don't need to validate - since they are not present in the form.

Relates to the ticked i have created: https://github.com/mozilla-services/react-jsonschema-form/issues/829

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
