### PR TITLE
Make numbers nullable by allowing null values to be echoed from asNumber()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsonschema-form",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4599,6 +4599,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -5267,7 +5268,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -5289,6 +5291,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsonschema-form",
-  "version": "1.5.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4599,7 +4599,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -5268,8 +5267,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -5291,7 +5289,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }

--- a/playground/samples/nullable.js
+++ b/playground/samples/nullable.js
@@ -15,7 +15,7 @@ module.exports = {
         title: "Last name",
       },
       age: {
-        type: "integer",
+        type: ["integer", "null"],
         title: "Age",
       },
       bio: {
@@ -43,6 +43,7 @@ module.exports = {
       "ui:widget": "updown",
       "ui:title": "Age of person",
       "ui:description": "(earthian year)",
+      "ui:emptyValue": null,
     },
     bio: {
       "ui:widget": "textarea",

--- a/src/utils.js
+++ b/src/utils.js
@@ -256,6 +256,9 @@ export function asNumber(value) {
   if (value === "") {
     return undefined;
   }
+  if (value === null) {
+    return null;
+  }
   if (/\.$/.test(value)) {
     // "3." can't really be considered a number even if it parses in js. The
     // user is most likely entering a float.

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -342,6 +342,10 @@ describe("utils", () => {
     it("should return undefined if the input is empty", () => {
       expect(asNumber("")).eql(undefined);
     });
+
+    it("should return null if the input is null", () => {
+      expect(asNumber(null)).eql(null);
+    });
   });
 
   describe("orderProperties()", () => {


### PR DESCRIPTION
### Reasons for making this change

To allow ui:emptyValue=null for number fields. Fixes #1268 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature