### PR TITLE
Default type to `object` if undefined

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -76,6 +76,10 @@ export function getSchemaType(schema) {
     return "string";
   }
 
+  if ((!type && schema.properties) || schema.additionalProperties) {
+    return "object";
+  }
+
   if (type instanceof Array && type.length === 2 && type.includes("null")) {
     return type.find(type => type !== "null");
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,7 +76,7 @@ export function getSchemaType(schema) {
     return "string";
   }
 
-  if ((!type && schema.properties) || schema.additionalProperties) {
+  if (!type && (schema.properties || schema.additionalProperties)) {
     return "object";
   }
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1544,11 +1544,22 @@ describe("utils", () => {
         schema: { type: ["integer", "null"] },
         expected: "integer",
       },
+      {
+        schema: { properties: {} },
+        expected: "object",
+      },
+      {
+        schema: { additionalProperties: {} },
+        expected: "object",
+      },
     ];
 
     it("should correctly guess the type of a schema", () => {
       for (const test of cases) {
-        expect(getSchemaType(test.schema)).eql(test.expected);
+        expect(getSchemaType(test.schema)).eql(
+          test.expected,
+          `${JSON.stringify(test.schema)} should guess type of ${test.expected}`
+        );
       }
     });
   });


### PR DESCRIPTION
### Reasons for making this change
Fixes #1265

Added tests and confirmed working on the local test app:
http://localhost:8080/#eyJmb3JtRGF0YSI6e30sInNjaGVtYSI6eyJwcm9wZXJ0aWVzIjp7ImEiOnsidHlwZSI6InN0cmluZyJ9fX0sInVpU2NoZW1hIjp7fX0=

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
