### PR TITLE
react-dom is external peerDependency, just like react.

### DIFF
--- a/webpack.config.dist.js
+++ b/webpack.config.dist.js
@@ -26,6 +26,13 @@ module.exports = {
       commonjs: "react",
       commonjs2: "react",
       amd: "react"
+    },
+    'react-dom': {
+      root: "ReactDOM",
+      commonjs2: 'react-dom',
+      commonjs: 'react-dom',
+      amd: 'react-dom',
+      umd: 'react-dom',
     }
   },
   module: {


### PR DESCRIPTION
fixes version conflicts, e.g. I got an error

  Uncaught TypeError: this.updater.enqueueCallback is not a function when using setState callback

because I use React 16.x and react-jsonschema-form bundled react-dom 15.x

See https://github.com/facebook/react/issues/10320#issuecomment-318754280

* [ ] **I'm updating documentation**
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
