### PR TITLE
Fix custom boolean option labels using oneOf schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,49 @@ This will be rendered as follows:
 </select>
 ```
 
+This also works for radio buttons:
+
+```js
+const schema = {
+  "type": "boolean",
+  "oneOf": [
+    {
+      "const": true,
+      "title": "Yes"
+    },
+    {
+      "const": false,
+      "title": "No"
+    }
+  ]
+};
+
+const uiSchema = {
+  "ui:widget": "radio"
+};
+```
+
+This will be rendered as follows:
+
+```html
+<div class="field-radio-group">
+  <div class="radio">
+    <label>
+      <span>
+        <input type="radio" name="0.005549338200675935" value="true"><span>Enable</span>
+      </span>
+    </label>
+  </div>
+  <div class="radio">
+    <label>
+      <span>
+        <input type="radio" name="0.005549338200675935" value="false"><span>Disable</span>
+      </span>
+    </label>
+  </div>
+</div>
+```
+
 A live example of both approaches side-by-side can be found in the **Alternatives** tab of the [playground](https://mozilla-services.github.io/react-jsonschema-form/).
 
 ### Disabled attribute for `enum` fields

--- a/playground/samples/alternatives.js
+++ b/playground/samples/alternatives.js
@@ -22,6 +22,20 @@ module.exports = {
           },
         ],
       },
+      Toggle: {
+        title: "Toggle",
+        type: "boolean",
+        oneOf: [
+          {
+            title: "Enable",
+            const: true,
+          },
+          {
+            title: "Disable",
+            const: false,
+          },
+        ],
+      },
     },
     title: "Image editor",
     type: "object",
@@ -38,6 +52,10 @@ module.exports = {
           $ref: "#/definitions/Color",
         },
         title: "Color mask",
+      },
+      toggleMask: {
+        title: "Apply color mask",
+        $ref: "#/definitions/Toggle",
       },
       colorPalette: {
         type: "array",
@@ -57,6 +75,9 @@ module.exports = {
   uiSchema: {
     blendMode: {
       "ui:enumDisabled": ["multiply"],
+    },
+    toggleMask: {
+      "ui:widget": "radio",
     },
   },
   formData: {

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -29,10 +29,23 @@ function BooleanField(props) {
   const { widgets, formContext } = registry;
   const { widget = "checkbox", ...options } = getUiOptions(uiSchema);
   const Widget = getWidget(schema, widget, widgets);
-  const enumOptions = optionsList({
-    enum: [true, false],
-    enumNames: schema.enumNames || ["yes", "no"],
-  });
+
+  let enumOptions;
+
+  if (Array.isArray(schema.oneOf)) {
+    enumOptions = optionsList({
+      oneOf: schema.oneOf.map(option => ({
+        ...option,
+        title: option.title || (option.const === true ? "yes" : "no"),
+      })),
+    });
+  } else {
+    enumOptions = optionsList({
+      enum: [true, false],
+      enumNames: schema.enumNames || ["yes", "no"],
+    });
+  }
+
   return (
     <Widget
       options={{ ...options, enumOptions }}

--- a/test/BooleanField_test.js
+++ b/test/BooleanField_test.js
@@ -124,6 +124,58 @@ describe("BooleanField", () => {
     expect(labels).eql(["Yes", "No"]);
   });
 
+  it("should support oneOf titles for radio widgets", () => {
+    const { node } = createFormComponent({
+      schema: {
+        type: "boolean",
+        oneOf: [
+          {
+            const: true,
+            title: "Yes",
+          },
+          {
+            const: false,
+            title: "No",
+          },
+        ],
+      },
+      formData: true,
+      uiSchema: { "ui:widget": "radio" },
+    });
+
+    const labels = [].map.call(
+      node.querySelectorAll(".field-radio-group label"),
+      label => label.textContent
+    );
+    expect(labels).eql(["Yes", "No"]);
+  });
+
+  it("should preserve oneOf option ordering for radio widgets", () => {
+    const { node } = createFormComponent({
+      schema: {
+        type: "boolean",
+        oneOf: [
+          {
+            const: false,
+            title: "No",
+          },
+          {
+            const: true,
+            title: "Yes",
+          },
+        ],
+      },
+      formData: true,
+      uiSchema: { "ui:widget": "radio" },
+    });
+
+    const labels = [].map.call(
+      node.querySelectorAll(".field-radio-group label"),
+      label => label.textContent
+    );
+    expect(labels).eql(["No", "Yes"]);
+  });
+
   it("should support inline radio widgets", () => {
     const { node } = createFormComponent({
       schema: { type: "boolean" },


### PR DESCRIPTION
### Reasons for making this change

As previously reported in the following issues specifying boolean options with a oneOf schema does not work as expected.

- #945 - Support oneOf syntax in BooleanField with radio widget.
- #781 - oneOf{const,title} with boolean type properties causes titles to be displayed in lower case
- #782 - https://github.com/mozilla-services/react-jsonschema-form/issues/782

These issues all essentially result from a lack of support for `oneOf` in BooleanWidget altogether. This implements that support with a similar approach to the [`optionsList` utility](https://github.com/mozilla-services/react-jsonschema-form/blob/b068705b32c9409058b826c7a7d88aa090ec8d29/src/utils.js#L372).

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
