### PR TITLE
Fix failing unit tests related to time widget

### DIFF
--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -773,7 +773,8 @@ describe("StringField", () => {
       );
 
       expect(lengths).eql([
-        121 + 1, // from 1900 to 2020 + undefined
+        // from 1900 to current year + 2 (inclusive) + 1 undefined option
+        new Date().getFullYear() - 1900 + 3 + 1,
         12 + 1,
         31 + 1,
         24 + 1,
@@ -1019,7 +1020,8 @@ describe("StringField", () => {
       );
 
       expect(lengths).eql([
-        121 + 1, // from 1900 to 2020 + undefined
+        // from 1900 to current year + 2 (inclusive) + 1 undefined option
+        new Date().getFullYear() - 1900 + 3 + 1,
         12 + 1,
         31 + 1,
       ]);


### PR DESCRIPTION
### Reasons for making this change

It appears that due to the recent change from 2018 to 2019, there is one additional year in the select list, which caused the unit tests to fail.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
