### PR TITLE
Fix idSchema issue with dependencies

### DIFF
--- a/src/components/fields/UnsupportedField.js
+++ b/src/components/fields/UnsupportedField.js
@@ -5,7 +5,8 @@ function UnsupportedField({ schema, idSchema, reason }) {
   return (
     <div className="unsupported-field">
       <p>
-        Unsupported field schema{idSchema &&
+        Unsupported field schema
+        {idSchema &&
           idSchema.$id && (
             <span>
               {" for"} field <code>{idSchema.$id}</code>

--- a/src/utils.js
+++ b/src/utils.js
@@ -628,7 +628,7 @@ export function toIdSchema(
   const idSchema = {
     $id: id || idPrefix,
   };
-  if ("$ref" in schema) {
+  if ("$ref" in schema || "dependencies" in schema) {
     const _schema = retrieveSchema(schema, definitions, formData);
     return toIdSchema(_schema, id, definitions, formData, idPrefix);
   }

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1054,6 +1054,31 @@ describe("utils", () => {
       });
     });
 
+    it("should return an idSchema for property dependencies", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+        },
+        dependencies: {
+          foo: {
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+        },
+      };
+      const formData = {
+        foo: "test",
+      };
+
+      expect(toIdSchema(schema, undefined, schema.definitions, formData)).eql({
+        $id: "root",
+        foo: { $id: "root_foo" },
+        bar: { $id: "root_bar" },
+      });
+    });
+
     it("should handle idPrefix parameter", () => {
       const schema = {
         definitions: {


### PR DESCRIPTION
### Reasons for making this change

This fixes an issue where an `idSchema` would not be generated for property fields of objects that are in a dependency. It also adds a test to validate the fix.

[This PR](https://github.com/mozilla-services/react-jsonschema-form/pull/950) actually fixes the same issue as a part of its changes ([here](https://github.com/mozilla-services/react-jsonschema-form/pull/950/files#diff-2b4ca49d4bb0a774c4d4c1672d7aa781R626)), but it looks like it's been sitting idle for the past month, and I'd like to get this fix in. My PR touches much less code, so I figure it should be easy to get this through.

The change in `UnsupportedField.js` is just because I ran the `cs-format` script. I suppose it was missed before, and I figured I'd commit it.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
