### PR TITLE
Show netlify badge on deploy previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[context.deploy-preview.environment]
+  SHOW_NETLIFY_BADGE = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [context.deploy-preview.environment]
-  SHOW_NETLIFY_BADGE = true
+  SHOW_NETLIFY_BADGE = "true"

--- a/playground/app.js
+++ b/playground/app.js
@@ -506,6 +506,27 @@ class App extends Component {
             </Form>
           )}
         </div>
+        <div className="col-sm-12">
+          <p style={{ textAlign: "center" }}>
+            Powered by
+            <a href="https://github.com/mozilla-services/react-jsonschema-form">
+              react-jsonschema-form
+            </a>
+            . Bootstrap themes courtesy of{" "}
+            <a href="http://bootswatch.com/">Bootswatch</a> and{" "}
+            <a href="https://github.com/aalpern/bootstrap-solarized/">
+              bootstrap-solarized
+            </a>
+            .
+            {process.env.SHOW_NETLIFY_BADGE === "true" && (
+              <div style={{ float: "right" }}>
+                <a href="https://www.netlify.com">
+                  <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" />
+                </a>
+              </div>
+            )}
+          </p>
+        </div>
       </div>
     );
   }

--- a/playground/index.html
+++ b/playground/index.html
@@ -9,13 +9,6 @@
 </head>
 <body>
   <div id="app"></div>
-  <p style="text-align:center">
-    Powered by
-    <a href="https://github.com/mozilla-services/react-jsonschema-form">react-jsonschema-form</a>.
-    Bootstrap themes courtsesy of
-    <a href="http://bootswatch.com/">Bootswatch</a> and
-    <a href="https://github.com/aalpern/bootstrap-solarized/">bootstrap-solarized</a>.
-  </p>
   <script src="/static/bundle.js"></script>
 </body>
 </html>

--- a/playground/index.prod.html
+++ b/playground/index.prod.html
@@ -10,13 +10,6 @@
 </head>
 <body>
   <div id="app"></div>
-  <p style="text-align:center">
-    Powered by
-    <a href="https://github.com/mozilla-services/react-jsonschema-form">react-jsonschema-form</a>.
-    Bootstrap themes courtsesy of
-    <a href="http://bootswatch.com/">Bootswatch</a> and
-    <a href="https://github.com/aalpern/bootstrap-solarized/">bootstrap-solarized</a>.
-  </p>
   <script src="./bundle.js"></script>
 </body>
 </html>

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -14,7 +14,8 @@ module.exports = {
     new MiniCssExtractPlugin({filename: "styles.css", allChunks: true}),
     new webpack.DefinePlugin({
       "process.env": {
-        NODE_ENV: JSON.stringify("production")
+        NODE_ENV: JSON.stringify("production"),
+        SHOW_NETLIFY_BADGE: JSON.stringify(process.env.SHOW_NETLIFY_BADGE)
       }
     })
   ],


### PR DESCRIPTION
This is needed because we're using Netlify to serve deploy previews and using their open-source plan.

We're not yet using Netlify to serve our playground, so the badge won't show up there.