### PR TITLE
Fields ordering in UISchema throw an error when the field is inside oneOf #1175 fix

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -280,13 +280,10 @@ export function orderProperties(properties, order) {
       ? `properties '${arr.join("', '")}'`
       : `property '${arr[0]}'`;
   const propertyHash = arrayToHash(properties);
+
+  order = order.filter(prop => prop === "*" || propertyHash[prop]);
   const orderHash = arrayToHash(order);
-  const extraneous = order.filter(prop => prop !== "*" && !propertyHash[prop]);
-  if (extraneous.length) {
-    throw new Error(
-      `uiSchema order list contains extraneous ${errorPropList(extraneous)}`
-    );
-  }
+
   const rest = properties.filter(prop => !orderHash[prop]);
   const restIndex = order.indexOf("*");
   if (restIndex === -1) {

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -231,17 +231,19 @@ describe("ObjectField", () => {
       expect(labels).eql(["baz", "bar", "qux", "foo"]);
     });
 
-    it("should throw when order list contains an extraneous property", () => {
+    it("should skip extraneous property order when list contains an extraneous property", () => {
       const { node } = createFormComponent({
         schema,
         uiSchema: {
           "ui:order": ["baz", "qux", "bar", "wut?", "foo", "huh?"],
         },
       });
-
-      expect(node.querySelector(".config-error").textContent).to.match(
-        /contains extraneous properties 'wut\?', 'huh\?'/
+      const labels = [].map.call(
+        node.querySelectorAll(".field > div > div> label"),
+        l => l.textContent
       );
+
+      expect(labels).eql(["baz", "qux", "bar", "foo"]);
     });
 
     it("should throw when order list misses an existing property", () => {

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -239,7 +239,7 @@ describe("ObjectField", () => {
         },
       });
       const labels = [].map.call(
-        node.querySelectorAll(".field > div > div> label"),
+        node.querySelectorAll(".field > label"),
         l => l.textContent
       );
 


### PR DESCRIPTION

### Reasons for making this change

[Fields ordering in UISchema throw an error when the field is inside oneOf ]

Fixes https://github.com/mozilla-services/react-jsonschema-form/issues/1175

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
