### PR TITLE
call props.onChange on Form component mount to set any defaults in sc…

### DIFF
--- a/playground/samples/simple.js
+++ b/playground/samples/simple.js
@@ -8,6 +8,7 @@ module.exports = {
       firstName: {
         type: "string",
         title: "First name",
+        default: "Chuck",
       },
       lastName: {
         type: "string",
@@ -60,7 +61,6 @@ module.exports = {
     },
   },
   formData: {
-    firstName: "Chuck",
     lastName: "Norris",
     age: 75,
     bio: "Roundhouse kicking asses since 1940",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -9,6 +9,7 @@ import {
   toIdSchema,
   setState,
   getDefaultRegistry,
+  deepEquals,
 } from "../utils";
 import validateFormData, { toErrorList } from "../validate";
 
@@ -25,10 +26,10 @@ export default class Form extends Component {
   constructor(props) {
     super(props);
     this.state = this.getStateFromProps(props);
-  }
-
-  componentDidMount() {
-    if (this.props.onChange) {
+    if (
+      this.props.onChange &&
+      !deepEquals(this.state.formData, this.props.formData)
+    ) {
       this.props.onChange(this.state);
     }
   }

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -35,7 +35,14 @@ export default class Form extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState(this.getStateFromProps(nextProps));
+    const nextState = this.getStateFromProps(nextProps);
+    this.setState(nextState);
+    if (
+      !deepEquals(nextState.formData, nextProps.formData) &&
+      this.props.onChange
+    ) {
+      this.props.onChange(nextState);
+    }
   }
 
   getStateFromProps(props) {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -27,6 +27,12 @@ export default class Form extends Component {
     this.state = this.getStateFromProps(props);
   }
 
+  componentDidMount() {
+    if (this.props.onChange) {
+      this.props.onChange(this.state);
+    }
+  }
+
   componentWillReceiveProps(nextProps) {
     this.setState(this.getStateFromProps(nextProps));
   }

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -44,35 +44,60 @@ describe("Form", () => {
     });
   });
 
-  describe("componentDidMount", () => {
-    describe("when props.onchange is set", () => {
-      let comp;
-      let onChangeProp;
+  describe("on component creation", () => {
+    let comp;
+    let onChangeProp;
+    let formData;
+    let schema;
 
-      beforeEach(() => {
-        onChangeProp = sinon.spy();
-        const schema = {
-          type: "object",
-          title: "root object",
-          required: ["foo"],
-          properties: {
-            count: {
-              type: "number",
-              default: 789,
-            },
+    function createComponent() {
+      comp = renderIntoDocument(
+        <Form schema={schema} onChange={onChangeProp} formData={formData}>
+          <button type="submit">Submit</button>
+          <button type="submit">Another submit</button>
+        </Form>
+      );
+    }
+
+    beforeEach(() => {
+      onChangeProp = sinon.spy();
+      schema = {
+        type: "object",
+        title: "root object",
+        required: ["count"],
+        properties: {
+          count: {
+            type: "number",
+            default: 789,
           },
+        },
+      };
+    });
+
+    describe("when props.formData does not equal the default values", () => {
+      beforeEach(() => {
+        formData = {
+          foo: 123,
         };
-        comp = renderIntoDocument(
-          <Form schema={schema} onChange={onChangeProp}>
-            <button type="submit">Submit</button>
-            <button type="submit">Another submit</button>
-          </Form>
-        );
+        createComponent();
       });
 
       it("should call props.onChange with current state", () => {
         sinon.assert.calledOnce(onChangeProp);
         sinon.assert.calledWith(onChangeProp, comp.state);
+      });
+    });
+
+    describe("when props.formData equals the default values", () => {
+      beforeEach(() => {
+        formData = {
+          count: 789,
+        };
+        createComponent();
+      });
+
+      it("should not call props.onChange", () => {
+        sinon.assert.notCalled(onChangeProp);
       });
     });
   });

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -44,6 +44,39 @@ describe("Form", () => {
     });
   });
 
+  describe("componentDidMount", () => {
+    describe("when props.onchange is set", () => {
+      let comp;
+      let onChangeProp;
+
+      beforeEach(() => {
+        onChangeProp = sinon.spy();
+        const schema = {
+          type: "object",
+          title: "root object",
+          required: ["foo"],
+          properties: {
+            count: {
+              type: "number",
+              default: 789,
+            },
+          },
+        };
+        comp = renderIntoDocument(
+          <Form schema={schema} onChange={onChangeProp}>
+            <button type="submit">Submit</button>
+            <button type="submit">Another submit</button>
+          </Form>
+        );
+      });
+
+      it("should call props.onChange with current state", () => {
+        sinon.assert.calledOnce(onChangeProp);
+        sinon.assert.calledWith(onChangeProp, comp.state);
+      });
+    });
+  });
+
   describe("Option idPrefix", function() {
     it("should change the rendered ids", function() {
       const schema = {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -825,6 +825,88 @@ describe("Form", () => {
     });
   });
 
+  describe("Schema and external formData updates", () => {
+    let comp;
+    let onChangeProp;
+
+    beforeEach(() => {
+      onChangeProp = sinon.spy();
+      const formProps = {
+        schema: {
+          type: "string",
+          default: "foobar",
+        },
+        formData: "some value",
+        onChange: onChangeProp,
+      };
+      comp = createFormComponent(formProps).comp;
+    });
+
+    describe("when the form data is set to null", () => {
+      beforeEach(() => comp.componentWillReceiveProps({ formData: null }));
+
+      it("should call onChange", () => {
+        sinon.assert.calledOnce(onChangeProp);
+        sinon.assert.calledWith(onChangeProp, comp.state);
+        expect(comp.state.formData).eql("foobar");
+      });
+    });
+
+    describe("when the schema default is changed but formData is not changed", () => {
+      const newSchema = {
+        type: "string",
+        default: "the new default",
+      };
+
+      beforeEach(() =>
+        comp.componentWillReceiveProps({
+          schema: newSchema,
+          formData: "some value",
+        }));
+
+      it("should not call onChange", () => {
+        sinon.assert.notCalled(onChangeProp);
+        expect(comp.state.formData).eql("some value");
+        expect(comp.state.schema).deep.eql(newSchema);
+      });
+    });
+
+    describe("when the schema default is changed and formData is changed", () => {
+      const newSchema = {
+        type: "string",
+        default: "the new default",
+      };
+
+      beforeEach(() =>
+        comp.componentWillReceiveProps({
+          schema: newSchema,
+          formData: "something else",
+        }));
+
+      it("should not call onChange", () => {
+        sinon.assert.notCalled(onChangeProp);
+        expect(comp.state.formData).eql("something else");
+        expect(comp.state.schema).deep.eql(newSchema);
+      });
+    });
+
+    describe("when the schema default is changed and formData is nulled", () => {
+      const newSchema = {
+        type: "string",
+        default: "the new default",
+      };
+
+      beforeEach(() =>
+        comp.componentWillReceiveProps({ schema: newSchema, formData: null }));
+
+      it("should call onChange", () => {
+        sinon.assert.calledOnce(onChangeProp);
+        sinon.assert.calledWith(onChangeProp, comp.state);
+        expect(comp.state.formData).eql("the new default");
+      });
+    });
+  });
+
   describe("External formData updates", () => {
     describe("root level", () => {
       const formProps = {


### PR DESCRIPTION
### Reasons for making this change

This fixes #1033 where schema defaults aren't being set on any model that is being updated using the form `onChange` prop.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
