### PR TITLE
Make ui:order less strict

### DIFF
--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -100,6 +100,11 @@ class ObjectField extends Component {
       );
     }
 
+    // filter out any property names that are not currently applicable
+    orderedProperties = orderedProperties.filter(name =>
+      schema.properties.hasOwnProperty(name)
+    );
+
     const Template = registry.ObjectFieldTemplate || DefaultObjectFieldTemplate;
 
     const templateProps = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -270,28 +270,13 @@ export function orderProperties(properties, order) {
       prev[curr] = true;
       return prev;
     }, {});
-  const errorPropList = arr =>
-    arr.length > 1
-      ? `properties '${arr.join("', '")}'`
-      : `property '${arr[0]}'`;
-  const propertyHash = arrayToHash(properties);
   const orderHash = arrayToHash(order);
-  const extraneous = order.filter(prop => prop !== "*" && !propertyHash[prop]);
-  if (extraneous.length) {
-    throw new Error(
-      `uiSchema order list contains extraneous ${errorPropList(extraneous)}`
-    );
-  }
   const rest = properties.filter(prop => !orderHash[prop]);
-  const restIndex = order.indexOf("*");
-  if (restIndex === -1) {
-    if (rest.length) {
-      throw new Error(
-        `uiSchema order list does not contain ${errorPropList(rest)}`
-      );
-    }
-    return order;
+  // add an asterisk to the end if there isn't one already defined
+  if (!order.includes("*")) {
+    order.push("*");
   }
+  const restIndex = order.indexOf("*");
   if (restIndex !== order.lastIndexOf("*")) {
     throw new Error("uiSchema order list contains more than one wildcard item");
   }

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -218,7 +218,7 @@ describe("ObjectField", () => {
       expect(labels).eql(["baz", "bar", "qux", "foo"]);
     });
 
-    it("should throw when order list contains an extraneous property", () => {
+    it("should not throw when order list contains an extraneous property", () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
@@ -226,12 +226,10 @@ describe("ObjectField", () => {
         },
       });
 
-      expect(node.querySelector(".config-error").textContent).to.match(
-        /contains extraneous properties 'wut\?', 'huh\?'/
-      );
+      expect(node.querySelector(".config-error")).to.eq(null);
     });
 
-    it("should throw when order list misses an existing property", () => {
+    it("should not throw when order list misses an existing property", () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
@@ -239,9 +237,7 @@ describe("ObjectField", () => {
         },
       });
 
-      expect(node.querySelector(".config-error").textContent).to.match(
-        /does not contain properties 'foo', 'qux'/
-      );
+      expect(node.querySelector(".config-error")).to.eq(null);
     });
 
     it("should throw when more than one wildcard is present", () => {


### PR DESCRIPTION
Throwing an error when an extraneous property name is included
or when a property name is missing is problematic when ordering
properties in a dynamic schema (e.g. via schema dependencies,
etc.).

This change ignores extraneous property names and places places
missing properties at the end if not specified.

### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
