### PR TITLE
Do not error when File is not defined

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -229,7 +229,7 @@ export function getUiOptions(uiSchema) {
 }
 
 export function isObject(thing) {
-  if (thing instanceof File) {
+  if (typeof File !== "undefined" && thing instanceof File) {
     return false;
   }
   return typeof thing === "object" && thing !== null && !Array.isArray(thing);


### PR DESCRIPTION
### Reasons for making this change

Fixes #1252, in which `File` being undefined in node environments (such as next.js) caused the forms to give errors and stop working.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
