### PR TITLE
Fix for new submit() method (PR #1058) also submitting the HTML form

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -189,7 +189,7 @@ export default class Form extends Component {
 
   submit() {
     if (this.formElement) {
-      this.formElement.dispatchEvent(new Event("submit"));
+      this.formElement.dispatchEvent(new Event("submit", { cancelable: true }));
     }
   }
 


### PR DESCRIPTION
Mew submit() method from PR #1058 also submitting the HTML form, which leads to navigating away from current page, at least in Firefox.

Reason: dispatched event was not cancelable, so preventDefault in onSubmit
couldn't cancel it.

Further information:

* <https://stackoverflow.com/a/40916998>
* <https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelable>

### Checklist

* [ ] **I'm updating documentation** 
* [x] **I'm adding or updating code**
  - ~[ ] I've added and/or updated tests~ (just fixing PR #1058 which didnt add new test)
  - ~[ ] I've updated docs if needed~ n/a
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**

