### PR TITLE
Add wrapper element around required asterisk in TitleField

### DIFF
--- a/src/components/fields/TitleField.js
+++ b/src/components/fields/TitleField.js
@@ -5,8 +5,12 @@ const REQUIRED_FIELD_SYMBOL = "*";
 
 function TitleField(props) {
   const { id, title, required } = props;
-  const legend = required ? title + REQUIRED_FIELD_SYMBOL : title;
-  return <legend id={id}>{legend}</legend>;
+  return (
+    <legend id={id}>
+      {title}
+      {required && <span className="required">{REQUIRED_FIELD_SYMBOL}</span>}
+    </legend>
+  );
 }
 
 if (process.env.NODE_ENV !== "production") {

--- a/test/TitleField_test.js
+++ b/test/TitleField_test.js
@@ -65,5 +65,7 @@ describe("TitleField", () => {
     const { node } = createComponent(TitleFieldWrapper, props);
 
     expect(node.textContent).to.equal(props.title + "*");
+
+    expect(node.querySelector("span.required").textContent).to.equal("*");
   });
 });


### PR DESCRIPTION
### Reasons for making this change
This is so that it can be separately styled easily via CSS.
It is already done this way in https://github.com/mozilla-services/react-jsonschema-form/blob/aadbbe9701c4db9df761e86f0280e1ecafc509f8/src/components/fields/SchemaField.js#L59

### Checklist
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
