### PR TITLE
Add schema name to console warning on anyOf error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsonschema-form",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -603,8 +603,11 @@ function withExactlyOneSubschema(
     }
   });
   if (validSubschemas.length !== 1) {
+    const schemaName = Object.keys(schema.properties)[0];
     console.warn(
-      "ignoring oneOf in dependencies because there isn't exactly one subschema that is valid"
+      "ignoring oneOf in dependencies for '" +
+        schemaName +
+        "' because there isn't exactly one subschema that is valid"
     );
     return schema;
   }


### PR DESCRIPTION
### Reasons for making this change

This PR tries to resolve https://github.com/mozilla-services/react-jsonschema-form/issues/1188

It adds the name of the schema to the console warning when an anyOf validation fails.

I don't know the codebase well, so I'm not sure if this validation is reused in other places, nor if this change would also be beneficial in other places. Feel free to update before merge.

**Update**: I also see I committed the package-lock file. I'm assuming you can remove/revert this before merging? 