### PR TITLE
Pass along required for custom checkboxes widgets

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -421,6 +421,7 @@ class ArrayField extends Component {
       formData,
       disabled,
       readonly,
+      required,
       autofocus,
       onBlur,
       onFocus,
@@ -448,6 +449,7 @@ class ArrayField extends Component {
         value={items}
         disabled={disabled}
         readonly={readonly}
+        required={required}
         formContext={formContext}
         autofocus={autofocus}
         rawErrors={rawErrors}


### PR DESCRIPTION
### Reasons for making this change

For custom checkboxes widget, required was not coming through. According to the documentation, the required prop should be passed through to custom widget components.
Reference - https://react-jsonschema-form.readthedocs.io/en/latest/advanced-customization/#custom-widget-components

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [X] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
