### PR TITLE
Pass along label/placeholder/registry for custom multiselect widgets.

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -422,6 +422,8 @@ class ArrayField extends Component {
       disabled,
       readonly,
       required,
+      label,
+      placeholder,
       autofocus,
       onBlur,
       onFocus,
@@ -446,10 +448,13 @@ class ArrayField extends Component {
         onFocus={onFocus}
         options={options}
         schema={schema}
+        registry={registry}
         value={items}
         disabled={disabled}
         readonly={readonly}
         required={required}
+        label={label}
+        placeholder={placeholder}
         formContext={formContext}
         autofocus={autofocus}
         rawErrors={rawErrors}


### PR DESCRIPTION
### Reasons for making this change

Inconsistency between properties passed to custom select widgets. When widget is for a question of type string with an enum, the custom widget receives props for label, placeholder, and registry. When widget is used on a multi-select field, these properties are missing.

Sample Schema:
```
{
	type: 'object',
	properties: {
		selectQuestion: {
			title: 'Select Question',
			type: 'string',
			enum: ['foo', 'bar', 'baz', 'qux'],
			enumNames: ['foo', 'bar', 'baz', 'qux']
		},
		multiSelectQuestion: {
			title: 'Multi-Select Question',
			type: 'array',
			uniqueItems: true,
			items: {
				type: 'string',
				enum: ['foo', 'bar', 'baz', 'qux'],
				enumNames: ['foo', 'bar', 'baz', 'qux']
			}
		}
}
```

Sample UI Schema:
```
{
	selectQuestion: {
		'ui:widget': 'select'
	},
	multiSelectQuestion: {
		'ui:widget': 'select'
	}
}
```

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [X I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
