### PR TITLE
Add preliminary support for object "additionalProperties"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
            - [Multiple files](#multiple-files)
            - [File widget input ref](#file-widget-input-ref)
      - [Object fields ordering](#object-fields-ordering)
+     - [Object item options](#object-item-options)
+        - [expandable option](#expandable-option)
      - [Array item options](#array-item-options)
         - [orderable option](#orderable-option)
         - [addable option](#addable-option)
@@ -481,6 +483,20 @@ If a guaranteed fixed order is only important for some fields, you can insert a 
 ```js
 const uiSchema = {
   "ui:order": ["bar", "*"]
+};
+```
+
+### Object item options
+
+#### `expandable` option
+
+If `additionalProperties` contains a schema object, an add button for new properies is shown by default. You can turn this off with the `expandable` option in `uiSchema`:
+
+```jsx
+const uiSchema = {
+  "ui:options":  {
+    expandable: false
+  }
 };
 ```
 

--- a/playground/samples/additionalProperties.js
+++ b/playground/samples/additionalProperties.js
@@ -1,0 +1,32 @@
+module.exports = {
+  schema: {
+    title: "A customizable registration form",
+    description: "A simple form with additional properties example.",
+    type: "object",
+    required: ["firstName", "lastName"],
+    additionalProperties: {
+      type: "string",
+    },
+    properties: {
+      firstName: {
+        type: "string",
+        title: "First name",
+      },
+      lastName: {
+        type: "string",
+        title: "Last name",
+      },
+    },
+  },
+  uiSchema: {
+    firstName: {
+      "ui:autofocus": true,
+      "ui:emptyValue": "",
+    },
+  },
+  formData: {
+    firstName: "Chuck",
+    lastName: "Norris",
+    assKickCount: "infinity",
+  },
+};

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -17,6 +17,7 @@ import customObject from "./customObject";
 import alternatives from "./alternatives";
 import propertyDependencies from "./propertyDependencies";
 import schemaDependencies from "./schemaDependencies";
+import additionalProperties from "./additionalProperties";
 
 export const samples = {
   Simple: simple,
@@ -38,4 +39,5 @@ export const samples = {
   Alternatives: alternatives,
   "Property dependencies": propertyDependencies,
   "Schema dependencies": schemaDependencies,
+  "Additional Properties": additionalProperties,
 };

--- a/src/components/AddButton.js
+++ b/src/components/AddButton.js
@@ -1,0 +1,19 @@
+import React from "react";
+import IconButton from "./IconButton";
+
+export default function AddButton({ className, onClick, disabled }) {
+  return (
+    <div className="row">
+      <p className={`col-xs-3 col-xs-offset-9 text-right ${className}`}>
+        <IconButton
+          type="info"
+          icon="plus"
+          className="btn-add col-xs-12"
+          tabIndex="0"
+          onClick={onClick}
+          disabled={disabled}
+        />
+      </p>
+    </div>
+  );
+}

--- a/src/components/IconButton.js
+++ b/src/components/IconButton.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function IconButton(props) {
+  const { type = "default", icon, className, ...otherProps } = props;
+  return (
+    <button
+      type="button"
+      className={`btn btn-${type} ${className}`}
+      {...otherProps}>
+      <i className={`glyphicon glyphicon-${icon}`} />
+    </button>
+  );
+}

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -1,3 +1,5 @@
+import AddButton from "../AddButton";
+import IconButton from "../IconButton";
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import includes from "core-js/library/fn/array/includes";
@@ -35,18 +37,6 @@ function ArrayFieldDescription({ DescriptionField, idSchema, description }) {
   return <DescriptionField id={id} description={description} />;
 }
 
-function IconBtn(props) {
-  const { type = "default", icon, className, ...otherProps } = props;
-  return (
-    <button
-      type="button"
-      className={`btn btn-${type} ${className}`}
-      {...otherProps}>
-      <i className={`glyphicon glyphicon-${icon}`} />
-    </button>
-  );
-}
-
 // Used in the two templates
 function DefaultArrayItem(props) {
   const btnStyle = {
@@ -70,7 +60,7 @@ function DefaultArrayItem(props) {
               justifyContent: "space-around",
             }}>
             {(props.hasMoveUp || props.hasMoveDown) && (
-              <IconBtn
+              <IconButton
                 icon="arrow-up"
                 className="array-item-move-up"
                 tabIndex="-1"
@@ -81,7 +71,7 @@ function DefaultArrayItem(props) {
             )}
 
             {(props.hasMoveUp || props.hasMoveDown) && (
-              <IconBtn
+              <IconButton
                 icon="arrow-down"
                 className="array-item-move-down"
                 tabIndex="-1"
@@ -94,7 +84,7 @@ function DefaultArrayItem(props) {
             )}
 
             {props.hasRemove && (
-              <IconBtn
+              <IconButton
                 type="danger"
                 icon="remove"
                 className="array-item-remove"
@@ -138,6 +128,7 @@ function DefaultFixedArrayFieldTemplate(props) {
 
       {props.canAdd && (
         <AddButton
+          className="array-item-add"
           onClick={props.onAddClick}
           disabled={props.disabled || props.readonly}
         />
@@ -176,6 +167,7 @@ function DefaultNormalArrayFieldTemplate(props) {
 
       {props.canAdd && (
         <AddButton
+          className="array-item-add"
           onClick={props.onAddClick}
           disabled={props.disabled || props.readonly}
         />
@@ -666,23 +658,6 @@ class ArrayField extends Component {
       readonly,
     };
   }
-}
-
-function AddButton({ onClick, disabled }) {
-  return (
-    <div className="row">
-      <p className="col-xs-3 col-xs-offset-9 array-item-add text-right">
-        <IconBtn
-          type="info"
-          icon="plus"
-          className="btn-add col-xs-12"
-          tabIndex="0"
-          onClick={onClick}
-          disabled={disabled}
-        />
-      </p>
-    </div>
-  );
 }
 
 if (process.env.NODE_ENV !== "production") {

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -1,3 +1,4 @@
+import AddButton from "../AddButton";
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
@@ -5,9 +6,28 @@ import {
   orderProperties,
   retrieveSchema,
   getDefaultRegistry,
+  getUiOptions,
 } from "../../utils";
 
 function DefaultObjectFieldTemplate(props) {
+  const canExpand = function canExpand() {
+    const { formData, schema, uiSchema } = props;
+    if (!schema.additionalProperties) {
+      return false;
+    }
+    let { expandable } = getUiOptions(uiSchema);
+    if (expandable !== false) {
+      // if ui:options.expandable was not explicitly set to false, we can add
+      // another property if we have not exceeded maxProperties yet
+      if (schema.maxProperties !== undefined) {
+        expandable = Object.keys(formData).length < schema.maxProperties;
+      } else {
+        expandable = true;
+      }
+    }
+    return expandable;
+  };
+
   const { TitleField, DescriptionField } = props;
   return (
     <fieldset>
@@ -27,6 +47,13 @@ function DefaultObjectFieldTemplate(props) {
         />
       )}
       {props.properties.map(prop => prop.content)}
+      {canExpand() && (
+        <AddButton
+          className="object-property-expand"
+          onClick={props.onAddClick(props.schema)}
+          disabled={props.disabled || props.readonly}
+        />
+      )}
     </fieldset>
   );
 }
@@ -41,6 +68,13 @@ class ObjectField extends Component {
     disabled: false,
     readonly: false,
   };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      additionalProperties: {},
+    };
+  }
 
   isRequired(name) {
     const schema = this.props.schema;
@@ -60,6 +94,64 @@ class ObjectField extends Component {
             [name]: errorSchema,
           }
       );
+    };
+  };
+
+  getAvailableKey = (preferredKey, formData) => {
+    var index = 0;
+    var newKey = preferredKey;
+    while (this.props.formData.hasOwnProperty(newKey)) {
+      newKey = `${preferredKey}-${++index}`;
+    }
+    return newKey;
+  };
+
+  onKeyChange = oldValue => {
+    return (value, errorSchema) => {
+      value = this.getAvailableKey(value, this.props.formData);
+      const newFormData = { ...this.props.formData };
+      const property = newFormData[oldValue];
+      delete newFormData[oldValue];
+      newFormData[value] = property;
+      this.props.onChange(
+        newFormData,
+        errorSchema &&
+          this.props.errorSchema && {
+            ...this.props.errorSchema,
+            [name]: errorSchema,
+          }
+      );
+    };
+  };
+
+  getDefaultValue(type) {
+    switch (type) {
+      case "string":
+        return "New Value";
+      case "array":
+        return [];
+      case "boolean":
+        return false;
+      case "null":
+        return null;
+      case "number":
+        return 0;
+      case "object":
+        return {};
+      default:
+        // We don't have a datatype for some reason (perhaps additionalProperties was true)
+        return "New Value";
+    }
+  }
+
+  handleAddClick = schema => {
+    return () => {
+      const type = schema.additionalProperties.type;
+      const newFormData = { ...this.props.formData };
+      newFormData[
+        this.getAvailableKey("newKey", newFormData)
+      ] = this.getDefaultValue(type);
+      this.props.onChange(newFormData);
     };
   };
 
@@ -120,6 +212,7 @@ class ObjectField extends Component {
               idSchema={idSchema[name]}
               idPrefix={idPrefix}
               formData={formData[name]}
+              onKeyChange={this.onKeyChange(name)}
               onChange={this.onPropertyChange(name)}
               onBlur={onBlur}
               onFocus={onFocus}
@@ -141,7 +234,12 @@ class ObjectField extends Component {
       formData,
       formContext,
     };
-    return <Template {...templateProps} />;
+    return (
+      <Template
+        {...templateProps}
+        onAddClick={this.handleAddClick.bind(this)}
+      />
+    );
   }
 }
 

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -15,15 +15,14 @@ function DefaultObjectFieldTemplate(props) {
     if (!schema.additionalProperties) {
       return false;
     }
-    let { expandable } = getUiOptions(uiSchema);
+    const { expandable } = getUiOptions(uiSchema);
     if (expandable !== false) {
       // if ui:options.expandable was not explicitly set to false, we can add
       // another property if we have not exceeded maxProperties yet
       if (schema.maxProperties !== undefined) {
-        expandable = Object.keys(formData).length < schema.maxProperties;
-      } else {
-        expandable = true;
+        return Object.keys(formData).length < schema.maxProperties;
       }
+      return true;
     }
     return expandable;
   };
@@ -69,12 +68,9 @@ class ObjectField extends Component {
     readonly: false,
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      additionalProperties: {},
-    };
-  }
+  state = {
+    additionalProperties: {},
+  };
 
   isRequired(name) {
     const schema = this.props.schema;
@@ -144,15 +140,13 @@ class ObjectField extends Component {
     }
   }
 
-  handleAddClick = schema => {
-    return () => {
-      const type = schema.additionalProperties.type;
-      const newFormData = { ...this.props.formData };
-      newFormData[
-        this.getAvailableKey("newKey", newFormData)
-      ] = this.getDefaultValue(type);
-      this.props.onChange(newFormData);
-    };
+  handleAddClick = schema => () => {
+    const type = schema.additionalProperties.type;
+    const newFormData = { ...this.props.formData };
+    newFormData[
+      this.getAvailableKey("newKey", newFormData)
+    ] = this.getDefaultValue(type);
+    this.props.onChange(newFormData);
   };
 
   render() {
@@ -234,12 +228,7 @@ class ObjectField extends Component {
       formData,
       formContext,
     };
-    return (
-      <Template
-        {...templateProps}
-        onAddClick={this.handleAddClick.bind(this)}
-      />
-    );
+    return <Template {...templateProps} onAddClick={this.handleAddClick} />;
   }
 }
 

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -16,15 +16,15 @@ function DefaultObjectFieldTemplate(props) {
       return false;
     }
     const { expandable } = getUiOptions(uiSchema);
-    if (expandable !== false) {
-      // if ui:options.expandable was not explicitly set to false, we can add
-      // another property if we have not exceeded maxProperties yet
-      if (schema.maxProperties !== undefined) {
-        return Object.keys(formData).length < schema.maxProperties;
-      }
-      return true;
+    if (expandable === false) {
+      return expandable;
     }
-    return expandable;
+    // if ui:options.expandable was not explicitly set to false, we can add
+    // another property if we have not exceeded maxProperties yet
+    if (schema.maxProperties !== undefined) {
+      return Object.keys(formData).length < schema.maxProperties;
+    }
+    return true;
   };
 
   const { TitleField, DescriptionField } = props;
@@ -114,7 +114,7 @@ class ObjectField extends Component {
         errorSchema &&
           this.props.errorSchema && {
             ...this.props.errorSchema,
-            [name]: errorSchema,
+            [value]: errorSchema,
           }
       );
     };

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -1,3 +1,4 @@
+import { ADDITIONAL_PROPERTY_FLAG } from "../../utils";
 import React from "react";
 import PropTypes from "prop-types";
 
@@ -61,6 +62,19 @@ function Label(props) {
   );
 }
 
+function LabelInput(props) {
+  const { id, label, onChange } = props;
+  return (
+    <input
+      className="form-control"
+      type="text"
+      id={id}
+      onBlur={event => onChange(event.target.value)}
+      defaultValue={label}
+    />
+  );
+}
+
 function Help(props) {
   const { help } = props;
   if (!help) {
@@ -106,13 +120,27 @@ function DefaultTemplate(props) {
     hidden,
     required,
     displayLabel,
+    onKeyChange,
   } = props;
   if (hidden) {
     return children;
   }
+  const additional = props.schema.hasOwnProperty(ADDITIONAL_PROPERTY_FLAG);
+  const keyLabel = `${label} Key`;
 
   return (
     <div className={classNames}>
+      {additional && (
+        <div className="form-group">
+          <Label label={keyLabel} required={required} id={`${id}-key`} />
+          <LabelInput
+            label={label}
+            required={required}
+            id={`${id}-key`}
+            onChange={onKeyChange}
+          />
+        </div>
+      )}
       {displayLabel && <Label label={label} required={required} id={id} />}
       {displayLabel && description ? description : null}
       {children}
@@ -157,6 +185,7 @@ function SchemaFieldRender(props) {
     errorSchema,
     idPrefix,
     name,
+    onKeyChange,
     required,
     registry = getDefaultRegistry(),
   } = props;
@@ -255,6 +284,7 @@ function SchemaFieldRender(props) {
     id,
     label,
     hidden,
+    onKeyChange,
     required,
     disabled,
     readonly,

--- a/src/utils.js
+++ b/src/utils.js
@@ -478,7 +478,7 @@ export function retrieveSchema(schema, definitions = {}, formData = {}) {
   const resolvedSchema = resolveSchema(schema, definitions, formData);
   const hasAdditionalProperties =
     resolvedSchema.hasOwnProperty("additionalProperties") &&
-    resolvedSchema.hasAdditionalProperties !== false;
+    resolvedSchema.additionalProperties !== false;
   if (hasAdditionalProperties) {
     return stubExistingAdditionalProperties(
       resolvedSchema,


### PR DESCRIPTION
### Reasons for making this change

This will add the ability for the form to understand "additionalProperties" definitions in the schema (see [json-schema properties documentation](https://json-schema.org/understanding-json-schema/reference/object.html#properties)).

Related issue: https://github.com/mozilla-services/react-jsonschema-form/issues/228

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [x] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature

### Details

Specifically, this will enable the following behaviors when additionalProperties is enabled:
* If the form data contains properties that are not explicitly defined, those fields will be automatically added to the form
* An "expand" button will be [optionally] added that allows the form user to manually add new properties.
* In any case in which an additional property has been added, a new text field will be rendered to allow the user to rename the key

Opportunities for improvement:
* Ability to remove additional properties
* Somewhat better test coverage (particularly around type detection)