### PR TITLE
Add example for collapsing fields using custom FieldTemplate

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -205,6 +205,7 @@ This component follows [JSON Schema](http://json-schema.org/documentation.html) 
  - 2 columns form with CSS and FieldTemplate: <https://jsfiddle.net/n1k0/bw0ffnz4/1/>
  - Validate and submit form from external control: <https://jsfiddle.net/spacebaboon/g5a1re63/>
  - Custom component for Help text with `ui:help`: <https://codesandbox.io/s/14pqx97xl7/>
+ - Collapsing / Showing and Hiding individual fields: <https://codesandbox.io/s/examplereactjsonschemaformcollapsefieldtemplate-t41dn>
 
 ## Contributing
 
@@ -260,7 +261,7 @@ $ npm run tdd
 
 #### Code coverage
 
-Code coverage reports are generated using [nyc](https://github.com/istanbuljs/nyc) each time the `npm test-coverage` script is run. 
+Code coverage reports are generated using [nyc](https://github.com/istanbuljs/nyc) each time the `npm test-coverage` script is run.
 The full report can be seen by opening `./coverage/lcov-report/index.html`.
 
 ### Releasing
@@ -289,7 +290,7 @@ A: Probably not. We use Bootstrap v3 and it works fine for our needs. We would l
 
 ### Q: Is there a way to "collapse" fields, for instance to show/hide individual fields?
 
-A: There's no specific built-in way to do this, but you can write your own FieldTemplate that supports hiding/showing fields according to user input. We don't yet have an example of this use, but if you write one, please add it to the "tips and tricks" section, above. See also: [#268](https://github.com/mozilla-services/react-jsonschema-form/issues/268), [#304](https://github.com/mozilla-services/react-jsonschema-form/pull/304), [#598](https://github.com/mozilla-services/react-jsonschema-form/issues/598), [#920](https://github.com/mozilla-services/react-jsonschema-form/issues/920).
+A: There's no specific built-in way to do this, but you can write your own FieldTemplate that supports hiding/showing fields according to user input. See the "tips and tricks" section above for one example implementation. See also: [#268](https://github.com/mozilla-services/react-jsonschema-form/issues/268), [#304](https://github.com/mozilla-services/react-jsonschema-form/pull/304), [#598](https://github.com/mozilla-services/react-jsonschema-form/issues/598), [#920](https://github.com/mozilla-services/react-jsonschema-form/issues/920).
 
 ## License
 


### PR DESCRIPTION
### Reasons for making this change

The [current documentation](https://react-jsonschema-form.readthedocs.io/en/latest/#q-is-there-a-way-to-collapse-fields-for-instance-to-showhide-individual-fields) contains a call for an example of collapsing fields in a form. This PR adds such an example, using a custom FieldTemplate.

This relates to #268, and hopefully resolves #598 -- the example I've linked doesn't show it, but I currently have also implemented an "Expand / Hide All" button using the React state of the component housing the `<Form>` component and the `formContext` object that's used in the linked example.

### Checklist

* [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
