### PR TITLE
Fix infinite loop when setting formData to falsey value in onChange handler

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -38,13 +38,14 @@ export default class Form extends Component {
 
   componentWillReceiveProps(nextProps) {
     const nextState = this.getStateFromProps(nextProps);
-    this.setState(nextState);
     if (
       !deepEquals(nextState.formData, nextProps.formData) &&
+      !deepEquals(nextState.formData, this.state.formData) &&
       this.props.onChange
     ) {
       this.props.onChange(nextState);
     }
+    this.setState(nextState);
   }
 
   getStateFromProps(props) {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -5,7 +5,11 @@ import { renderIntoDocument, Simulate } from "react-addons-test-utils";
 import { findDOMNode } from "react-dom";
 
 import Form from "../src";
-import { createFormComponent, createSandbox } from "./test_utils";
+import {
+  createComponent,
+  createFormComponent,
+  createSandbox,
+} from "./test_utils";
 
 describe("Form", () => {
   let sandbox;
@@ -906,6 +910,54 @@ describe("Form", () => {
         sinon.assert.calledOnce(onChangeProp);
         sinon.assert.calledWith(onChangeProp, comp.state);
         expect(comp.state.formData).eql("the new default");
+      });
+    });
+
+    describe("when the onChange prop sets formData to a falsey value", () => {
+      class TestForm extends React.Component {
+        constructor() {
+          super();
+
+          this.state = {
+            formData: {},
+          };
+        }
+
+        onChange = () => {
+          this.setState({ formData: this.props.falseyValue });
+        };
+
+        render() {
+          const schema = {
+            type: "object",
+            properties: {
+              value: {
+                type: "string",
+              },
+            },
+          };
+          return (
+            <Form
+              onChange={this.onChange}
+              schema={schema}
+              formData={this.state.formData}
+            />
+          );
+        }
+      }
+
+      const falseyValues = [0, false, null, undefined, NaN];
+
+      falseyValues.forEach(falseyValue => {
+        it("Should not crash due to 'Maximum call stack size exceeded...'", () => {
+          // It is expected that this will throw an error due to non-matching propTypes,
+          // so the error message needs to be inspected
+          try {
+            createComponent(TestForm, { falseyValue });
+          } catch (e) {
+            expect(e.message).to.not.equal("Maximum call stack size exceeded");
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
Fixes #1086

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

### Reasons for making this change

This fixes a bug where the `<Form>` component would go into an infinite loop if the `onChange` handler set `formData` to a falsey value. See #1086 for more details.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
