### PR TITLE
#556 - handle recursive references to deep schema definitions

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -394,6 +394,9 @@ function findSchemaDefinition($ref, definitions = {}) {
     let current = definitions;
     for (let part of parts) {
       part = part.replace(/~1/g, "/").replace(/~0/g, "~");
+      if (current.hasOwnProperty("$ref")) {
+        current = findSchemaDefinition(current.$ref, definitions);
+      }
       if (current.hasOwnProperty(part)) {
         current = current[part];
       } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -394,7 +394,7 @@ function findSchemaDefinition($ref, definitions = {}) {
     let current = definitions;
     for (let part of parts) {
       part = part.replace(/~1/g, "/").replace(/~0/g, "~");
-      if (current.hasOwnProperty("$ref")) {
+      while (current.hasOwnProperty("$ref")) {
         current = findSchemaDefinition(current.$ref, definitions);
       }
       if (current.hasOwnProperty(part)) {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -541,6 +541,30 @@ describe("Form", () => {
       expect(node.querySelector("#root_children_0_name")).to.exist;
     });
 
+    it("should handle recursive references to deep schema definitions", () => {
+      const schema = {
+        definitions: {
+          testdef: {
+            $ref: "#/definitions/testdefref",
+          },
+          testdefref: {
+            type: "object",
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+        },
+        type: "object",
+        properties: {
+          foo: { $ref: "#/definitions/testdef/properties/bar" },
+        },
+      };
+
+      const { node } = createFormComponent({ schema });
+
+      expect(node.querySelectorAll("input[type=text]")).to.have.length.of(1);
+    });
+
     it("should priorize definition over schema type property", () => {
       // Refs bug #140
       const schema = {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -600,6 +600,33 @@ describe("Form", () => {
       expect(node.querySelectorAll("input[type=text]")).to.have.length.of(1);
     });
 
+    it("should handle multiple recursive references to deep schema definitions", () => {
+      const schema = {
+        definitions: {
+          testdef: {
+            $ref: "#/definitions/testdefref1",
+          },
+          testdefref1: {
+            $ref: "#/definitions/testdefref2",
+          },
+          testdefref2: {
+            type: "object",
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+        },
+        type: "object",
+        properties: {
+          foo: { $ref: "#/definitions/testdef/properties/bar" },
+        },
+      };
+
+      const { node } = createFormComponent({ schema });
+
+      expect(node.querySelectorAll("input[type=text]")).to.have.length.of(1);
+    });
+
     it("should priorize definition over schema type property", () => {
       // Refs bug #140
       const schema = {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -541,6 +541,41 @@ describe("Form", () => {
       expect(node.querySelector("#root_children_0_name")).to.exist;
     });
 
+    it("should follow recursive references", () => {
+      const schema = {
+        definitions: {
+          bar: { $ref: "#/definitions/qux" },
+          qux: { type: "string" },
+        },
+        type: "object",
+        required: ["foo"],
+        properties: {
+          foo: { $ref: "#/definitions/bar" },
+        },
+      };
+      const { node } = createFormComponent({ schema });
+
+      expect(node.querySelectorAll("input[type=text]")).to.have.length.of(1);
+    });
+
+    it("should follow multiple recursive references", () => {
+      const schema = {
+        definitions: {
+          bar: { $ref: "#/definitions/bar2" },
+          bar2: { $ref: "#/definitions/qux" },
+          qux: { type: "string" },
+        },
+        type: "object",
+        required: ["foo"],
+        properties: {
+          foo: { $ref: "#/definitions/bar" },
+        },
+      };
+      const { node } = createFormComponent({ schema });
+
+      expect(node.querySelectorAll("input[type=text]")).to.have.length.of(1);
+    });
+
     it("should handle recursive references to deep schema definitions", () => {
       const schema = {
         definitions: {


### PR DESCRIPTION
### Reasons for making this change

Fixes #556 (case 2)

Also follows a series of recursive references, for example,
```
{
        definitions: {
          testdef: {
            $ref: "#/definitions/testdefref1",
          },
          testdefref1: {
            $ref: "#/definitions/testdefref2",
          },
          testdefref2: {
            type: "object",
            properties: {
              bar: { type: "string" },
            },
          },
        },
        type: "object",
        properties: {
          foo: { $ref: "#/definitions/testdef/properties/bar" },
        },
}
```

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
