### PR TITLE
schema is not an html attribute

### DIFF
--- a/docs/form-customization.md
+++ b/docs/form-customization.md
@@ -694,8 +694,7 @@ The `Form` component supports the following html attributes:
   action="/users/list"
   autocomplete="off"
   enctype="multipart/form-data"
-  acceptcharset="ISO-8859-1"
-  schema={} />
+  acceptcharset="ISO-8859-1" />
 ```
 
 ### Disabling a form


### PR DESCRIPTION
### Reasons for making this change

schema is not an html attribute


### Checklist

* [x] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
