### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ The `ui:readonly` uiSchema directive will mark all child widgets from a given fi
 
 #### Hidden widgets
 
-It's possible to use an hidden widget for a given field by setting the `ui:widget` uiSchema directive to `hidden` for this field:
+It's possible to use a hidden widget for a given field by setting the `ui:widget` uiSchema directive to `hidden` for this field:
 
 ```js
 const schema = {
@@ -391,7 +391,7 @@ const uiSchema = {
 > Notes
 >
 > - Hiding widgets is only supported for `boolean`, `string`, `number` and `integer` schema types;
-> - An hidden widget takes its value from the `formData` prop.
+> - A hidden widget takes its value from the `formData` prop.
 
 #### File widgets
 


### PR DESCRIPTION
### Reasons for making this change

Fixing what I believe is a minor README grammar error. 

Because the `h` in `hidden` is not unsounded (eg vs something like `hour`, where the `h` is completely mute), the correct phrase would be `a hidden widget`

Another example of a similar phrase would be `a hint` (not `an hint`)

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
