### PR TITLE
Custom string formats

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -49,7 +49,7 @@ render((
 
 ### Custom string formats
 
-[Pre-defined semantic formats](https://json-schema.org/latest/json-schema-validation.html#rfc.section.7) are limited. react-jsonschema-form adds two formats: `color` and `data-url` to support certain [alternative widgets](form-customization.md#alternative-widgets). You can add formats of your own through the `customFormats` prop to your `Form` component:
+[Pre-defined semantic formats](https://json-schema.org/latest/json-schema-validation.html#rfc.section.7) are limited. react-jsonschema-form adds two formats, `color` and `data-url`, to support certain [alternative widgets](form-customization.md#alternative-widgets). You can add formats of your own through the `customFormats` prop to your `Form` component:
 
 ```jsx
 const schema = {

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -47,6 +47,30 @@ render((
 >   received as second argument.
 > - The `validate()` function is called **after** the JSON schema validation.
 
+### Custom string formats
+
+[Pre-defined semantic formats](https://json-schema.org/latest/json-schema-validation.html#rfc.section.7) are limited. react-jsonschema-form adds two formats: `color` and `data-url` to support certain [alternative widgets](form-customization.md#alternative-widgets). You can add formats of your own through the `additionalFormats` prop to your `Form` component:
+
+```jsx
+const schema = {
+  phoneNumber: {
+    type: 'string',
+    format: 'format-us'
+  }
+};
+
+const additionalFormats = {
+  'phone-us': /\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}$/
+};
+
+render((
+  <Form schema={schema} 
+        additionalFormats={additionalFormats}/>
+), document.getElementById("app"));
+```
+
+Format values can be anything AJV’s [`addFormat` method](https://github.com/epoberezkin/ajv#addformatstring-name-stringregexpfunctionobject-format---ajv) accepts.
+
 ### Custom schema validation
 
 To have your schemas validated against any other meta schema than draft-07 (the current version of [JSON Schema](http://json-schema.org/)), make sure your schema has a `$schema` attribute that enables the validator to use the correct meta schema. For example:

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -49,7 +49,7 @@ render((
 
 ### Custom string formats
 
-[Pre-defined semantic formats](https://json-schema.org/latest/json-schema-validation.html#rfc.section.7) are limited. react-jsonschema-form adds two formats: `color` and `data-url` to support certain [alternative widgets](form-customization.md#alternative-widgets). You can add formats of your own through the `additionalFormats` prop to your `Form` component:
+[Pre-defined semantic formats](https://json-schema.org/latest/json-schema-validation.html#rfc.section.7) are limited. react-jsonschema-form adds two formats: `color` and `data-url` to support certain [alternative widgets](form-customization.md#alternative-widgets). You can add formats of your own through the `customFormats` prop to your `Form` component:
 
 ```jsx
 const schema = {
@@ -59,13 +59,13 @@ const schema = {
   }
 };
 
-const additionalFormats = {
+const customFormats = {
   'phone-us': /\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}$/
 };
 
 render((
   <Form schema={schema} 
-        additionalFormats={additionalFormats}/>
+        customFormats={customFormats}/>
 ), document.getElementById("app"));
 ```
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -92,7 +92,7 @@ export default class Form extends Component {
     formData,
     schema = this.props.schema,
     additionalMetaSchemas = this.props.additionalMetaSchemas,
-    additionalFormats = this.props.additionalFormats
+    customFormats = this.props.customFormats
   ) {
     const { validate, transformErrors } = this.props;
     const { definitions } = this.getRegistry();
@@ -103,7 +103,7 @@ export default class Form extends Component {
       validate,
       transformErrors,
       additionalMetaSchemas,
-      additionalFormats
+      customFormats
     );
   }
 
@@ -303,7 +303,7 @@ if (process.env.NODE_ENV !== "production") {
     transformErrors: PropTypes.func,
     safeRenderCompletion: PropTypes.bool,
     formContext: PropTypes.object,
-    additionalFormats: PropTypes.object,
+    customFormats: PropTypes.object,
     additionalMetaSchemas: PropTypes.arrayOf(PropTypes.object),
   };
 }

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -91,7 +91,8 @@ export default class Form extends Component {
   validate(
     formData,
     schema = this.props.schema,
-    additionalMetaSchemas = this.props.additionalMetaSchemas
+    additionalMetaSchemas = this.props.additionalMetaSchemas,
+    additionalFormats = this.props.additionalFormats
   ) {
     const { validate, transformErrors } = this.props;
     const { definitions } = this.getRegistry();
@@ -101,7 +102,8 @@ export default class Form extends Component {
       resolvedSchema,
       validate,
       transformErrors,
-      additionalMetaSchemas
+      additionalMetaSchemas,
+      additionalFormats
     );
   }
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -58,9 +58,10 @@ export default class Form extends Component {
     const { definitions } = schema;
     const formData = getDefaultFormState(schema, props.formData, definitions);
     const retrievedSchema = retrieveSchema(schema, definitions, formData);
+    const customFormats = props.customFormats;
     const additionalMetaSchemas = props.additionalMetaSchemas;
     const { errors, errorSchema } = mustValidate
-      ? this.validate(formData, schema, additionalMetaSchemas)
+      ? this.validate(formData, schema, additionalMetaSchemas, customFormats)
       : {
           errors: state.errors || [],
           errorSchema: state.errorSchema || {},

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -301,6 +301,7 @@ if (process.env.NODE_ENV !== "production") {
     transformErrors: PropTypes.func,
     safeRenderCompletion: PropTypes.bool,
     formContext: PropTypes.object,
+    additionalFormats: PropTypes.object,
     additionalMetaSchemas: PropTypes.arrayOf(PropTypes.object),
   };
 }

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1979,6 +1979,53 @@ describe("Form", () => {
     });
   });
 
+  describe("Custom format updates", () => {
+    it("Should update custom formats when customFormats is changed", () => {
+      const formProps = {
+        liveValidate: true,
+        formData: {
+          areaCode: 123,
+        },
+        schema: {
+          type: "object",
+          properties: {
+            areaCode: {
+              type: "number",
+              format: "area-code",
+            },
+          },
+        },
+        uiSchema: {
+          areaCode: {
+            "ui:widget": "area-code",
+          },
+        },
+        widgets: {
+          "area-code": () => <div id="custom" />,
+        },
+      };
+
+      const { comp } = createFormComponent(formProps);
+
+      expect(comp.state.errorSchema).eql({
+        $schema: {
+          __errors: [
+            'unknown format "area-code" is used in schema at path "#/properties/areaCode"',
+          ],
+        },
+      });
+
+      setProps(comp, {
+        ...formProps,
+        customFormats: {
+          "area-code": /\d{3}/,
+        },
+      });
+
+      expect(comp.state.errorSchema).eql({});
+    });
+  });
+
   describe("Meta schema updates", () => {
     it("Should update allowed meta schemas when additionalMetaSchemas is changed", () => {
       const formProps = {

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -163,6 +163,69 @@ describe("Validation", () => {
       });
     });
 
+    describe("validating using custom string formats", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          phone: {
+            type: "string",
+            format: "phone-us",
+          },
+        },
+      };
+
+      it("should return a validation error if unknown string format is used", () => {
+        const result = validateFormData({ phone: "800.555.2368" }, schema);
+        const errMessage =
+          'unknown format "phone-us" is used in schema at path "#/properties/phone"';
+
+        expect(result.errors[0].stack).include(errMessage);
+        expect(result.errorSchema).to.eql({
+          $schema: { __errors: [errMessage] },
+        });
+      });
+
+      it("should return a validation error about formData", () => {
+        const result = validateFormData(
+          { phone: "800.555.2368" },
+          schema,
+          null,
+          null,
+          null,
+          { "phone-us": /\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}$/ }
+        );
+
+        expect(result.errors).to.have.lengthOf(1);
+        expect(result.errors[0].stack).to.equal(
+          '.phone should match format "phone-us"'
+        );
+      });
+
+      it("prop updates with new custom formats are accepted", () => {
+        const result = validateFormData(
+          { phone: "abc" },
+          {
+            type: "object",
+            properties: {
+              phone: {
+                type: "string",
+                format: "area-code",
+              },
+            },
+          },
+          null,
+          null,
+          null,
+          { "area-code": /\d{3}/ }
+        );
+
+        expect(result.errors).to.have.lengthOf(1);
+        expect(result.errors[0].stack).to.equal(
+          '.phone should match format "area-code"'
+        );
+      });
+    });
+
     describe("Custom validate function", () => {
       let errors, errorSchema;
 


### PR DESCRIPTION
### Reasons for making this change

This is based off https://github.com/mozilla-services/react-jsonschema-form/pull/1130, following it as a pattern for passing through additional configuration to AJV.

A prior PR, #889, attempted to add this. However I disagree with the guidance there to use custom widgets. That approach does not allow custom defined formats to be validated outside of the widget. Sure, validation logic can be implemented within and only emit values onChange on valid input. But should a parent form, custom validation functions, etc. not have awareness of validation status for _all_ fields?

#889 opted to ignore custom formats altogether which I agree is ill-advised. AJV implements an [addFormat method](https://github.com/epoberezkin/ajv#api-addformat) however that can associate validation patterns (and more) with named formats. This suppresses AJV warnings about these formats _and_ validates data. Using formats also allows AJV to be used externally for validation in other contexts, e.g. on a backend.

Granted this is all similar to schema definitions but the key benefit is automatic [assignment of custom widgets](https://github.com/mozilla-services/react-jsonschema-form/blob/6e79281a3c5ea99763cfce6ea78fcfe776824bad/src/utils.js#L14-L34) without requiring these to be specified as uiSchema wherever a definition is referenced. AJV's own custom validation functions, etc. may also be useful for advanced usage.

Lastly, https://github.com/json-schema-org/json-schema-spec/issues/563 documents broader need for this capability in JSON Schema. This library itself has added `color` and `data-url`. Meta-schemas are not a viable solution as the above issue notes. A separate _vocabulary definition file format_ may be specified in draft-08 but in the meantime being able to register such custom vocabularies with AJV would fill the need and give users of this library a solution until draft-08 arrives.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

> :warning: I am opening this early, before https://github.com/mozilla-services/react-jsonschema-form/pull/1130 is merged, to demonstrate this separate (but somewhat related) use case and see whether this is an acceptable solution before doing anything further.