### PR TITLE
fix: populate defaults for nested dependencies when formData is undefined

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -144,7 +144,13 @@ export function hasWidget(schema, widget, registeredWidgets = {}) {
   }
 }
 
-function computeDefaults(schema, parentDefaults, definitions, formData = {}) {
+function computeDefaults(
+  schema,
+  parentDefaults,
+  definitions,
+  rawFormData = {}
+) {
+  const formData = isObject(rawFormData) ? rawFormData : {};
   // Compute the defaults recursively: give highest priority to deepest nodes.
   let defaults = parentDefaults;
   if (isObject(defaults) && isObject(schema.default)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -144,7 +144,7 @@ export function hasWidget(schema, widget, registeredWidgets = {}) {
   }
 }
 
-function computeDefaults(schema, parentDefaults, definitions, formData) {
+function computeDefaults(schema, parentDefaults, definitions, formData = {}) {
   // Compute the defaults recursively: give highest priority to deepest nodes.
   let defaults = parentDefaults;
   if (isObject(defaults) && isObject(schema.default)) {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -615,7 +615,7 @@ describe("utils", () => {
         });
       });
 
-      it("should populate defaults for nested dependencies when formData is undefined", () => {
+      it("should populate defaults for nested dependencies when formData passed to computeDefaults is undefined", () => {
         const schema = {
           type: "object",
           properties: {
@@ -661,7 +661,7 @@ describe("utils", () => {
         });
       });
 
-      it("should populate defaults for nested dependencies when formData is null", () => {
+      it("should not crash for defaults for nested dependencies when formData passed to computeDefaults is null", () => {
         const schema = {
           type: "object",
           properties: {
@@ -698,11 +698,9 @@ describe("utils", () => {
             },
           },
         };
-        expect(getDefaultFormState(schema, null)).eql({
+        expect(getDefaultFormState(schema, { can_1: { phy: null } })).eql({
           can_1: {
-            phy: {
-              bit_rate_cfg_mode: 0,
-            },
+            phy: null,
           },
         });
       });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -660,6 +660,52 @@ describe("utils", () => {
           },
         });
       });
+
+      it("should populate defaults for nested dependencies when formData is null", () => {
+        const schema = {
+          type: "object",
+          properties: {
+            can_1: {
+              type: "object",
+              properties: {
+                phy: {
+                  title: "Physical",
+                  description: "XYZ",
+                  type: "object",
+                  properties: {
+                    bit_rate_cfg_mode: {
+                      title: "Sub title",
+                      description: "XYZ",
+                      type: "integer",
+                      default: 0,
+                    },
+                  },
+                  dependencies: {
+                    bit_rate_cfg_mode: {
+                      oneOf: [
+                        {
+                          properties: {
+                            bit_rate_cfg_mode: {
+                              enum: [0],
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        expect(getDefaultFormState(schema, null)).eql({
+          can_1: {
+            phy: {
+              bit_rate_cfg_mode: 0,
+            },
+          },
+        });
+      });
     });
   });
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -614,6 +614,52 @@ describe("utils", () => {
           },
         });
       });
+
+      it("should populate defaults for nested dependencies when formData is undefined", () => {
+        const schema = {
+          type: "object",
+          properties: {
+            can_1: {
+              type: "object",
+              properties: {
+                phy: {
+                  title: "Physical",
+                  description: "XYZ",
+                  type: "object",
+                  properties: {
+                    bit_rate_cfg_mode: {
+                      title: "Sub title",
+                      description: "XYZ",
+                      type: "integer",
+                      default: 0,
+                    },
+                  },
+                  dependencies: {
+                    bit_rate_cfg_mode: {
+                      oneOf: [
+                        {
+                          properties: {
+                            bit_rate_cfg_mode: {
+                              enum: [0],
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        expect(getDefaultFormState(schema, undefined)).eql({
+          can_1: {
+            phy: {
+              bit_rate_cfg_mode: 0,
+            },
+          },
+        });
+      });
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

Fixes #1311. It looks like the problem is that formData is not defaulted to `{}` when populating defaults for dependencies, so then when formData is undefined / null, it crashes.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
