### PR TITLE
Add test and update documentation for using anyOf inside array items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1846,6 +1846,7 @@ This component follows [JSON Schema](http://json-schema.org/documentation.html) 
     This keyword works when `items` is an array. `additionalItems: true` is not supported because there's no widget to represent an item of any type. In this case it will be treated as no additional items allowed. `additionalItems` being a valid schema is supported.
 
 * `anyOf`, `allOf`, and `oneOf`, or multiple `types` (i.e. `"type": ["string", "array"]`)
+
     The `anyOf` and `oneOf` keywords are supported,  however, properties declared inside the `anyOf/oneOf` should not overlap with properties "outside" of the `anyOf/oneOf`.
 
     You can also use `oneOf` with [schema dependencies](#schema-dependencies) to dynamically add schema properties based on input data.

--- a/README.md
+++ b/README.md
@@ -1845,9 +1845,8 @@ This component follows [JSON Schema](http://json-schema.org/documentation.html) 
 
     This keyword works when `items` is an array. `additionalItems: true` is not supported because there's no widget to represent an item of any type. In this case it will be treated as no additional items allowed. `additionalItems` being a valid schema is supported.
 
-* `anyOf`, `allOf`, and `oneOf`, or multiple `types` (i.e. `"type": ["string", "array"]`
-
-    The `anyOf`  and `oneOf` keywords are supported,  however, properties declared inside the `anyOf/oneOf` should not overlap with properties "outside" of the `anyOf/oneOf`.
+* `anyOf`, `allOf`, and `oneOf`, or multiple `types` (i.e. `"type": ["string", "array"]`)
+    The `anyOf` and `oneOf` keywords are supported,  however, properties declared inside the `anyOf/oneOf` should not overlap with properties "outside" of the `anyOf/oneOf`.
 
     You can also use `oneOf` with [schema dependencies](#schema-dependencies) to dynamically add schema properties based on input data.
 
@@ -1922,6 +1921,7 @@ $ git push --tags origin master
 ### Q: Does rjsf support `oneOf`, `anyOf`, multiple types in an array, etc.?
 
 A: The `anyOf`  and `oneOf` keywords are supported,  however, properties declared inside the `anyOf/oneOf` should not overlap with properties "outside" of the `anyOf/oneOf`.
+
 There is also special cased where you can use `oneOf` in [schema dependencies](#schema-dependencies), If you'd like to help improve support for these keywords, see the following issues for inspiration [#329](https://github.com/mozilla-services/react-jsonschema-form/pull/329) or [#417](https://github.com/mozilla-services/react-jsonschema-form/pull/417). See also: [#52](https://github.com/mozilla-services/react-jsonschema-form/issues/52), [#151](https://github.com/mozilla-services/react-jsonschema-form/issues/151), [#171](https://github.com/mozilla-services/react-jsonschema-form/issues/171), [#200](https://github.com/mozilla-services/react-jsonschema-form/issues/200), [#282](https://github.com/mozilla-services/react-jsonschema-form/issues/282), [#302](https://github.com/mozilla-services/react-jsonschema-form/pull/302), [#330](https://github.com/mozilla-services/react-jsonschema-form/issues/330), [#430](https://github.com/mozilla-services/react-jsonschema-form/issues/430), [#522](https://github.com/mozilla-services/react-jsonschema-form/issues/522), [#538](https://github.com/mozilla-services/react-jsonschema-form/issues/538), [#551](https://github.com/mozilla-services/react-jsonschema-form/issues/551), [#552](https://github.com/mozilla-services/react-jsonschema-form/issues/552), or [#648](https://github.com/mozilla-services/react-jsonschema-form/issues/648).
 
 ### Q: Will react-jsonschema-form support Material, Ant-Design, Foundation, or [some other specific widget library or frontend style]?

--- a/docs/index.md
+++ b/docs/index.md
@@ -1743,7 +1743,7 @@ This component follows [JSON Schema](http://json-schema.org/documentation.html) 
 
     This keyword works when `items` is an array. `additionalItems: true` is not supported because there's no widget to represent an item of any type. In this case it will be treated as no additional items allowed. `additionalItems` being a valid schema is supported.
 
-* `anyOf`, `allOf`, and `oneOf`, or multiple `types` (i.e. `"type": ["string", "array"]`
+* `anyOf`, `allOf`, and `oneOf`, or multiple `types` (i.e. `"type": ["string", "array"]`)
 
     The `anyOf`  and `oneOf` keywords are supported,  however, properties declared inside the `anyOf/oneOf` should not overlap with properties "outside" of the `anyOf/oneOf`.
 

--- a/playground/samples/anyOf.js
+++ b/playground/samples/anyOf.js
@@ -6,6 +6,28 @@ module.exports = {
         type: "integer",
         title: "Age",
       },
+      items: {
+        type: "array",
+        items: {
+          type: "object",
+          anyOf: [
+            {
+              properties: {
+                foo: {
+                  type: "string",
+                },
+              },
+            },
+            {
+              properties: {
+                bar: {
+                  type: "string",
+                },
+              },
+            },
+          ],
+        },
+      },
     },
     anyOf: [
       {

--- a/test/anyOf_test.js
+++ b/test/anyOf_test.js
@@ -299,4 +299,48 @@ describe("anyOf", () => {
 
     expect(node.querySelector("select").value).eql("1");
   });
+
+  describe("Arrays", () => {
+    it("should correctly render form inputs for anyOf inside array items", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "object",
+              anyOf: [
+                {
+                  properties: {
+                    foo: {
+                      type: "string",
+                    },
+                  },
+                },
+                {
+                  properties: {
+                    bar: {
+                      type: "string",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+      });
+
+      expect(node.querySelector(".array-item-add button")).not.eql(null);
+
+      Simulate.click(node.querySelector(".array-item-add button"));
+
+      expect(node.querySelectorAll("select")).to.have.length.of(1);
+
+      expect(node.querySelectorAll("input#root_foo")).to.have.length.of(1);
+    });
+  });
 });


### PR DESCRIPTION
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

I'd previously made the incorrect assumption that #1118 would not automatically work with array items - upon investigation I found that it just works™.
This PR just adds a basic test case for array support, updates the documentation and adds to the examples.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
