### PR TITLE
Validation errors when using refs in dependencies

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -478,6 +478,18 @@ function resolveReference(schema, definitions, formData) {
   );
 }
 
+export function resolveReferences(schema, definitions, formData) {
+  if (!Array.isArray(schema)) {
+    throw new Error(`invalid: it is some ${typeof schema} instead of an array`);
+  }
+  return schema.map(
+    subschema =>
+      subschema.hasOwnProperty("$ref")
+        ? resolveReference(subschema, definitions, formData)
+        : subschema
+  );
+}
+
 export function retrieveSchema(schema, definitions = {}, formData = {}) {
   const resolvedSchema = resolveSchema(schema, definitions, formData);
   const hasAdditionalProperties =
@@ -548,7 +560,7 @@ function withDependentSchema(
         definitions,
         formData,
         dependencyKey,
-        oneOf
+        resolveReferences(oneOf, definitions, formData)
       );
 }
 
@@ -559,11 +571,6 @@ function withExactlyOneSubschema(
   dependencyKey,
   oneOf
 ) {
-  if (!Array.isArray(oneOf)) {
-    throw new Error(
-      `invalid oneOf: it is some ${typeof oneOf} instead of an array`
-    );
-  }
   const validSubschemas = oneOf.filter(subschema => {
     if (!subschema.properties) {
       return false;

--- a/src/utils.js
+++ b/src/utils.js
@@ -455,16 +455,7 @@ export function stubExistingAdditionalProperties(
 
 export function resolveSchema(schema, definitions = {}, formData = {}) {
   if (schema.hasOwnProperty("$ref")) {
-    // Retrieve the referenced schema definition.
-    const $refSchema = findSchemaDefinition(schema.$ref, definitions);
-    // Drop the $ref property of the source schema.
-    const { $ref, ...localSchema } = schema;
-    // Update referenced schema definition with local schema properties.
-    return retrieveSchema(
-      { ...$refSchema, ...localSchema },
-      definitions,
-      formData
-    );
+    return resolveReference(schema, definitions, formData);
   } else if (schema.hasOwnProperty("dependencies")) {
     const resolvedSchema = resolveDependencies(schema, definitions, formData);
     return retrieveSchema(resolvedSchema, definitions, formData);
@@ -472,6 +463,19 @@ export function resolveSchema(schema, definitions = {}, formData = {}) {
     // No $ref or dependencies attribute found, returning the original schema.
     return schema;
   }
+}
+
+function resolveReference(schema, definitions, formData) {
+  // Retrieve the referenced schema definition.
+  const $refSchema = findSchemaDefinition(schema.$ref, definitions);
+  // Drop the $ref property of the source schema.
+  const { $ref, ...localSchema } = schema;
+  // Update referenced schema definition with local schema properties.
+  return retrieveSchema(
+    { ...$refSchema, ...localSchema },
+    definitions,
+    formData
+  );
 }
 
 export function retrieveSchema(schema, definitions = {}, formData = {}) {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -12,7 +12,6 @@ import {
   mergeObjects,
   pad,
   parseDateString,
-  resolveReferences,
   retrieveSchema,
   shouldRender,
   toDateString,
@@ -692,10 +691,12 @@ describe("utils", () => {
 
         describe("with $ref in oneOf", () => {
           it("should retrieve referenced schemas", () => {
-            const schema = [
-              { $ref: "#/definitions/needsA" },
-              { $ref: "#/definitions/needsB" },
-            ];
+            const schema = {
+              oneOf: [
+                { $ref: "#/definitions/needsA" },
+                { $ref: "#/definitions/needsB" },
+              ],
+            };
             const definitions = {
               needsA: {
                 properties: {
@@ -709,10 +710,9 @@ describe("utils", () => {
               },
             };
             const formData = { a: "1" };
-            expect(resolveReferences(schema, definitions, formData)).eql([
-              definitions.needsA,
-              definitions.needsB,
-            ]);
+            expect(retrieveSchema(schema, definitions, formData)).eql({
+              oneOf: [definitions.needsA, definitions.needsB],
+            });
           });
         });
       });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -692,26 +692,40 @@ describe("utils", () => {
         describe("with $ref in oneOf", () => {
           it("should retrieve referenced schemas", () => {
             const schema = {
-              oneOf: [
-                { $ref: "#/definitions/needsA" },
-                { $ref: "#/definitions/needsB" },
-              ],
+              type: "object",
+              properties: {
+                a: { enum: ["typeA", "typeB"] },
+              },
+              dependencies: {
+                a: {
+                  oneOf: [
+                    { $ref: "#/definitions/needsA" },
+                    { $ref: "#/definitions/needsB" },
+                  ],
+                },
+              },
             };
             const definitions = {
               needsA: {
                 properties: {
-                  a: { type: "string" },
+                  a: { enum: ["typeA"] },
+                  b: { type: "number" },
                 },
               },
               needsB: {
                 properties: {
-                  b: { type: "integer" },
+                  a: { enum: ["typeB"] },
+                  c: { type: "boolean" },
                 },
               },
             };
-            const formData = { a: "1" };
+            const formData = { a: "typeB" };
             expect(retrieveSchema(schema, definitions, formData)).eql({
-              oneOf: [definitions.needsA, definitions.needsB],
+              type: "object",
+              properties: {
+                a: { enum: ["typeA", "typeB"] },
+                c: { type: "boolean" },
+              },
             });
           });
         });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -12,6 +12,7 @@ import {
   mergeObjects,
   pad,
   parseDateString,
+  resolveReferences,
   retrieveSchema,
   shouldRender,
   toDateString,
@@ -686,6 +687,32 @@ describe("utils", () => {
                 b: { type: "integer" },
               },
             });
+          });
+        });
+
+        describe("with $ref in oneOf", () => {
+          it("should retrieve referenced schemas", () => {
+            const schema = [
+              { $ref: "#/definitions/needsA" },
+              { $ref: "#/definitions/needsB" },
+            ];
+            const definitions = {
+              needsA: {
+                properties: {
+                  a: { type: "string" },
+                },
+              },
+              needsB: {
+                properties: {
+                  b: { type: "integer" },
+                },
+              },
+            };
+            const formData = { a: "1" };
+            expect(resolveReferences(schema, definitions, formData)).eql([
+              definitions.needsA,
+              definitions.needsB,
+            ]);
           });
         });
       });


### PR DESCRIPTION
### Reasons for making this change

I understand that there is no fully support for `oneOf`, nevertheless, on the README it says that except for a special case where we can use oneOf in schema dependencies.
I search on the issues and couldn't find something related. My issue is when inside the oneOf I have $refs. Looks like it doesn't match any of the options. I attached a shared playground link showing it.

### Steps to Reproduce

1. Open the [shared playground example](https://mozilla-services.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6eyJwZXJzb24iOnsiRG8geW91IGhhdmUgYW55IHBldHM/IjoiTm8ifX0sInNjaGVtYSI6eyJ0aXRsZSI6IlNjaGVtYSBkZXBlbmRlbmNpZXMiLCJ0eXBlIjoib2JqZWN0IiwiZGVmaW5pdGlvbnMiOnsib3B0aW9uMSI6eyJwcm9wZXJ0aWVzIjp7IkRvIHlvdSBoYXZlIGFueSBwZXRzPyI6eyJlbnVtIjpbIk5vIl19fX0sIm9wdGlvbjIiOnsicHJvcGVydGllcyI6eyJEbyB5b3UgaGF2ZSBhbnkgcGV0cz8iOnsiZW51bSI6WyJZZXM6IE9uZSJdfSwiSG93IG9sZCBpcyB5b3VyIHBldD8iOnsidHlwZSI6Im51bWJlciJ9fSwicmVxdWlyZWQiOlsiSG93IG9sZCBpcyB5b3VyIHBldD8iXX0sIm9wdGlvbjMiOnsicHJvcGVydGllcyI6eyJEbyB5b3UgaGF2ZSBhbnkgcGV0cz8iOnsiZW51bSI6WyJZZXM6IE1vcmUgdGhhbiBvbmUiXX0sIkRvIHlvdSB3YW50IHRvIGdldCByaWQgb2YgYW55PyI6eyJ0eXBlIjoiYm9vbGVhbiJ9fSwicmVxdWlyZWQiOlsiRG8geW91IHdhbnQgdG8gZ2V0IHJpZCBvZiBhbnk/Il19fSwicHJvcGVydGllcyI6eyJwZXJzb24iOnsidGl0bGUiOiJQZXJzb24iLCJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJEbyB5b3UgaGF2ZSBhbnkgcGV0cz8iOnsidHlwZSI6InN0cmluZyIsImVudW0iOlsiTm8iLCJZZXM6IE9uZSIsIlllczogTW9yZSB0aGFuIG9uZSJdLCJkZWZhdWx0IjoiTm8ifX0sInJlcXVpcmVkIjpbIkRvIHlvdSBoYXZlIGFueSBwZXRzPyJdLCJkZXBlbmRlbmNpZXMiOnsiRG8geW91IGhhdmUgYW55IHBldHM/Ijp7Im9uZU9mIjpbeyIkcmVmIjoiIy9kZWZpbml0aW9ucy9vcHRpb24xIn0seyIkcmVmIjoiIy9kZWZpbml0aW9ucy9vcHRpb24yIn0seyIkcmVmIjoiIy9kZWZpbml0aW9ucy9vcHRpb24zIn1dfX19fX0sInVpU2NoZW1hIjp7fX0=)
2. Select any option on the **Do you have any pets?** question.

#### Expected behavior

For this example I took the working example and just moved the options to the definitions and add the refs. So I would expect to work as usual and is not.

#### Actual behavior

When moving the possible options to the definitions section. It does not match any of them showing the errors:
- should be equal to one of the allowed values
- should match exactly one schema in oneOf

### Version
Playground

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
