### PR TITLE
Prevent stale form errors appearing

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -147,10 +147,11 @@ export default class Form extends Component {
       }
     }
 
-    if (this.props.onSubmit) {
-      this.props.onSubmit({ ...this.state, status: "submitted" });
-    }
-    this.setState({ errors: [], errorSchema: {} });
+    this.setState({ status: "initial", errors: [], errorSchema: {} }, () => {
+      if (this.props.onSubmit) {
+        this.props.onSubmit({ ...this.state, status: "submitted" });
+      }
+    });
   };
 
   getRegistry() {


### PR DESCRIPTION
Call submit as setState callback to prevent stale errors appearing.

### Reasons for making this change

Stale form errors can sometimes appear when invalid fields are submitted, corrected, resubmitted, followed by rerendering the form. 

fixes mozilla-services/react-jsonschema-form#315

I've just seen that somebody else has made an identical change, but it was from last year so I'll continue with this pull request anyway. I've not added a test because I'm not sure it's really relevant. If somebody wants to suggest a test, I'll add it.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ x ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ X ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
