### PR TITLE
Added an 'Omit extra data' prop to remove formData fields not represented in the schema

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -118,6 +118,8 @@ render((
 ), document.getElementById("app"));
 ```
 
+> Note: If there are fields in the `formData` that are not represented in the schema, they will be retained by default. If you would like to remove those extra values on form submission, then set the `omitExtraData` prop to `true`.
+
 #### Form error event handler
 
 To react when submitted form data are invalid, pass an `onError` handler. It will be passed the list of encountered errors:
@@ -134,6 +136,8 @@ render((
 #### Form data changes
 
 If you plan on being notified every time the form data are updated, you can pass an `onChange` handler, which will receive the same args as `onSubmit` any time a value is updated in the form.
+
+> Note: If `omitExtraData` and `liveValidate` are both set to true, then extra form data values that are not in any form field will be removed whenever `onChange` is called.
 
 #### Form field blur events
 
@@ -260,7 +264,7 @@ $ npm run tdd
 
 #### Code coverage
 
-Code coverage reports are generated using [nyc](https://github.com/istanbuljs/nyc) each time the `npm test-coverage` script is run. 
+Code coverage reports are generated using [nyc](https://github.com/istanbuljs/nyc) each time the `npm test-coverage` script is run.
 The full report can be seen by opening `./coverage/lcov-report/index.html`.
 
 ### Releasing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsonschema-form",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3873,8 +3873,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3898,15 +3897,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3923,22 +3920,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4069,8 +4063,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4084,7 +4077,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4101,7 +4093,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4110,15 +4101,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4139,7 +4128,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4228,8 +4216,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4243,7 +4230,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4339,8 +4325,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4382,7 +4367,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4404,7 +4388,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4453,15 +4436,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5946,6 +5927,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.restparam": {
       "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ajv": "^6.7.0",
     "babel-runtime": "^6.26.0",
     "core-js": "^2.5.7",
+    "lodash.pick": "^4.4.0",
     "lodash.topath": "^4.5.2",
     "prop-types": "^15.5.8"
   },

--- a/playground/app.js
+++ b/playground/app.js
@@ -26,6 +26,7 @@ const liveSettingsSchema = {
   properties: {
     validate: { type: "boolean", title: "Live validation" },
     disable: { type: "boolean", title: "Disable whole form" },
+    omitExtraData: { type: "boolean", title: "Omit extra data" },
   },
 };
 const cmOptions = {
@@ -332,6 +333,7 @@ class App extends Component {
       liveSettings: {
         validate: true,
         disable: false,
+        omitExtraData: false,
       },
       shareURL: null,
     };
@@ -472,6 +474,7 @@ class App extends Component {
               ObjectFieldTemplate={ObjectFieldTemplate}
               liveValidate={liveSettings.validate}
               disabled={liveSettings.disable}
+              omitExtraData={liveSettings.omitExtraData}
               schema={schema}
               uiSchema={uiSchema}
               formData={formData}

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -150,7 +150,7 @@ export default class Form extends Component {
             newPaths = newPaths.map(path => `${path}.${key}`);
             getAllPaths(_obj[key], acc, newPaths);
           }
-        } else if (key === "name") {
+        } else if (key === "$name") {
           paths.forEach(path => {
             const formValue = _get(formData, path);
             if (typeof formValue !== "object") {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -133,6 +133,11 @@ export default class Form extends Component {
   }
 
   getUsedFormData = (formData, fields) => {
+    //for the case of a single input form
+    if (fields.length === 0 && typeof formData !== "object") {
+      return formData;
+    }
+
     return _pick(formData, fields);
   };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -755,13 +755,13 @@ export function toIdSchema(
 
 export function toNameSchema(schema, name = "", definitions, formData = {}) {
   const nameSchema = {
-    name,
+    $name: name,
   };
   if ("$ref" in schema || "dependencies" in schema) {
     const _schema = retrieveSchema(schema, definitions, formData);
     return toNameSchema(_schema, name, definitions, formData);
   }
-  if ("items" in schema && !schema.items.$ref) {
+  if ("items" in schema) {
     const retVal = {};
     if (Array.isArray(formData) && formData.length > 0) {
       formData.forEach((element, index) => {
@@ -780,8 +780,8 @@ export function toNameSchema(schema, name = "", definitions, formData = {}) {
   }
   for (const property in schema.properties || {}) {
     const field = schema.properties[property];
-    const fieldId = nameSchema.name
-      ? nameSchema.name + "." + property
+    const fieldId = nameSchema.$name
+      ? nameSchema.$name + "." + property
       : property;
 
     nameSchema[property] = toNameSchema(

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -914,6 +914,132 @@ describe("Form", () => {
     });
   });
 
+  describe("getFieldNames()", () => {
+    it("should get field names from nameSchema", () => {
+      const schema = {};
+
+      const formData = {
+        extra: {
+          foo: "bar",
+        },
+        level1: {
+          level2: "test",
+          anotherThing: {
+            anotherThingNested: "abc",
+            extra: "asdf",
+            anotherThingNested2: 0,
+          },
+        },
+        level1a: 1.23,
+      };
+
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const nameSchema = {
+        $name: "",
+        level1: {
+          $name: "level1",
+          level2: { $name: "level1.level2" },
+          anotherThing: {
+            $name: "level1.anotherThing",
+            anotherThingNested: {
+              $name: "level1.anotherThing.anotherThingNested",
+            },
+            anotherThingNested2: {
+              $name: "level1.anotherThing.anotherThingNested2",
+            },
+          },
+        },
+        level1a: {
+          $name: "level1a",
+        },
+      };
+
+      const fieldNames = comp.getFieldNames(nameSchema, formData);
+      expect(fieldNames.sort()).eql(
+        [
+          "level1a",
+          "level1.level2",
+          "level1.anotherThing.anotherThingNested",
+          "level1.anotherThing.anotherThingNested2",
+        ].sort()
+      );
+    });
+
+    it("should get field names from nameSchema with array", () => {
+      const schema = {};
+
+      const formData = {
+        address_list: [
+          {
+            street_address: "21, Jump Street",
+            city: "Babel",
+            state: "Neverland",
+          },
+          {
+            street_address: "1234 Schema Rd.",
+            city: "New York",
+            state: "Arizona",
+          },
+        ],
+      };
+
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const nameSchema = {
+        $name: "",
+        address_list: {
+          "0": {
+            $name: "address_list.0",
+            city: {
+              $name: "address_list.0.city",
+            },
+            state: {
+              $name: "address_list.0.state",
+            },
+            street_address: {
+              $name: "address_list.0.street_address",
+            },
+          },
+          "1": {
+            $name: "address_list.1",
+            city: {
+              $name: "address_list.1.city",
+            },
+            state: {
+              $name: "address_list.1.state",
+            },
+            street_address: {
+              $name: "address_list.1.street_address",
+            },
+          },
+        },
+      };
+
+      const fieldNames = comp.getFieldNames(nameSchema, formData);
+      expect(fieldNames.sort()).eql(
+        [
+          "address_list.0.city",
+          "address_list.0.state",
+          "address_list.0.street_address",
+          "address_list.1.city",
+          "address_list.1.state",
+          "address_list.1.street_address",
+        ].sort()
+      );
+    });
+  });
+
   describe("Change handler", () => {
     it("should call provided change handler on form state change", () => {
       const schema = {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -847,6 +847,23 @@ describe("Form", () => {
   });
 
   describe("getUsedFormData", () => {
+    it("should just return the single input form value", () => {
+      const schema = {
+        title: "A single-field form",
+        type: "string",
+      };
+      const formData = "foo";
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const result = comp.getUsedFormData(formData, []);
+      expect(result).eql("foo");
+    });
+
     it("should call getUsedFormData with data from fields in event", () => {
       const schema = {
         type: "object",
@@ -915,6 +932,28 @@ describe("Form", () => {
   });
 
   describe("getFieldNames()", () => {
+    it("should return an empty array for a single input form", () => {
+      const schema = {
+        type: "string",
+      };
+
+      const formData = "foo";
+
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const nameSchema = {
+        $name: "",
+      };
+
+      const fieldNames = comp.getFieldNames(nameSchema, formData);
+      expect(fieldNames).eql([]);
+    });
+
     it("should get field names from nameSchema", () => {
       const schema = {};
 

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -812,6 +812,106 @@ describe("Form", () => {
 
       sinon.assert.notCalled(onSubmit);
     });
+
+    it("should call getUsedFormData when the omitExtraData prop is true", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string",
+          },
+        },
+      };
+      const formData = {
+        foo: "",
+      };
+      const onSubmit = sandbox.spy();
+      const onError = sandbox.spy();
+      const omitExtraData = true;
+      const { comp, node } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+        onError,
+        omitExtraData,
+      });
+
+      sandbox.stub(comp, "getUsedFormData").returns({
+        foo: "",
+      });
+
+      Simulate.submit(node);
+
+      sinon.assert.calledOnce(comp.getUsedFormData);
+    });
+  });
+
+  describe("getUsedFormData", () => {
+    it("should call getUsedFormData with data from fields in event", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+        },
+      };
+      const formData = {
+        foo: "bar",
+      };
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const result = comp.getUsedFormData(formData, ["foo"]);
+      expect(result).eql({ foo: "bar" });
+    });
+
+    it("unused form values should be omitted", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+          baz: { type: "string" },
+          list: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                title: { type: "string" },
+                details: { type: "string" },
+              },
+            },
+          },
+        },
+      };
+
+      const formData = {
+        foo: "bar",
+        baz: "buzz",
+        list: [
+          { title: "title0", details: "details0" },
+          { title: "title1", details: "details1" },
+        ],
+      };
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const result = comp.getUsedFormData(formData, [
+        "foo",
+        "list.0.title",
+        "list.1.details",
+      ]);
+      expect(result).eql({
+        foo: "bar",
+        list: [{ title: "title0" }, { details: "details1" }],
+      });
+    });
   });
 
   describe("Change handler", () => {
@@ -843,6 +943,74 @@ describe("Form", () => {
           foo: "new",
         },
       });
+    });
+
+    it("should call getUsedFormData when the omitExtraData prop is true and liveValidate is true", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string",
+          },
+        },
+      };
+      const formData = {
+        foo: "bar",
+      };
+      const onChange = sandbox.spy();
+      const omitExtraData = true;
+      const liveValidate = true;
+      const { node, comp } = createFormComponent({
+        schema,
+        formData,
+        onChange,
+        omitExtraData,
+        liveValidate,
+      });
+
+      sandbox.stub(comp, "getUsedFormData").returns({
+        foo: "",
+      });
+
+      Simulate.change(node.querySelector("[type=text]"), {
+        target: { value: "new" },
+      });
+
+      sinon.assert.calledOnce(comp.getUsedFormData);
+    });
+
+    it("should not call getUsedFormData when the omitExtraData prop is true and liveValidate is false", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string",
+          },
+        },
+      };
+      const formData = {
+        foo: "bar",
+      };
+      const onChange = sandbox.spy();
+      const omitExtraData = true;
+      const liveValidate = false;
+      const { node, comp } = createFormComponent({
+        schema,
+        formData,
+        onChange,
+        omitExtraData,
+        liveValidate,
+      });
+
+      sandbox.stub(comp, "getUsedFormData").returns({
+        foo: "",
+      });
+
+      Simulate.change(node.querySelector("[type=text]"), {
+        target: { value: "new" },
+      });
+
+      sinon.assert.notCalled(comp.getUsedFormData);
     });
   });
   describe("Blur handler", () => {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1331,10 +1331,10 @@ describe("utils", () => {
     it("should return a nameSchema for root field", () => {
       const schema = { type: "string" };
 
-      expect(toNameSchema(schema)).eql({ name: "" });
+      expect(toNameSchema(schema)).eql({ $name: "" });
     });
 
-    it("should return an idSchema for nested objects", () => {
+    it("should return a nameSchema for nested objects", () => {
       const schema = {
         type: "object",
         properties: {
@@ -1348,10 +1348,558 @@ describe("utils", () => {
       };
 
       expect(toNameSchema(schema)).eql({
-        name: "",
+        $name: "",
         level1: {
-          name: "level1",
-          level2: { name: "level1.level2" },
+          $name: "level1",
+          level2: { $name: "level1.level2" },
+        },
+      });
+    });
+
+    it("should return a nameSchema for a schema with dependencies", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          list: {
+            title: "list",
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                a: { type: "string" },
+                b: { type: "string" },
+              },
+              dependencies: {
+                b: {
+                  properties: {
+                    c: {
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const formData = {
+        list: [
+          {
+            a: "a1",
+            b: "b1",
+            c: "c1",
+          },
+          {
+            a: "a2",
+          },
+          {
+            a: "a2",
+            c: "c2",
+          },
+        ],
+      };
+
+      expect(toNameSchema(schema, "", schema.definitions, formData)).eql({
+        $name: "",
+        list: {
+          "0": {
+            $name: "list.0",
+            a: {
+              $name: "list.0.a",
+            },
+            b: {
+              $name: "list.0.b",
+            },
+            c: {
+              $name: "list.0.c",
+            },
+          },
+          "1": {
+            $name: "list.1",
+            a: {
+              $name: "list.1.a",
+            },
+            b: {
+              $name: "list.1.b",
+            },
+          },
+          "2": {
+            $name: "list.2",
+            a: {
+              $name: "list.2.a",
+            },
+            b: {
+              $name: "list.2.b",
+            },
+          },
+        },
+      });
+    });
+
+    it("should return a nameSchema for a schema with references", () => {
+      const schema = {
+        definitions: {
+          address: {
+            type: "object",
+            properties: {
+              street_address: {
+                type: "string",
+              },
+              city: {
+                type: "string",
+              },
+              state: {
+                type: "string",
+              },
+            },
+            required: ["street_address", "city", "state"],
+          },
+        },
+        type: "object",
+        properties: {
+          billing_address: {
+            title: "Billing address",
+            $ref: "#/definitions/address",
+          },
+        },
+      };
+
+      const formData = {
+        billing_address: {
+          street_address: "21, Jump Street",
+          city: "Babel",
+          state: "Neverland",
+        },
+      };
+
+      expect(toNameSchema(schema, "", schema.definitions, formData)).eql({
+        $name: "",
+        billing_address: {
+          $name: "billing_address",
+          city: {
+            $name: "billing_address.city",
+          },
+          state: {
+            $name: "billing_address.state",
+          },
+          street_address: {
+            $name: "billing_address.street_address",
+          },
+        },
+      });
+    });
+
+    it("should return a nameSchema for a schema with references in an array item", () => {
+      const schema = {
+        definitions: {
+          address: {
+            type: "object",
+            properties: {
+              street_address: {
+                type: "string",
+              },
+              city: {
+                type: "string",
+              },
+              state: {
+                type: "string",
+              },
+            },
+            required: ["street_address", "city", "state"],
+          },
+        },
+        type: "object",
+        properties: {
+          address_list: {
+            title: "Address list",
+            type: "array",
+            items: {
+              $ref: "#/definitions/address",
+            },
+          },
+        },
+      };
+
+      const formData = {
+        address_list: [
+          {
+            street_address: "21, Jump Street",
+            city: "Babel",
+            state: "Neverland",
+          },
+          {
+            street_address: "1234 Schema Rd.",
+            city: "New York",
+            state: "Arizona",
+          },
+        ],
+      };
+
+      expect(toNameSchema(schema, "", schema.definitions, formData)).eql({
+        $name: "",
+        address_list: {
+          "0": {
+            $name: "address_list.0",
+            city: {
+              $name: "address_list.0.city",
+            },
+            state: {
+              $name: "address_list.0.state",
+            },
+            street_address: {
+              $name: "address_list.0.street_address",
+            },
+          },
+          "1": {
+            $name: "address_list.1",
+            city: {
+              $name: "address_list.1.city",
+            },
+            state: {
+              $name: "address_list.1.state",
+            },
+            street_address: {
+              $name: "address_list.1.street_address",
+            },
+          },
+        },
+      });
+    });
+
+    it("should return an nameSchema with different types of arrays", () => {
+      const schema = {
+        definitions: {
+          Thing: {
+            type: "object",
+            properties: {
+              name: {
+                type: "string",
+                default: "Default name",
+              },
+            },
+          },
+        },
+        type: "object",
+        properties: {
+          listOfStrings: {
+            type: "array",
+            title: "A list of strings",
+            items: {
+              type: "string",
+              default: "bazinga",
+            },
+          },
+          multipleChoicesList: {
+            type: "array",
+            title: "A multiple choices list",
+            items: {
+              type: "string",
+              enum: ["foo", "bar", "fuzz", "qux"],
+            },
+            uniqueItems: true,
+          },
+          fixedItemsList: {
+            type: "array",
+            title: "A list of fixed items",
+            items: [
+              {
+                title: "A string value",
+                type: "string",
+                default: "lorem ipsum",
+              },
+              {
+                title: "a boolean value",
+                type: "boolean",
+              },
+            ],
+            additionalItems: {
+              title: "Additional item",
+              type: "number",
+            },
+          },
+          minItemsList: {
+            type: "array",
+            title: "A list with a minimal number of items",
+            minItems: 3,
+            items: {
+              $ref: "#/definitions/Thing",
+            },
+          },
+          defaultsAndMinItems: {
+            type: "array",
+            title: "List and item level defaults",
+            minItems: 5,
+            default: ["carp", "trout", "bream"],
+            items: {
+              type: "string",
+              default: "unidentified",
+            },
+          },
+          nestedList: {
+            type: "array",
+            title: "Nested list",
+            items: {
+              type: "array",
+              title: "Inner list",
+              items: {
+                type: "string",
+                default: "lorem ipsum",
+              },
+            },
+          },
+          listOfObjects: {
+            type: "array",
+            title: "List of objects",
+            items: {
+              type: "object",
+              title: "Object in list",
+              properties: {
+                name: {
+                  type: "string",
+                  default: "Default name",
+                },
+                id: {
+                  type: "number",
+                  default: "an id",
+                },
+              },
+            },
+          },
+          unorderable: {
+            title: "Unorderable items",
+            type: "array",
+            items: {
+              type: "string",
+              default: "lorem ipsum",
+            },
+          },
+          unremovable: {
+            title: "Unremovable items",
+            type: "array",
+            items: {
+              type: "string",
+              default: "lorem ipsum",
+            },
+          },
+          noToolbar: {
+            title: "No add, remove and order buttons",
+            type: "array",
+            items: {
+              type: "string",
+              default: "lorem ipsum",
+            },
+          },
+          fixedNoToolbar: {
+            title: "Fixed array without buttons",
+            type: "array",
+            items: [
+              {
+                title: "A number",
+                type: "number",
+                default: 42,
+              },
+              {
+                title: "A boolean",
+                type: "boolean",
+                default: false,
+              },
+            ],
+            additionalItems: {
+              title: "A string",
+              type: "string",
+              default: "lorem ipsum",
+            },
+          },
+        },
+      };
+
+      const formData = {
+        listOfStrings: ["foo", "bar"],
+        multipleChoicesList: ["foo", "bar"],
+        fixedItemsList: ["Some text", true, 123],
+        minItemsList: [
+          {
+            name: "Default name",
+          },
+          {
+            name: "Default name",
+          },
+          {
+            name: "Default name",
+          },
+        ],
+        defaultsAndMinItems: [
+          "carp",
+          "trout",
+          "bream",
+          "unidentified",
+          "unidentified",
+        ],
+        nestedList: [["lorem", "ipsum"], ["dolor"]],
+        listOfObjects: [
+          { name: "name1", id: 123 },
+          { name: "name2", id: 1234 },
+          { id: 12345 },
+        ],
+        unorderable: ["one", "two"],
+        unremovable: ["one", "two"],
+        noToolbar: ["one", "two"],
+        fixedNoToolbar: [
+          42,
+          true,
+          "additional item one",
+          "additional item two",
+        ],
+      };
+
+      expect(toNameSchema(schema, "", schema.definitions, formData)).eql({
+        $name: "",
+        defaultsAndMinItems: {
+          "0": {
+            $name: "defaultsAndMinItems.0",
+          },
+          "1": {
+            $name: "defaultsAndMinItems.1",
+          },
+          "2": {
+            $name: "defaultsAndMinItems.2",
+          },
+          "3": {
+            $name: "defaultsAndMinItems.3",
+          },
+          "4": {
+            $name: "defaultsAndMinItems.4",
+          },
+        },
+        fixedItemsList: {
+          "0": {
+            $name: "fixedItemsList.0",
+          },
+          "1": {
+            $name: "fixedItemsList.1",
+          },
+          "2": {
+            $name: "fixedItemsList.2",
+          },
+        },
+        fixedNoToolbar: {
+          "0": {
+            $name: "fixedNoToolbar.0",
+          },
+          "1": {
+            $name: "fixedNoToolbar.1",
+          },
+          "2": {
+            $name: "fixedNoToolbar.2",
+          },
+          "3": {
+            $name: "fixedNoToolbar.3",
+          },
+        },
+        listOfObjects: {
+          "0": {
+            $name: "listOfObjects.0",
+            id: {
+              $name: "listOfObjects.0.id",
+            },
+            name: {
+              $name: "listOfObjects.0.name",
+            },
+          },
+          "1": {
+            $name: "listOfObjects.1",
+            id: {
+              $name: "listOfObjects.1.id",
+            },
+            name: {
+              $name: "listOfObjects.1.name",
+            },
+          },
+          "2": {
+            $name: "listOfObjects.2",
+            id: {
+              $name: "listOfObjects.2.id",
+            },
+            name: {
+              $name: "listOfObjects.2.name",
+            },
+          },
+        },
+        listOfStrings: {
+          "0": {
+            $name: "listOfStrings.0",
+          },
+          "1": {
+            $name: "listOfStrings.1",
+          },
+        },
+        minItemsList: {
+          "0": {
+            $name: "minItemsList.0",
+            name: {
+              $name: "minItemsList.0.name",
+            },
+          },
+          "1": {
+            $name: "minItemsList.1",
+            name: {
+              $name: "minItemsList.1.name",
+            },
+          },
+          "2": {
+            $name: "minItemsList.2",
+            name: {
+              $name: "minItemsList.2.name",
+            },
+          },
+        },
+        multipleChoicesList: {
+          "0": {
+            $name: "multipleChoicesList.0",
+          },
+          "1": {
+            $name: "multipleChoicesList.1",
+          },
+        },
+        nestedList: {
+          "0": {
+            "0": {
+              $name: "nestedList.0.0",
+            },
+            "1": {
+              $name: "nestedList.0.1",
+            },
+          },
+          "1": {
+            "0": {
+              $name: "nestedList.1.0",
+            },
+          },
+        },
+        noToolbar: {
+          "0": {
+            $name: "noToolbar.0",
+          },
+          "1": {
+            $name: "noToolbar.1",
+          },
+        },
+        unorderable: {
+          "0": {
+            $name: "unorderable.0",
+          },
+          "1": {
+            $name: "unorderable.1",
+          },
+        },
+        unremovable: {
+          "0": {
+            $name: "unremovable.0",
+          },
+          "1": {
+            $name: "unremovable.1",
+          },
         },
       });
     });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -18,6 +18,7 @@ import {
   shouldRender,
   toDateString,
   toIdSchema,
+  toNameSchema,
   guessType,
 } from "../src/utils";
 
@@ -1322,6 +1323,36 @@ describe("utils", () => {
         $id: "rjsf",
         foo: { $id: "rjsf_foo" },
         bar: { $id: "rjsf_bar" },
+      });
+    });
+  });
+
+  describe("toNameSchema", () => {
+    it("should return a nameSchema for root field", () => {
+      const schema = { type: "string" };
+
+      expect(toNameSchema(schema)).eql({ name: "" });
+    });
+
+    it("should return an idSchema for nested objects", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          level1: {
+            type: "object",
+            properties: {
+              level2: { type: "string" },
+            },
+          },
+        },
+      };
+
+      expect(toNameSchema(schema)).eql({
+        name: "",
+        level1: {
+          name: "level1",
+          level2: { name: "level1.level2" },
+        },
       });
     });
   });


### PR DESCRIPTION
### Reasons for making this change

Please see #1190 for details. This PR is accomplishes the same goal as #1190, but this solution does not rely on changing the DOM.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
