### PR TITLE
Pass registry to ArrayFieldTemplate

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -406,6 +406,7 @@ class ArrayField extends Component {
       formContext,
       formData,
       rawErrors,
+      registry,
     };
 
     // Check if a custom render function was passed in

--- a/test/ArrayFieldTemplate_test.js
+++ b/test/ArrayFieldTemplate_test.js
@@ -1,5 +1,4 @@
 import React, { PureComponent } from "react";
-
 import { expect } from "chai";
 import { createFormComponent, createSandbox } from "./test_utils";
 
@@ -38,31 +37,6 @@ describe("ArrayFieldTemplate", () => {
         </div>
       );
     }
-
-    describe("Stateful ArrayFieldTemplate", () => {
-      class ArrayFieldTemplate extends PureComponent {
-        render() {
-          return (
-            <div className="field-content">
-              {this.props.items.map((item, i) => (
-                <div key={i}>item.children</div>
-              ))}
-            </div>
-          );
-        }
-      }
-
-      it("should render a stateful custom component", () => {
-        const { node } = createFormComponent({
-          schema: { type: "array", items: { type: "string" } },
-          formData,
-          ArrayFieldTemplate,
-        });
-        expect(
-          node.querySelectorAll(".field-array .field-content div")
-        ).to.have.length.of(3);
-      });
-    });
 
     describe("not fixed items", () => {
       const schema = {
@@ -173,6 +147,47 @@ describe("ArrayFieldTemplate", () => {
         expect(
           node.querySelectorAll(".custom-array-item-move-down")
         ).to.have.length.of(0);
+      });
+    });
+  });
+
+  describe("Stateful ArrayFieldTemplate", () => {
+    class ArrayFieldTemplate extends PureComponent {
+      render() {
+        return (
+          <div className="field-content">
+            {this.props.items.map((item, i) => (
+              <div key={i}>item.children</div>
+            ))}
+          </div>
+        );
+      }
+    }
+
+    it("should render a stateful custom component", () => {
+      const { node } = createFormComponent({
+        schema: { type: "array", items: { type: "string" } },
+        formData,
+        ArrayFieldTemplate,
+      });
+      expect(
+        node.querySelectorAll(".field-array .field-content div")
+      ).to.have.length.of(3);
+    });
+  });
+
+  describe("pass right props to ArrayFieldTemplate", () => {
+    it("should pass registry prop", () => {
+      const ArrayFieldTemplate = ({ registry }) => {
+        if (!registry) {
+          throw "Error";
+        }
+        return null;
+      };
+      createFormComponent({
+        schema: { type: "array", items: { type: "string" } },
+        formData,
+        ArrayFieldTemplate,
       });
     });
   });


### PR DESCRIPTION
### Reasons for making this change

Fixes https://github.com/mozilla-services/react-jsonschema-form/issues/1113

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
