### PR TITLE
Key-value pair in additional properties retains order when edited

### DIFF
--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -106,11 +106,14 @@ class ObjectField extends Component {
     return (value, errorSchema) => {
       value = this.getAvailableKey(value, this.props.formData);
       const newFormData = { ...this.props.formData };
-      const property = newFormData[oldValue];
-      delete newFormData[oldValue];
-      newFormData[value] = property;
+      const newKeys = { [oldValue]: value };
+      const keyValues = Object.keys(newFormData).map(key => {
+        const newKey = newKeys[key] || key;
+        return { [newKey]: newFormData[key] };
+      });
+      const renamedObj = Object.assign({}, ...keyValues);
       this.props.onChange(
-        newFormData,
+        renamedObj,
         errorSchema &&
           this.props.errorSchema && {
             ...this.props.errorSchema,

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -96,7 +96,7 @@ class ObjectField extends Component {
   getAvailableKey = (preferredKey, formData) => {
     var index = 0;
     var newKey = preferredKey;
-    while (this.props.formData.hasOwnProperty(newKey)) {
+    while (formData.hasOwnProperty(newKey)) {
       newKey = `${preferredKey}-${++index}`;
     }
     return newKey;
@@ -104,6 +104,9 @@ class ObjectField extends Component {
 
   onKeyChange = oldValue => {
     return (value, errorSchema) => {
+      if (oldValue === value) {
+        return;
+      }
       value = this.getAvailableKey(value, this.props.formData);
       const newFormData = { ...this.props.formData };
       const newKeys = { [oldValue]: value };

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -132,7 +132,7 @@ function DefaultTemplate(props) {
     <div className={classNames}>
       {additional && (
         <div className="form-group">
-          <Label label={keyLabel} required={required} />
+          <Label label={keyLabel} required={required} id={`${id}-key`} />
           <LabelInput
             label={label}
             required={required}

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -132,7 +132,7 @@ function DefaultTemplate(props) {
     <div className={classNames}>
       {additional && (
         <div className="form-group">
-          <Label label={keyLabel} required={required} id={`${id}-key`} />
+          <Label label={keyLabel} required={required} />
           <LabelInput
             label={label}
             required={required}

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -520,6 +520,24 @@ describe("ObjectField", () => {
       expect(comp.state.formData.newFirst).eql(1);
     });
 
+    it("should keep order of renamed key-value pairs while renaming key", () => {
+      const { comp, node } = createFormComponent({
+        schema,
+        formData: { first: 1, second: 2, third: 3 },
+      });
+
+      const textNode = node.querySelector("#root_second-key");
+      Simulate.blur(textNode, {
+        target: { value: "newSecond" },
+      });
+
+      expect(Object.keys(comp.state.formData)).eql([
+        "first",
+        "newSecond",
+        "third",
+      ]);
+    });
+
     it("should attach suffix to formData key if new key already exists when key input is renamed", () => {
       const formData = {
         first: 1,
@@ -536,6 +554,21 @@ describe("ObjectField", () => {
       });
 
       expect(comp.state.formData["second-1"]).eql(1);
+    });
+
+    it("should not attach suffix when input is only clicked", () => {
+      const formData = {
+        first: 1,
+      };
+      const { comp, node } = createFormComponent({
+        schema,
+        formData,
+      });
+
+      const textNode = node.querySelector("#root_first-key");
+      Simulate.blur(textNode);
+
+      expect(comp.state.formData.hasOwnProperty("first")).to.be.true;
     });
 
     it("should continue incrementing suffix to formData key until that key name is unique after a key input collision", () => {


### PR DESCRIPTION
### Reasons for making this change

When you change key it shows on the bottom of the list, instead of keeping its place, keeping the order of key-value pairs.

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

Solves two things of #1099