### PR TITLE
Add new number input for type number

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ render((
 
 ### Alternative widgets
 
-The uiSchema `ui:widget` property tells the form which UI widget should be used to render a field. 
+The uiSchema `ui:widget` property tells the form which UI widget should be used to render a field.
 
 Example:
 
@@ -370,7 +370,7 @@ uiSchema: {
   * `updown`: an `input[type=number]` updown selector;
   * `range`: an `input[type=range]` slider;
   * `radio`: a radio button group with enum values. This can only be used when `enum` values are specified for this input.
-  * By default, a regular `input[type=text]` element is used.
+  * By default, a regular `input[type=number]` element is used.
 
 > Note: If JSONSchema's `minimum`, `maximum` and `multipleOf` values are defined, the `min`, `max` and `step` input attributes values will take those values.
 

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -26,10 +26,11 @@ function StringField(props) {
     registry = getDefaultRegistry(),
     rawErrors,
   } = props;
-  const { title, format } = schema;
+  const { type, title, format } = schema;
   const { widgets, formContext } = registry;
   const enumOptions = isSelect(schema) && optionsList(schema);
-  const defaultWidget = format || (enumOptions ? "select" : "text");
+  const defaultWidget =
+    format || (enumOptions ? "select" : type == "number" ? "number" : "text");
   const { widget = defaultWidget, placeholder = "", ...options } = getUiOptions(
     uiSchema
   );

--- a/src/components/widgets/NumberWidget.js
+++ b/src/components/widgets/NumberWidget.js
@@ -1,0 +1,18 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { rangeSpec } from "../../utils";
+
+function NumberWidget(props) {
+  const { schema } = props;
+  const { BaseInput } = props.registry.widgets;
+  return <BaseInput type="number" {...props} {...rangeSpec(schema)} />;
+}
+
+if (process.env.NODE_ENV !== "production") {
+  Number.propTypes = {
+    value: PropTypes.string,
+  };
+}
+
+export default NumberWidget;

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -9,6 +9,7 @@ import DateTimeWidget from "./DateTimeWidget";
 import EmailWidget from "./EmailWidget";
 import FileWidget from "./FileWidget";
 import HiddenWidget from "./HiddenWidget";
+import NumberWidget from "./NumberWidget";
 import PasswordWidget from "./PasswordWidget";
 import RadioWidget from "./RadioWidget";
 import RangeWidget from "./RangeWidget";
@@ -21,6 +22,7 @@ import UpDownWidget from "./UpDownWidget";
 export default {
   BaseInput,
   PasswordWidget,
+  NumberWidget,
   RadioWidget,
   UpDownWidget,
   RangeWidget,

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,6 +31,7 @@ const widgetMap = {
     file: "FileWidget",
   },
   number: {
+    number: "NumberWidget",
     text: "TextWidget",
     select: "SelectWidget",
     updown: "UpDownWidget",
@@ -39,6 +40,7 @@ const widgetMap = {
     hidden: "HiddenWidget",
   },
   integer: {
+    number: "NumberWidget",
     text: "TextWidget",
     select: "SelectWidget",
     updown: "UpDownWidget",

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -1045,7 +1045,7 @@ describe("ArrayField", () => {
         "fieldset .field-string input[type=text]"
       );
       const numInput = node.querySelector(
-        "fieldset .field-number input[type=text]"
+        "fieldset .field-number input[type=number]"
       );
       expect(strInput.id).eql("root_0");
       expect(numInput.id).eql("root_1");
@@ -1057,7 +1057,7 @@ describe("ArrayField", () => {
         "fieldset .field-string input[type=text]"
       );
       const numInput = node.querySelector(
-        "fieldset .field-number input[type=text]"
+        "fieldset .field-number input[type=number]"
       );
       expect(strInput.required).eql(true);
       expect(numInput.required).eql(true);
@@ -1072,7 +1072,7 @@ describe("ArrayField", () => {
         "fieldset .field-string input[type=text]"
       );
       const numInput = node.querySelector(
-        "fieldset .field-number input[type=text]"
+        "fieldset .field-number input[type=number]"
       );
       expect(strInput.value).eql("foo");
       expect(numInput.value).eql("42");
@@ -1084,7 +1084,7 @@ describe("ArrayField", () => {
         "fieldset .field-string input[type=text]"
       );
       const numInput = node.querySelector(
-        "fieldset .field-number input[type=text]"
+        "fieldset .field-number input[type=number]"
       );
 
       Simulate.change(strInput, { target: { value: "bar" } });

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1410,7 +1410,7 @@ describe("Form", () => {
           liveValidate: true,
         });
 
-        Simulate.change(node.querySelector("input[type=text]"), {
+        Simulate.change(node.querySelector("input[type=number]"), {
           target: { value: "not a number" },
         });
 
@@ -1428,7 +1428,7 @@ describe("Form", () => {
           formData: { branch: 2 },
         });
 
-        Simulate.change(node.querySelector("input[type=text]"), {
+        Simulate.change(node.querySelector("input[type=number]"), {
           target: { value: "not a number" },
         });
 

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -24,7 +24,7 @@ describe("NumberField", () => {
       });
 
       expect(
-        node.querySelectorAll(".field input[type=text]")
+        node.querySelectorAll(".field input[type=number]")
       ).to.have.length.of(1);
     });
 
@@ -149,7 +149,7 @@ describe("NumberField", () => {
         },
       });
 
-      expect(node.querySelector("input[type=text]").id).eql("root");
+      expect(node.querySelector("input[type=number]").id).eql("root");
     });
 
     it("should render with trailing zeroes", () => {

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -1860,11 +1860,11 @@ describe("uiSchema", () => {
         expect(node.querySelector(selector).disabled).eql(true);
       }
 
-      it("should disable a text widget", () => {
+      it("should disable a number widget", () => {
         shouldBeDisabled(
-          "input[type=text]",
+          "input[type=number]",
           {
-            type: "string",
+            type: "number",
           },
           { "ui:disabled": true }
         );
@@ -1900,7 +1900,7 @@ describe("uiSchema", () => {
 
       it("should disable a number text widget", () => {
         shouldBeDisabled(
-          "input[type=text]",
+          "input[type=number]",
           {
             type: "number",
           },
@@ -2191,9 +2191,9 @@ describe("uiSchema", () => {
         );
       });
 
-      it("should mark as readonly a number text widget", () => {
+      it("should mark as readonly a number widget", () => {
         shouldBeReadonly(
-          "input[type=text]",
+          "input[type=number]",
           {
             type: "number",
           },


### PR DESCRIPTION
### Reasons for making this change

When schema has `type: number`, we should use a `type=number` otherwise with a text widget the serialized value is a string.

Fixes #966 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
