### PR TITLE
#226 - restrict accepted mimetype

### DIFF
--- a/playground/samples/files.js
+++ b/playground/samples/files.js
@@ -16,8 +16,17 @@ module.exports = {
           format: "data-url",
         },
       },
+      filesAccept: {
+        type: "string",
+        format: "data-url",
+        title: "Single File with Accept attribute",
+      },
     },
   },
-  uiSchema: {},
+  uiSchema: {
+    filesAccept: {
+      "ui:accept": ".pdf",
+    },
+  },
   formData: {},
 };

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -21,7 +21,6 @@ import {
 
 function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
   if (!title) {
-    // See #312: Ensure compatibility with old versions of React.
     return null;
   }
   const id = `${idSchema.$id}__title`;
@@ -30,7 +29,6 @@ function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
 
 function ArrayFieldDescription({ DescriptionField, idSchema, description }) {
   if (!description) {
-    // See #312: Ensure compatibility with old versions of React.
     return null;
   }
   const id = `${idSchema.$id}__description`;

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -22,7 +22,7 @@ import {
 function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
   if (!title) {
     // See #312: Ensure compatibility with old versions of React.
-    return <div />;
+    return null;
   }
   const id = `${idSchema.$id}__title`;
   return <TitleField id={id} title={title} required={required} />;
@@ -31,7 +31,7 @@ function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
 function ArrayFieldDescription({ DescriptionField, idSchema, description }) {
   if (!description) {
     // See #312: Ensure compatibility with old versions of React.
-    return <div />;
+    return null;
   }
   const id = `${idSchema.$id}__description`;
   return <DescriptionField id={id} description={description} />;

--- a/src/components/fields/DescriptionField.js
+++ b/src/components/fields/DescriptionField.js
@@ -4,8 +4,7 @@ import PropTypes from "prop-types";
 function DescriptionField(props) {
   const { id, description } = props;
   if (!description) {
-    // See #312: Ensure compatibility with old versions of React.
-    return <div />;
+    return null;
   }
   if (typeof description === "string") {
     return (

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -61,8 +61,7 @@ function getFieldComponent(schema, uiSchema, idSchema, fields) {
 function Label(props) {
   const { label, required, id } = props;
   if (!label) {
-    // See #312: Ensure compatibility with old versions of React.
-    return <div />;
+    return null;
   }
   return (
     <label className="control-label" htmlFor={id}>
@@ -88,8 +87,7 @@ function LabelInput(props) {
 function Help(props) {
   const { help } = props;
   if (!help) {
-    // See #312: Ensure compatibility with old versions of React.
-    return <div />;
+    return null;
   }
   if (typeof help === "string") {
     return <p className="help-block">{help}</p>;
@@ -100,7 +98,7 @@ function Help(props) {
 function ErrorList(props) {
   const { errors = [] } = props;
   if (errors.length === 0) {
-    return <div />;
+    return null;
   }
 
   return (
@@ -254,10 +252,8 @@ function SchemaFieldRender(props) {
   const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);
   const readonly = Boolean(props.readonly || uiSchema["ui:readonly"]);
   const autofocus = Boolean(props.autofocus || uiSchema["ui:autofocus"]);
-
   if (Object.keys(schema).length === 0) {
-    // See #312: Ensure compatibility with old versions of React.
-    return <div />;
+    return null;
   }
 
   const uiOptions = getUiOptions(uiSchema);

--- a/src/components/widgets/FileWidget.js
+++ b/src/components/widgets/FileWidget.js
@@ -90,7 +90,7 @@ class FileWidget extends Component {
   };
 
   render() {
-    const { multiple, id, readonly, disabled, autofocus } = this.props;
+    const { multiple, id, readonly, disabled, autofocus, options } = this.props;
     const { filesInfo } = this.state;
     return (
       <div>
@@ -104,6 +104,7 @@ class FileWidget extends Component {
             defaultValue=""
             autoFocus={autofocus}
             multiple={multiple}
+            accept={options.accept}
           />
         </p>
         <FilesInfo filesInfo={filesInfo} />

--- a/test/ArrayFieldTemplate_test.js
+++ b/test/ArrayFieldTemplate_test.js
@@ -42,7 +42,13 @@ describe("ArrayFieldTemplate", () => {
     describe("Stateful ArrayFieldTemplate", () => {
       class ArrayFieldTemplate extends PureComponent {
         render() {
-          return <div>{this.props.items.map(item => item.element)}</div>;
+          return (
+            <div className="field-content">
+              {this.props.items.map((item, i) => (
+                <div key={i}>item.children</div>
+              ))}
+            </div>
+          );
         }
       }
 
@@ -52,8 +58,9 @@ describe("ArrayFieldTemplate", () => {
           formData,
           ArrayFieldTemplate,
         });
-
-        expect(node.querySelectorAll(".field-array div")).to.have.length.of(3);
+        expect(
+          node.querySelectorAll(".field-array .field-content div")
+        ).to.have.length.of(3);
       });
     });
 

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -108,7 +108,7 @@ describe("SchemaField", () => {
               receivedProps = props;
             }
             render() {
-              return <div />;
+              return null;
             }
           },
         },


### PR DESCRIPTION
### Reasons for making this change
- Added a feature to support accepted mime type in file widget

If this is related to existing tickets, include links to them as well.
#226 - Restrict accepted mimetypes in file widget
### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
