### PR TITLE
Fix defaults with oneof/anyof and nested dependencies

### DIFF
--- a/src/components/fields/MultiSchemaField.js
+++ b/src/components/fields/MultiSchemaField.js
@@ -6,8 +6,8 @@ import {
   getWidget,
   guessType,
   retrieveSchema,
+  getMatchingOption,
 } from "../../utils";
-import { isValid } from "../../validate";
 
 class AnyOfField extends Component {
   constructor(props) {
@@ -35,65 +35,11 @@ class AnyOfField extends Component {
 
   getMatchingOption(formData, options) {
     const { definitions } = this.props.registry;
-    for (let i = 0; i < options.length; i++) {
-      // Assign the definitions to the option, otherwise the match can fail if
-      // the new option uses a $ref
-      const option = Object.assign(
-        {
-          definitions,
-        },
-        options[i]
-      );
 
-      // If the schema describes an object then we need to add slightly more
-      // strict matching to the schema, because unless the schema uses the
-      // "requires" keyword, an object will match the schema as long as it
-      // doesn't have matching keys with a conflicting type. To do this we use an
-      // "anyOf" with an array of requires. This augmentation expresses that the
-      // schema should match if any of the keys in the schema are present on the
-      // object and pass validation.
-      if (option.properties) {
-        // Create an "anyOf" schema that requires at least one of the keys in the
-        // "properties" object
-        const requiresAnyOf = {
-          anyOf: Object.keys(option.properties).map(key => ({
-            required: [key],
-          })),
-        };
-
-        let augmentedSchema;
-
-        // If the "anyOf" keyword already exists, wrap the augmentation in an "allOf"
-        if (option.anyOf) {
-          // Create a shallow clone of the option
-          const { ...shallowClone } = option;
-
-          if (!shallowClone.allOf) {
-            shallowClone.allOf = [];
-          } else {
-            // If "allOf" already exists, shallow clone the array
-            shallowClone.allOf = shallowClone.allOf.slice();
-          }
-
-          shallowClone.allOf.push(requiresAnyOf);
-
-          augmentedSchema = shallowClone;
-        } else {
-          augmentedSchema = Object.assign({}, option, requiresAnyOf);
-        }
-
-        // Remove the "required" field as it's likely that not all fields have
-        // been filled in yet, which will mean that the schema is not valid
-        delete augmentedSchema.required;
-
-        if (isValid(augmentedSchema, formData)) {
-          return i;
-        }
-      } else if (isValid(options[i], formData)) {
-        return i;
-      }
+    let option = getMatchingOption(formData, options, definitions);
+    if (option !== 0) {
+      return option;
     }
-
     // If the form data matches none of the options, use the currently selected
     // option, assuming it's available; otherwise use the first option
     return this && this.state ? this.state.selectedOption : 0;

--- a/src/components/fields/MultiSchemaField.js
+++ b/src/components/fields/MultiSchemaField.js
@@ -6,6 +6,7 @@ import {
   getWidget,
   guessType,
   retrieveSchema,
+  getDefaultFormState,
   getMatchingOption,
 } from "../../utils";
 
@@ -57,11 +58,12 @@ class AnyOfField extends Component {
 
     // If the new option is of type object and the current data is an object,
     // discard properties added using the old option.
+    let newFormData = undefined;
     if (
       guessType(formData) === "object" &&
       (newOption.type === "object" || newOption.properties)
     ) {
-      const newFormData = Object.assign({}, formData);
+      newFormData = Object.assign({}, formData);
 
       const optionsToDiscard = options.slice();
       optionsToDiscard.splice(selectedOption, 1);
@@ -76,11 +78,11 @@ class AnyOfField extends Component {
           }
         }
       }
-
-      onChange(newFormData);
-    } else {
-      onChange(undefined);
     }
+    // Call getDefaultFormState to make sure defaults are populated on change.
+    onChange(
+      getDefaultFormState(options[selectedOption], newFormData, definitions)
+    );
 
     this.setState({
       selectedOption: parseInt(option, 10),

--- a/src/utils.js
+++ b/src/utils.js
@@ -562,7 +562,7 @@ function resolveDependencies(schema, definitions, formData) {
       ];
   } else if ("anyOf" in resolvedSchema) {
     resolvedSchema =
-      resolvedSchema.oneOf[
+      resolvedSchema.anyOf[
         getMatchingOption(formData, resolvedSchema.anyOf, definitions)
       ];
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -139,7 +139,7 @@ export function hasWidget(schema, widget, registeredWidgets = {}) {
   }
 }
 
-export function computeDefaults(schema, parentDefaults, definitions = {}) {
+function computeDefaults(schema, parentDefaults, definitions = {}) {
   // Compute the defaults recursively: give highest priority to deepest nodes.
   let defaults = parentDefaults;
   if (isObject(defaults) && isObject(schema.default)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -157,6 +157,16 @@ export function computeDefaults(schema, parentDefaults, definitions = {}) {
     defaults = schema.items.map(itemSchema =>
       computeDefaults(itemSchema, undefined, definitions)
     );
+  } else if ("oneOf" in schema) {
+    schema =
+      schema["oneOf"][
+        getMatchingOption(undefined, schema["oneOf"], definitions)
+      ];
+  } else if ("anyOf" in schema) {
+    schema =
+      schema["anyOf"][
+        getMatchingOption(undefined, schema["anyOf"], definitions)
+      ];
   }
   // Not defaults defined for this node, fallback to generic typed ones.
   if (typeof defaults === "undefined") {

--- a/src/utils.js
+++ b/src/utils.js
@@ -549,6 +549,17 @@ export function retrieveSchema(schema, definitions = {}, formData = {}) {
 function resolveDependencies(schema, definitions, formData) {
   // Drop the dependencies from the source schema.
   let { dependencies = {}, ...resolvedSchema } = schema;
+  if ("oneOf" in resolvedSchema) {
+    resolvedSchema =
+      resolvedSchema["oneOf"][
+        getMatchingOption(formData, resolvedSchema["oneOf"], definitions)
+      ];
+  } else if ("anyOf" in resolvedSchema) {
+    resolvedSchema =
+      resolvedSchema["anyOf"][
+        getMatchingOption(formData, resolvedSchema["anyOf"], definitions)
+      ];
+  }
   // Process dependencies updating the local schema properties as appropriate.
   for (const dependencyKey in dependencies) {
     // Skip this dependency if its trigger property is not present.

--- a/src/utils.js
+++ b/src/utils.js
@@ -162,14 +162,10 @@ function computeDefaults(schema, parentDefaults, definitions, formData) {
     );
   } else if ("oneOf" in schema) {
     schema =
-      schema["oneOf"][
-        getMatchingOption(undefined, schema["oneOf"], definitions)
-      ];
+      schema.oneOf[getMatchingOption(undefined, schema.oneOf, definitions)];
   } else if ("anyOf" in schema) {
     schema =
-      schema["anyOf"][
-        getMatchingOption(undefined, schema["anyOf"], definitions)
-      ];
+      schema.anyOf[getMatchingOption(undefined, schema.anyOf, definitions)];
   }
 
   // Not defaults defined for this node, fallback to generic typed ones.
@@ -561,13 +557,13 @@ function resolveDependencies(schema, definitions, formData) {
   let { dependencies = {}, ...resolvedSchema } = schema;
   if ("oneOf" in resolvedSchema) {
     resolvedSchema =
-      resolvedSchema["oneOf"][
-        getMatchingOption(formData, resolvedSchema["oneOf"], definitions)
+      resolvedSchema.oneOf[
+        getMatchingOption(formData, resolvedSchema.oneOf, definitions)
       ];
   } else if ("anyOf" in resolvedSchema) {
     resolvedSchema =
-      resolvedSchema["anyOf"][
-        getMatchingOption(formData, resolvedSchema["anyOf"], definitions)
+      resolvedSchema.oneOf[
+        getMatchingOption(formData, resolvedSchema.anyOf, definitions)
       ];
   }
   // Process dependencies updating the local schema properties as appropriate.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import React from "react";
-import validateFormData from "./validate";
+import validateFormData, { isValid } from "./validate";
 import fill from "core-js/library/fn/array/fill";
 
 export const ADDITIONAL_PROPERTY_FLAG = "__additional_property";
@@ -139,7 +139,7 @@ export function hasWidget(schema, widget, registeredWidgets = {}) {
   }
 }
 
-function computeDefaults(schema, parentDefaults, definitions = {}) {
+export function computeDefaults(schema, parentDefaults, definitions = {}) {
   // Compute the defaults recursively: give highest priority to deepest nodes.
   let defaults = parentDefaults;
   if (isObject(defaults) && isObject(schema.default)) {
@@ -869,4 +869,66 @@ export function rangeSpec(schema) {
     spec.max = schema.maximum;
   }
   return spec;
+}
+
+export function getMatchingOption(formData, options, definitions) {
+  for (let i = 0; i < options.length; i++) {
+    // Assign the definitions to the option, otherwise the match can fail if
+    // the new option uses a $ref
+    const option = Object.assign(
+      {
+        definitions,
+      },
+      options[i]
+    );
+
+    // If the schema describes an object then we need to add slightly more
+    // strict matching to the schema, because unless the schema uses the
+    // "requires" keyword, an object will match the schema as long as it
+    // doesn't have matching keys with a conflicting type. To do this we use an
+    // "anyOf" with an array of requires. This augmentation expresses that the
+    // schema should match if any of the keys in the schema are present on the
+    // object and pass validation.
+    if (option.properties) {
+      // Create an "anyOf" schema that requires at least one of the keys in the
+      // "properties" object
+      const requiresAnyOf = {
+        anyOf: Object.keys(option.properties).map(key => ({
+          required: [key],
+        })),
+      };
+
+      let augmentedSchema;
+
+      // If the "anyOf" keyword already exists, wrap the augmentation in an "allOf"
+      if (option.anyOf) {
+        // Create a shallow clone of the option
+        const { ...shallowClone } = option;
+
+        if (!shallowClone.allOf) {
+          shallowClone.allOf = [];
+        } else {
+          // If "allOf" already exists, shallow clone the array
+          shallowClone.allOf = shallowClone.allOf.slice();
+        }
+
+        shallowClone.allOf.push(requiresAnyOf);
+
+        augmentedSchema = shallowClone;
+      } else {
+        augmentedSchema = Object.assign({}, option, requiresAnyOf);
+      }
+
+      // Remove the "required" field as it's likely that not all fields have
+      // been filled in yet, which will mean that the schema is not valid
+      delete augmentedSchema.required;
+
+      if (isValid(augmentedSchema, formData)) {
+        return i;
+      }
+    } else if (isValid(options[i], formData)) {
+      return i;
+    }
+  }
+  return 0;
 }

--- a/test/anyOf_test.js
+++ b/test/anyOf_test.js
@@ -54,6 +54,29 @@ describe("anyOf", () => {
     expect(node.querySelectorAll("select")).to.have.length.of(1);
   });
 
+  it("should assign a default value", () => {
+    const { comp } = createFormComponent({
+      schema: {
+        anyOf: [
+          {
+            type: "object",
+            properties: {
+              foo: { type: "string", default: "defaultfoo" },
+            },
+          },
+          {
+            type: "object",
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(comp.state.formData).eql({ foo: "defaultfoo" });
+  });
+
   it("should render a custom widget", () => {
     const schema = {
       type: "object",

--- a/test/anyOf_test.js
+++ b/test/anyOf_test.js
@@ -54,8 +54,8 @@ describe("anyOf", () => {
     expect(node.querySelectorAll("select")).to.have.length.of(1);
   });
 
-  it("should assign a default value", () => {
-    const { comp } = createFormComponent({
+  it("should assign a default value and set defaults on option change", () => {
+    const { comp, node } = createFormComponent({
       schema: {
         anyOf: [
           {
@@ -67,7 +67,7 @@ describe("anyOf", () => {
           {
             type: "object",
             properties: {
-              bar: { type: "string" },
+              foo: { type: "string", default: "defaultbar" },
             },
           },
         ],
@@ -75,6 +75,14 @@ describe("anyOf", () => {
     });
 
     expect(comp.state.formData).eql({ foo: "defaultfoo" });
+
+    const $select = node.querySelector("select");
+
+    Simulate.change($select, {
+      target: { value: $select.options[1].value },
+    });
+
+    expect(comp.state.formData).eql({ foo: "defaultbar" });
   });
 
   it("should render a custom widget", () => {

--- a/test/oneOf_test.js
+++ b/test/oneOf_test.js
@@ -54,8 +54,8 @@ describe("oneOf", () => {
     expect(node.querySelectorAll("select")).to.have.length.of(1);
   });
 
-  it("should assign a default value", () => {
-    const { comp } = createFormComponent({
+  it("should assign a default value and set defaults on option change", () => {
+    const { comp, node } = createFormComponent({
       schema: {
         oneOf: [
           {
@@ -67,7 +67,7 @@ describe("oneOf", () => {
           {
             type: "object",
             properties: {
-              bar: { type: "string" },
+              foo: { type: "string", default: "defaultbar" },
             },
           },
         ],
@@ -75,6 +75,14 @@ describe("oneOf", () => {
     });
 
     expect(comp.state.formData).eql({ foo: "defaultfoo" });
+
+    const $select = node.querySelector("select");
+
+    Simulate.change($select, {
+      target: { value: $select.options[1].value },
+    });
+
+    expect(comp.state.formData).eql({ foo: "defaultbar" });
   });
 
   it("should render a custom widget", () => {

--- a/test/oneOf_test.js
+++ b/test/oneOf_test.js
@@ -54,6 +54,29 @@ describe("oneOf", () => {
     expect(node.querySelectorAll("select")).to.have.length.of(1);
   });
 
+  it("should assign a default value", () => {
+    const { comp } = createFormComponent({
+      schema: {
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              foo: { type: "string", default: "defaultfoo" },
+            },
+          },
+          {
+            type: "object",
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(comp.state.formData).eql({ foo: "defaultfoo" });
+  });
+
   it("should render a custom widget", () => {
     const schema = {
       type: "object",

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -358,6 +358,41 @@ describe("utils", () => {
             },
           });
         });
+
+        it("should populate defaults for oneOf + dependencies", () => {
+          const schema = {
+            oneOf: [
+              {
+                type: "object",
+                properties: {
+                  name: {
+                    type: "string",
+                  },
+                },
+              },
+            ],
+            dependencies: {
+              name: {
+                oneOf: [
+                  {
+                    properties: {
+                      name: {
+                        type: "string",
+                      },
+                      grade: {
+                        default: "A",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          };
+          expect(getDefaultFormState(schema, { name: "Name" })).eql({
+            name: "Name",
+            grade: "A",
+          });
+        });
       });
 
       describe("getDefaultFormState with anyOf", () => {
@@ -401,6 +436,41 @@ describe("utils", () => {
             name: {
               first: "First Name",
             },
+          });
+        });
+
+        it("should populate defaults for anyOf + dependencies", () => {
+          const schema = {
+            anyOf: [
+              {
+                type: "object",
+                properties: {
+                  name: {
+                    type: "string",
+                  },
+                },
+              },
+            ],
+            dependencies: {
+              name: {
+                oneOf: [
+                  {
+                    properties: {
+                      name: {
+                        type: "string",
+                      },
+                      grade: {
+                        default: "A",
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          };
+          expect(getDefaultFormState(schema, { name: "Name" })).eql({
+            name: "Name",
+            grade: "A",
           });
         });
       });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -476,6 +476,122 @@ describe("utils", () => {
         });
       });
     });
+
+    describe("with dependencies", () => {
+      it("should populate defaults for dependencies", () => {
+        const schema = {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+            },
+          },
+          dependencies: {
+            name: {
+              oneOf: [
+                {
+                  properties: {
+                    name: {
+                      type: "string",
+                    },
+                    grade: {
+                      type: "string",
+                      default: "A",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        };
+        expect(getDefaultFormState(schema, { name: "Name" })).eql({
+          name: "Name",
+          grade: "A",
+        });
+      });
+
+      it("should populate defaults for nested dependencies", () => {
+        const schema = {
+          type: "object",
+          properties: {
+            foo: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                },
+              },
+              dependencies: {
+                name: {
+                  oneOf: [
+                    {
+                      properties: {
+                        name: {
+                          type: "string",
+                        },
+                        grade: {
+                          type: "string",
+                          default: "A",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        };
+        expect(getDefaultFormState(schema, { foo: { name: "Name" } })).eql({
+          foo: {
+            name: "Name",
+            grade: "A",
+          },
+        });
+      });
+
+      it("should populate defaults for nested oneOf + dependencies", () => {
+        const schema = {
+          type: "object",
+          properties: {
+            foo: {
+              oneOf: [
+                {
+                  type: "object",
+                  properties: {
+                    name: {
+                      type: "string",
+                    },
+                  },
+                },
+              ],
+              dependencies: {
+                name: {
+                  oneOf: [
+                    {
+                      properties: {
+                        name: {
+                          type: "string",
+                        },
+                        grade: {
+                          type: "string",
+                          default: "A",
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        };
+        expect(getDefaultFormState(schema, { foo: { name: "Name" } })).eql({
+          foo: {
+            name: "Name",
+            grade: "A",
+          },
+        });
+      });
+    });
   });
 
   describe("asNumber()", () => {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -314,6 +314,96 @@ describe("utils", () => {
           array: ["foo"],
         });
       });
+
+      describe("getDefaultFormState with oneOf", () => {
+        it("should populate defaults for oneOf", () => {
+          const schema = {
+            type: "object",
+            properties: {
+              name: {
+                type: "string",
+                oneOf: [
+                  { type: "string", default: "a" },
+                  { type: "string", default: "b" },
+                ],
+              },
+            },
+          };
+          expect(getDefaultFormState(schema, {})).eql({
+            name: "a",
+          });
+        });
+
+        it("should populate nested default values for oneOf", () => {
+          const schema = {
+            type: "object",
+            properties: {
+              name: {
+                type: "object",
+                oneOf: [
+                  {
+                    type: "object",
+                    properties: {
+                      first: { type: "string", default: "First Name" },
+                    },
+                  },
+                  { type: "string", default: "b" },
+                ],
+              },
+            },
+          };
+          expect(getDefaultFormState(schema, {})).eql({
+            name: {
+              first: "First Name",
+            },
+          });
+        });
+      });
+
+      describe("getDefaultFormState with anyOf", () => {
+        it("should populate defaults for anyOf", () => {
+          const schema = {
+            type: "object",
+            properties: {
+              name: {
+                type: "string",
+                anyOf: [
+                  { type: "string", default: "a" },
+                  { type: "string", default: "b" },
+                ],
+              },
+            },
+          };
+          expect(getDefaultFormState(schema, {})).eql({
+            name: "a",
+          });
+        });
+
+        it("should populate nested default values for anyOf", () => {
+          const schema = {
+            type: "object",
+            properties: {
+              name: {
+                type: "object",
+                anyOf: [
+                  {
+                    type: "object",
+                    properties: {
+                      first: { type: "string", default: "First Name" },
+                    },
+                  },
+                  { type: "string", default: "b" },
+                ],
+              },
+            },
+          };
+          expect(getDefaultFormState(schema, {})).eql({
+            name: {
+              first: "First Name",
+            },
+          });
+        });
+      });
     });
   });
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -314,164 +314,165 @@ describe("utils", () => {
           array: ["foo"],
         });
       });
+    });
 
-      describe("getDefaultFormState with oneOf", () => {
-        it("should populate defaults for oneOf", () => {
-          const schema = {
-            type: "object",
-            properties: {
-              name: {
-                type: "string",
-                oneOf: [
-                  { type: "string", default: "a" },
-                  { type: "string", default: "b" },
-                ],
-              },
-            },
-          };
-          expect(getDefaultFormState(schema, {})).eql({
-            name: "a",
-          });
-        });
-
-        it("should populate nested default values for oneOf", () => {
-          const schema = {
-            type: "object",
-            properties: {
-              name: {
-                type: "object",
-                oneOf: [
-                  {
-                    type: "object",
-                    properties: {
-                      first: { type: "string", default: "First Name" },
-                    },
-                  },
-                  { type: "string", default: "b" },
-                ],
-              },
-            },
-          };
-          expect(getDefaultFormState(schema, {})).eql({
+    describe("defaults with oneOf", () => {
+      it("should populate defaults for oneOf", () => {
+        const schema = {
+          type: "object",
+          properties: {
             name: {
-              first: "First Name",
+              type: "string",
+              oneOf: [
+                { type: "string", default: "a" },
+                { type: "string", default: "b" },
+              ],
             },
-          });
-        });
-
-        it("should populate defaults for oneOf + dependencies", () => {
-          const schema = {
-            oneOf: [
-              {
-                type: "object",
-                properties: {
-                  name: {
-                    type: "string",
-                  },
-                },
-              },
-            ],
-            dependencies: {
-              name: {
-                oneOf: [
-                  {
-                    properties: {
-                      name: {
-                        type: "string",
-                      },
-                      grade: {
-                        default: "A",
-                      },
-                    },
-                  },
-                ],
-              },
-            },
-          };
-          expect(getDefaultFormState(schema, { name: "Name" })).eql({
-            name: "Name",
-            grade: "A",
-          });
+          },
+        };
+        expect(getDefaultFormState(schema, {})).eql({
+          name: "a",
         });
       });
 
-      describe("getDefaultFormState with anyOf", () => {
-        it("should populate defaults for anyOf", () => {
-          const schema = {
-            type: "object",
-            properties: {
-              name: {
-                type: "string",
-                anyOf: [
-                  { type: "string", default: "a" },
-                  { type: "string", default: "b" },
-                ],
-              },
-            },
-          };
-          expect(getDefaultFormState(schema, {})).eql({
-            name: "a",
-          });
-        });
-
-        it("should populate nested default values for anyOf", () => {
-          const schema = {
-            type: "object",
-            properties: {
-              name: {
-                type: "object",
-                anyOf: [
-                  {
-                    type: "object",
-                    properties: {
-                      first: { type: "string", default: "First Name" },
-                    },
-                  },
-                  { type: "string", default: "b" },
-                ],
-              },
-            },
-          };
-          expect(getDefaultFormState(schema, {})).eql({
+      it("should populate nested default values for oneOf", () => {
+        const schema = {
+          type: "object",
+          properties: {
             name: {
-              first: "First Name",
-            },
-          });
-        });
-
-        it("should populate defaults for anyOf + dependencies", () => {
-          const schema = {
-            anyOf: [
-              {
-                type: "object",
-                properties: {
-                  name: {
-                    type: "string",
+              type: "object",
+              oneOf: [
+                {
+                  type: "object",
+                  properties: {
+                    first: { type: "string", default: "First Name" },
                   },
                 },
-              },
-            ],
-            dependencies: {
-              name: {
-                oneOf: [
-                  {
-                    properties: {
-                      name: {
-                        type: "string",
-                      },
-                      grade: {
-                        default: "A",
-                      },
-                    },
-                  },
-                ],
+                { type: "string", default: "b" },
+              ],
+            },
+          },
+        };
+        expect(getDefaultFormState(schema, {})).eql({
+          name: {
+            first: "First Name",
+          },
+        });
+      });
+
+      it("should populate defaults for oneOf + dependencies", () => {
+        const schema = {
+          oneOf: [
+            {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                },
               },
             },
-          };
-          expect(getDefaultFormState(schema, { name: "Name" })).eql({
-            name: "Name",
-            grade: "A",
-          });
+          ],
+          dependencies: {
+            name: {
+              oneOf: [
+                {
+                  properties: {
+                    name: {
+                      type: "string",
+                    },
+                    grade: {
+                      default: "A",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        };
+        expect(getDefaultFormState(schema, { name: "Name" })).eql({
+          name: "Name",
+          grade: "A",
+        });
+      });
+    });
+
+    describe("defaults with anyOf", () => {
+      it("should populate defaults for anyOf", () => {
+        const schema = {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              anyOf: [
+                { type: "string", default: "a" },
+                { type: "string", default: "b" },
+              ],
+            },
+          },
+        };
+        expect(getDefaultFormState(schema, {})).eql({
+          name: "a",
+        });
+      });
+
+      it("should populate nested default values for anyOf", () => {
+        const schema = {
+          type: "object",
+          properties: {
+            name: {
+              type: "object",
+              anyOf: [
+                {
+                  type: "object",
+                  properties: {
+                    first: { type: "string", default: "First Name" },
+                  },
+                },
+                { type: "string", default: "b" },
+              ],
+            },
+          },
+        };
+        expect(getDefaultFormState(schema, {})).eql({
+          name: {
+            first: "First Name",
+          },
+        });
+      });
+
+      it("should populate defaults for anyOf + dependencies", () => {
+        const schema = {
+          anyOf: [
+            {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                },
+              },
+            },
+          ],
+          dependencies: {
+            name: {
+              oneOf: [
+                {
+                  properties: {
+                    name: {
+                      type: "string",
+                    },
+                    grade: {
+                      type: "string",
+                      default: "A",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        };
+        expect(getDefaultFormState(schema, { name: "Name" })).eql({
+          name: "Name",
+          grade: "A",
         });
       });
     });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -440,7 +440,7 @@ describe("utils", () => {
         });
       });
 
-      it.only("should populate defaults for anyOf + dependencies", () => {
+      it("should populate defaults for anyOf + dependencies", () => {
         const schema = {
           anyOf: [
             {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -440,7 +440,7 @@ describe("utils", () => {
         });
       });
 
-      it("should populate defaults for anyOf + dependencies", () => {
+      it.only("should populate defaults for anyOf + dependencies", () => {
         const schema = {
           anyOf: [
             {


### PR DESCRIPTION
### Reasons for making this change

Fixes #1293 - default with oneof/anyof
Fixes #1229, fixes #768 - default with nested dependencies

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
