### PR TITLE
Issue-881 : Added support for onFocus and onBlur for BooleanField

### DIFF
--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -60,6 +60,8 @@ if (process.env.NODE_ENV !== "production") {
     uiSchema: PropTypes.object,
     idSchema: PropTypes.object,
     onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func,
+    onBlur: PropTypes.func,
     formData: PropTypes.bool,
     required: PropTypes.bool,
     disabled: PropTypes.bool,

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -21,6 +21,8 @@ function BooleanField(props) {
     readonly,
     autofocus,
     onChange,
+    onFocus,
+    onBlur,
     rawErrors,
   } = props;
   const { title } = schema;
@@ -37,6 +39,8 @@ function BooleanField(props) {
       schema={schema}
       id={idSchema && idSchema.$id}
       onChange={onChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
       label={title === undefined ? name : title}
       value={formData}
       required={required}
@@ -56,6 +60,8 @@ if (process.env.NODE_ENV !== "production") {
     uiSchema: PropTypes.object,
     idSchema: PropTypes.object,
     onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func.isRequired,
+    onBlur: PropTypes.func.isRequired,
     formData: PropTypes.bool,
     required: PropTypes.bool,
     disabled: PropTypes.bool,

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -60,8 +60,6 @@ if (process.env.NODE_ENV !== "production") {
     uiSchema: PropTypes.object,
     idSchema: PropTypes.object,
     onChange: PropTypes.func.isRequired,
-    onFocus: PropTypes.func.isRequired,
-    onBlur: PropTypes.func.isRequired,
     formData: PropTypes.bool,
     required: PropTypes.bool,
     disabled: PropTypes.bool,


### PR DESCRIPTION
### Reasons for making this change

onFocus and onBlur callbacks are not currently supported for Checkboxes i.e BooleanFields. Added the code for passing on these callbacks as part of the props variable.

https://github.com/mozilla-services/react-jsonschema-form/issues/881

### Checklist

* [ ] **I'm updating documentation** (Not Needed, since onFocus is mentioned as already supported in the docs)
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
