### PR TITLE
Add the full source maps by default for development

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -3,7 +3,7 @@ var webpack = require("webpack");
 
 module.exports = {
   mode: "development",
-  devtool: "eval",
+  devtool: "source-map",
   entry: [
     "webpack-hot-middleware/client?reload=true",
     "./playground/app"


### PR DESCRIPTION
### Reasons for making this change

I'm adding the source mappings to the current dev deployment for debugging. I've checked that the dev server runs pretty much exactly as fast as before (for rebuilds), so I don't see any reason not to add them. I've decided not to add them to the production config for now, because I don't think it would just be as simple as changing one webpack config and it's most useful in development.

Fixes #1203 