### PR TITLE
Infer field type from const value

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -67,6 +67,11 @@ export function getDefaultRegistry() {
 
 export function getSchemaType(schema) {
   let { type } = schema;
+
+  if (!type && schema.const) {
+    return guessType(schema.const);
+  }
+
   if (!type && schema.enum) {
     type = "string";
   }

--- a/test/const_test.js
+++ b/test/const_test.js
@@ -1,0 +1,60 @@
+import { expect } from "chai";
+
+import { createFormComponent, createSandbox } from "./test_utils";
+
+describe("const", () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should render a schema that uses const with a string value", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: { const: "bar" },
+      },
+    };
+
+    const { node } = createFormComponent({
+      schema,
+    });
+
+    expect(node.querySelector("input#root_foo")).not.eql(null);
+  });
+
+  it("should render a schema that uses const with a number value", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: { const: 123 },
+      },
+    };
+
+    const { node } = createFormComponent({
+      schema,
+    });
+
+    expect(node.querySelector("input#root_foo")).not.eql(null);
+  });
+
+  it("should render a schema that uses const with a boolean value", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: { const: true },
+      },
+    };
+
+    const { node } = createFormComponent({
+      schema,
+    });
+
+    expect(node.querySelector("input#root_foo[type='checkbox']")).not.eql(null);
+  });
+});

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -5,6 +5,7 @@ import {
   dataURItoBlob,
   deepEquals,
   getDefaultFormState,
+  getSchemaType,
   isFilesArray,
   isConstant,
   toConstant,
@@ -1367,6 +1368,53 @@ describe("utils", () => {
 
     it("should guess the type of object values", () => {
       expect(guessType({})).eql("object");
+    });
+  });
+
+  describe("getSchemaType()", () => {
+    const cases = [
+      {
+        schema: { type: "string" },
+        expected: "string",
+      },
+      {
+        schema: { type: "number" },
+        expected: "number",
+      },
+      {
+        schema: { type: "integer" },
+        expected: "integer",
+      },
+      {
+        schema: { type: "object" },
+        expected: "object",
+      },
+      {
+        schema: { type: "array" },
+        expected: "array",
+      },
+      {
+        schema: { type: "boolean" },
+        expected: "boolean",
+      },
+      {
+        schema: { type: "null" },
+        expected: "null",
+      },
+      {
+        schema: { const: "foo" },
+        expected: "string",
+      },
+      {
+        schema: { const: 1 },
+        expected: "number",
+      },
+    ];
+
+    it("should correctly guess the type of a schema", () => {
+      for (const test of cases) {
+        expect(getSchemaType(test.schema)).eql(test.expected);
+      }
     });
   });
 });


### PR DESCRIPTION
This change adds support for schemas that use the `const` keyword
without and adjacent `type` keyword. For example:

```json
{
  "type": "object",
  "properties": {
    "firstName": {
      "const": "Chuck"
    }
  }
}
```

Signed-off-by: Lucian <lucian.buzzo@gmail.com>

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
