### PR TITLE
Synchronous call to onSubmit() from props

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -165,7 +165,7 @@ export default class Form extends Component {
       }
     }
 
-    setState(this, { errors: [], errorSchema: {} }, () => {
+    this.setState({ errors: [], errorSchema: {} }, () => {
       if (this.props.onSubmit) {
         this.props.onSubmit({ ...this.state, status: "submitted" });
       }


### PR DESCRIPTION
### Reasons for making this change

Due to the use of `setImmediate()` hack in `setState` utility function from `utils.js`,
the `onSubmit()` handler from props is called asynchronously.

This leads to problems for submit handlers requiring browser "trusted events", like `window.open()` or
when programmatically submitting forms with target `_blank`.

Because `onSubmit()` should not need the performance-related `setImmiate()` hack, I
replaced call to `setState` utility function with proper `this.setState()` from
React, which fixed the problem.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests: couldnt figure out how to properly test this.
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
