### PR TITLE
Fix multiple bugs related to switching between anyOf/oneOf options

### DIFF
--- a/src/components/fields/MultiSchemaField.js
+++ b/src/components/fields/MultiSchemaField.js
@@ -69,6 +69,10 @@ class AnyOfField extends Component {
           augmentedSchema = Object.assign({}, option, requiresAnyOf);
         }
 
+        // Remove the "required" field as it's likely that not all fields have
+        // been filled in yet, which will mean that the schema is not valid
+        delete augmentedSchema.required;
+
         if (isValid(augmentedSchema, formData)) {
           return i;
         }
@@ -85,7 +89,14 @@ class AnyOfField extends Component {
     const selectedOption = parseInt(event.target.value, 10);
     const { formData, onChange, options } = this.props;
 
-    if (guessType(formData) === "object") {
+    const newOption = options[selectedOption];
+
+    // If the new option is of type object and the current data is an object,
+    // discard properties added using the old option.
+    if (
+      guessType(formData) === "object" &&
+      (newOption.type === "object" || newOption.properties)
+    ) {
       const newFormData = Object.assign({}, formData);
 
       const optionsToDiscard = options.slice();

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -237,7 +237,7 @@ class ObjectField extends Component {
               errorSchema={errorSchema[name]}
               idSchema={idSchema[name]}
               idPrefix={idPrefix}
-              formData={formData[name]}
+              formData={(formData || {})[name]}
               onKeyChange={this.onKeyChange(name)}
               onChange={this.onPropertyChange(
                 name,

--- a/src/utils.js
+++ b/src/utils.js
@@ -732,7 +732,9 @@ export function toIdSchema(
       field,
       fieldId,
       definitions,
-      formData[name],
+      // Its possible that formData is not an object, this can happen if an
+      // array item has just been added, but not populated with data yet
+      (formData || {})[name],
       idPrefix
     );
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -732,7 +732,7 @@ export function toIdSchema(
       field,
       fieldId,
       definitions,
-      // Its possible that formData is not an object, this can happen if an
+      // It's possible that formData is not an object, this can happen if an
       // array item has just been added, but not populated with data yet
       (formData || {})[name],
       idPrefix

--- a/src/utils.js
+++ b/src/utils.js
@@ -732,7 +732,7 @@ export function toIdSchema(
       field,
       fieldId,
       definitions,
-      // It's possible that formData is not an object, this can happen if an
+      // It's possible that formData is not an object -- this can happen if an
       // array item has just been added, but not populated with data yet
       (formData || {})[name],
       idPrefix

--- a/test/anyOf_test.js
+++ b/test/anyOf_test.js
@@ -571,5 +571,51 @@ describe("anyOf", () => {
 
       expect(node.querySelectorAll("input#root_foo")).to.have.length.of(1);
     });
+
+    it("should correctly render mixed types for anyOf inside array items", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              anyOf: [
+                {
+                  type: "string",
+                },
+                {
+                  type: "object",
+                  properties: {
+                    foo: {
+                      type: "integer",
+                    },
+                    bar: {
+                      type: "string",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+      });
+
+      expect(node.querySelector(".array-item-add button")).not.eql(null);
+
+      Simulate.click(node.querySelector(".array-item-add button"));
+
+      const $select = node.querySelector("select");
+      expect($select).not.eql(null);
+      Simulate.change($select, {
+        target: { value: $select.options[1].value },
+      });
+
+      expect(node.querySelectorAll("input#root_foo")).to.have.length.of(1);
+      expect(node.querySelectorAll("input#root_bar")).to.have.length.of(1);
+    });
   });
 });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1183,6 +1183,64 @@ describe("utils", () => {
       });
     });
 
+    it("should return an idSchema for nested property dependencies", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          obj: {
+            type: "object",
+            properties: {
+              foo: { type: "string" },
+            },
+            dependencies: {
+              foo: {
+                properties: {
+                  bar: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      };
+      const formData = {
+        obj: {
+          foo: "test",
+        },
+      };
+
+      expect(toIdSchema(schema, undefined, schema.definitions, formData)).eql({
+        $id: "root",
+        obj: {
+          $id: "root_obj",
+          foo: { $id: "root_obj_foo" },
+          bar: { $id: "root_obj_bar" },
+        },
+      });
+    });
+
+    it("should return an idSchema for unmet property dependencies", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+        },
+        dependencies: {
+          foo: {
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const formData = {};
+
+      expect(toIdSchema(schema, undefined, schema.definitions, formData)).eql({
+        $id: "root",
+        foo: { $id: "root_foo" },
+      });
+    });
+
     it("should handle idPrefix parameter", () => {
       const schema = {
         definitions: {
@@ -1204,6 +1262,24 @@ describe("utils", () => {
           bar: { $id: "rjsf_bar" },
         }
       );
+    });
+
+    it("should handle null form data for object schemas", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+          bar: { type: "string" },
+        },
+      };
+      const formData = null;
+      const result = toIdSchema(schema, null, {}, formData, "rjsf");
+
+      expect(result).eql({
+        $id: "rjsf",
+        foo: { $id: "rjsf_foo" },
+        bar: { $id: "rjsf_bar" },
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #1168

- Fixed a bug that would prevent input fields from rendering when
switching between a non-object type option and an object type option
- Fixed a bug where options would incorrectly change when entering
values if a subschema with multiple required fields is used
- Fixed a bug where switching from an object type option to a non-object
type option would result in an input field containing the value [Object object]

Change-type: patch
Signed-off-by: Lucian <lucian.buzzo@gmail.com>

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
