### PR TITLE
Added hideNowButton and hideClearButton options to alt-date widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Please note that, even though they are standardized, `datetime-local` and `date`
 
 ![](http://i.imgur.com/VF5tY60.png)
 
-You can customize the list of years displayed in the `year` dropdown by providing a ``yearsRange`` property to ``ui:options`` in your uiSchema:
+You can customize the list of years displayed in the `year` dropdown by providing a ``yearsRange`` property to ``ui:options`` in your uiSchema. Its also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
 
 ```jsx
 uiSchema: {
@@ -361,6 +361,8 @@ uiSchema: {
       "ui:widget": "alt-datetime",
       "ui:options": {
         yearsRange: [1980, 2030],
+        hideNowButton: true,
+        hideClearButton: true,
       },
     },
   },

--- a/src/components/widgets/AltDateWidget.js
+++ b/src/components/widgets/AltDateWidget.js
@@ -125,7 +125,15 @@ class AltDateWidget extends Component {
   }
 
   render() {
-    const { id, disabled, readonly, autofocus, registry, onBlur } = this.props;
+    const {
+      id,
+      disabled,
+      readonly,
+      autofocus,
+      registry,
+      onBlur,
+      options,
+    } = this.props;
     return (
       <ul className="list-inline">
         {this.dateElementProps.map((elemProps, i) => (
@@ -142,19 +150,27 @@ class AltDateWidget extends Component {
             />
           </li>
         ))}
-        <li>
-          <a href="#" className="btn btn-info btn-now" onClick={this.setNow}>
-            Now
-          </a>
-        </li>
-        <li>
-          <a
-            href="#"
-            className="btn btn-warning btn-clear"
-            onClick={this.clear}>
-            Clear
-          </a>
-        </li>
+        {(options.hideNowButton !== "undefined"
+          ? !options.hideNowButton
+          : true) && (
+          <li>
+            <a href="#" className="btn btn-info btn-now" onClick={this.setNow}>
+              Now
+            </a>
+          </li>
+        )}
+        {(options.hideClearButton !== "undefined"
+          ? !options.hideClearButton
+          : true) && (
+          <li>
+            <a
+              href="#"
+              className="btn btn-warning btn-clear"
+              onClick={this.clear}>
+              Clear
+            </a>
+          </li>
+        )}
       </ul>
     );
   }


### PR DESCRIPTION
### Reasons for making this change

I used the alt-date widget in a form for the user to add his/her birthdate and then the "now" button is a little out of place. So I added an option to hide it. And when i already was on it I added an option to hide the clear button as well.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
