### PR TITLE
doc: remove cs-format from PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,5 @@ If this is related to existing tickets, include links to them as well.
 * [ ] **I'm adding or updating code**
   - [ ] I've added and/or updated tests
   - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
-  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
 * [ ] **I'm adding a new feature**
   - [ ] I've updated the playground with an example use of the feature


### PR DESCRIPTION
### Reasons for making this change

`npm run cs-format` is already run in the precommit hook.

### Checklist

* [x] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
