### PR TITLE
Add NullField

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsonschema-form",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4599,7 +4599,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -5268,8 +5267,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -5291,7 +5289,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -21,6 +21,7 @@ import propertyDependencies from "./propertyDependencies";
 import schemaDependencies from "./schemaDependencies";
 import additionalProperties from "./additionalProperties";
 import nullable from "./nullable";
+import nullField from "./null";
 
 export const samples = {
   Simple: simple,
@@ -45,5 +46,6 @@ export const samples = {
   "Additional Properties": additionalProperties,
   "Any Of": anyOf,
   "One Of": oneOf,
+  "Null fields": nullField,
   Nullable: nullable,
 };

--- a/playground/samples/null.js
+++ b/playground/samples/null.js
@@ -1,0 +1,28 @@
+module.exports = {
+  schema: {
+    title: "Null field example",
+    description: "A short form with a null field",
+    type: "object",
+    required: ["firstName"],
+    properties: {
+      helpText: {
+        title: "A null field",
+        description:
+          "Null fields like this are great for adding extra information",
+        type: "null",
+      },
+      firstName: {
+        type: "string",
+        title: "A regular string field",
+        default: "Chuck",
+      },
+    },
+  },
+  uiSchema: {
+    firstName: {
+      "ui:autofocus": true,
+      "ui:emptyValue": "",
+    },
+  },
+  formData: {},
+};

--- a/src/components/fields/NullField.js
+++ b/src/components/fields/NullField.js
@@ -3,7 +3,9 @@ import PropTypes from "prop-types";
 
 class NullField extends Component {
   componentDidMount() {
-    this.props.onChange(null);
+    if (this.props.formData === undefined) {
+      this.props.onChange(null);
+    }
   }
 
   render() {

--- a/src/components/fields/NullField.js
+++ b/src/components/fields/NullField.js
@@ -1,5 +1,5 @@
 import { Component } from "react";
-import PropTypes from "prop-types";
+import * as types from "../../types";
 
 class NullField extends Component {
   componentDidMount() {
@@ -14,9 +14,7 @@ class NullField extends Component {
 }
 
 if (process.env.NODE_ENV !== "production") {
-  NullField.propTypes = {
-    onChange: PropTypes.func,
-  };
+  NullField.propTypes = types.fieldProps;
 }
 
 export default NullField;

--- a/src/components/fields/NullField.js
+++ b/src/components/fields/NullField.js
@@ -1,5 +1,20 @@
-function NullField(props) {
-  return null;
+import { Component } from "react";
+import PropTypes from "prop-types";
+
+class NullField extends Component {
+  componentDidMount() {
+    this.props.onChange(null);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+if (process.env.NODE_ENV !== "production") {
+  NullField.propTypes = {
+    onChange: PropTypes.func,
+  };
 }
 
 export default NullField;

--- a/src/components/fields/NullField.js
+++ b/src/components/fields/NullField.js
@@ -1,0 +1,5 @@
+function NullField(props) {
+  return null;
+}
+
+export default NullField;

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -26,6 +26,7 @@ const COMPONENT_TYPES = {
   number: "NumberField",
   object: "ObjectField",
   string: "StringField",
+  null: "NullField",
 };
 
 function getFieldComponent(schema, uiSchema, idSchema, fields) {

--- a/src/components/fields/index.js
+++ b/src/components/fields/index.js
@@ -7,6 +7,7 @@ import ObjectField from "./ObjectField";
 import SchemaField from "./SchemaField";
 import StringField from "./StringField";
 import TitleField from "./TitleField";
+import NullField from "./NullField";
 import UnsupportedField from "./UnsupportedField";
 
 export default {
@@ -20,5 +21,6 @@ export default {
   SchemaField,
   StringField,
   TitleField,
+  NullField,
   UnsupportedField,
 };

--- a/test/NullField_test.js
+++ b/test/NullField_test.js
@@ -45,5 +45,15 @@ describe("NullField", () => {
 
       expect(comp.state.formData).eql(null);
     });
+
+    it("should always hold the value null", () => {
+      const { comp } = createFormComponent({
+        schema: {
+          type: "null",
+        },
+      });
+
+      expect(comp.state.formData).eql(null);
+    });
   });
 });

--- a/test/NullField_test.js
+++ b/test/NullField_test.js
@@ -46,14 +46,15 @@ describe("NullField", () => {
       expect(comp.state.formData).eql(null);
     });
 
-    it("should always hold the value null", () => {
+    it("should not overwrite existing data", () => {
       const { comp } = createFormComponent({
         schema: {
           type: "null",
         },
+        formData: 3,
       });
 
-      expect(comp.state.formData).eql(null);
+      expect(comp.state.formData).eql(3);
     });
   });
 });

--- a/test/NullField_test.js
+++ b/test/NullField_test.js
@@ -1,0 +1,49 @@
+import { expect } from "chai";
+
+import { createFormComponent, createSandbox } from "./test_utils";
+
+describe("NullField", () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("No widget", () => {
+    it("should render a null field", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "null",
+        },
+      });
+
+      expect(node.querySelectorAll(".field")).to.have.length.of(1);
+    });
+
+    it("should render a null field with a label", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "null",
+          title: "foo",
+        },
+      });
+
+      expect(node.querySelector(".field label").textContent).eql("foo");
+    });
+
+    it("should assign a default value", () => {
+      const { comp } = createFormComponent({
+        schema: {
+          type: "null",
+          default: null,
+        },
+      });
+
+      expect(comp.state.formData).eql(null);
+    });
+  });
+});


### PR DESCRIPTION
### Reasons for making this change

The JSON Schema type 'null' is currently validated and inferred as a type but shows an error when trying to render. This corrects the issue such that null fields will render nothing, allowing for things like additional help text or use as a temporary placeholder field.  
  
#1232

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [X] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [X] **I'm adding a new feature**
  - [X] I've updated the playground with an example use of the feature
