### PR TITLE
Handle sort arrays better

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -277,17 +277,16 @@ class ArrayField extends Component {
         }
       }
       onChange(
-        formData.map((item, i) => {
-          // i is string, index and newIndex are numbers,
-          // so using "==" to compare
-          if (i == newIndex) {
-            return formData[index];
-          } else if (i == index) {
-            return formData[newIndex];
-          } else {
-            return item;
-          }
-        }),
+        function() {
+          // Copy item
+           let newFormData = formData.slice();
+ 
+           // Moves item from index to newIndex
+           newFormData.splice(index, 1);
+           newFormData.splice(newIndex, 0, formData[index]);
+ 
+           return newFormData
+         }(),
         newErrorSchema
       );
     };

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -277,16 +277,16 @@ class ArrayField extends Component {
         }
       }
       onChange(
-        function() {
+        (function() {
           // Copy item
-           let newFormData = formData.slice();
- 
-           // Moves item from index to newIndex
-           newFormData.splice(index, 1);
-           newFormData.splice(newIndex, 0, formData[index]);
- 
-           return newFormData
-         }(),
+          let newFormData = formData.slice();
+
+          // Moves item from index to newIndex
+          newFormData.splice(index, 1);
+          newFormData.splice(newIndex, 0, formData[index]);
+
+          return newFormData;
+        })(),
         newErrorSchema
       );
     };

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -276,19 +276,19 @@ class ArrayField extends Component {
           }
         }
       }
-      onChange(
-        (function() {
-          // Copy item
-          let newFormData = formData.slice();
 
-          // Moves item from index to newIndex
-          newFormData.splice(index, 1);
-          newFormData.splice(newIndex, 0, formData[index]);
+      function reOrderArray() {
+        // Copy item
+        let newFormData = formData.slice();
 
-          return newFormData;
-        })(),
-        newErrorSchema
-      );
+        // Moves item from index to newIndex
+        newFormData.splice(index, 1);
+        newFormData.splice(newIndex, 0, formData[index]);
+
+        return newFormData;
+      }
+
+      onChange(reOrderArray(), newErrorSchema);
     };
   };
 

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -269,6 +269,50 @@ describe("ArrayField", () => {
       expect(inputs[2].value).eql("bar");
     });
 
+    it("should move from first to last in the list", () => {
+      function moveAnywhereArrayItemTemplate(props) {
+        const buttons = [];
+        for (let i = 0; i < 3; i++) {
+          buttons.push(
+            <button
+              key={i}
+              className={"array-item-move-to-" + i}
+              onClick={props.onReorderClick(props.index, i)}>
+              {"Move item to index " + i}
+            </button>
+          );
+        }
+        return (
+          <div key={props.index} className={"item-" + props.index}>
+            {props.children}
+            {buttons}
+          </div>
+        );
+      }
+
+      function moveAnywhereArrayFieldTemplate(props) {
+        return (
+          <div className="array">
+            {props.items.map(moveAnywhereArrayItemTemplate)}
+          </div>
+        );
+      }
+
+      const { node } = createFormComponent({
+        schema,
+        formData: ["foo", "bar", "baz"],
+        ArrayFieldTemplate: moveAnywhereArrayFieldTemplate,
+      });
+
+      const button = node.querySelector(".item-0 .array-item-move-to-2");
+      Simulate.click(button);
+
+      const inputs = node.querySelectorAll(".field-string input[type=text]");
+      expect(inputs[0].value).eql("bar");
+      expect(inputs[1].value).eql("baz");
+      expect(inputs[2].value).eql("foo");
+    });
+
     it("should disable move buttons on the ends of the list", () => {
       const { node } = createFormComponent({
         schema,


### PR DESCRIPTION
### Reasons for making this change

The current sortfunctions for arrayFields will only work if you shuffle an item 1 step up or down. If you create your own ArrayFieldTemplate with drag and drop, users can move items in larger steps, and this library will at this time not handle this. 

This pull simply sorts the moved array item from its old index to its new index.


### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
