### PR TITLE
Docs updated: Firefox date, time support

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,8 @@ Please note that, even though they are standardized, `datetime-local` and `date`
 - `alt-datetime`: Six `select` elements are used to select the year, the month, the day, the hour, the minute and the second;
 - `alt-date`: Three `select` elements are used to select the year, month and the day.
 
+> **Firefox 57 - 66**: Firefox partially supporting `date` and `time` input types, but not `datetime-local`, `month` or `week`
+
 ![](http://i.imgur.com/VF5tY60.png)
 
 You can customize the list of years displayed in the `year` dropdown by providing a ``yearsRange`` property to ``ui:options`` in your uiSchema. Its also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.


### PR DESCRIPTION
Firefox date, time input types partial support starting from Firefox 57

### Reasons for making this change

Starting from Firefox 57, they started supporting date, time input types and the feature remains as partial support

### Checklist

* [*] **I'm updating documentation**
  - [* ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
