### PR TITLE
[WIP] Live omit

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -118,7 +118,7 @@ render((
 ), document.getElementById("app"));
 ```
 
-> Note: If there are fields in the `formData` that are not represented in the schema, they will be retained by default. If you would like to remove those extra values on form submission, then set the `omitExtraData` prop to `true`.
+> Note: If there are fields in the `formData` that are not represented in the schema, they will be retained by default. If you would like to remove those extra values on form submission, then set the `omitExtraData` prop to `true`. Set the `liveOmit` prop to true in order to remove extra data upon form data change.
 
 #### Form error event handler
 
@@ -137,7 +137,7 @@ render((
 
 If you plan on being notified every time the form data are updated, you can pass an `onChange` handler, which will receive the same args as `onSubmit` any time a value is updated in the form.
 
-> Note: If `omitExtraData` and `liveValidate` are both set to true, then extra form data values that are not in any form field will be removed whenever `onChange` is called.
+> Note: If `omitExtraData` and `liveOmit` are both set to true, then extra form data values that are not in any form field will be removed whenever `onChange` is called.
 
 #### Form field blur events
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -175,11 +175,7 @@ export default class Form extends Component {
     let state = { formData };
     let newFormData = formData;
 
-    if (
-      this.props.omitExtraData === true &&
-      (this.props.liveValidate || this.props.liveOmit) &&
-      this.props.liveOmit !== false
-    ) {
+    if (this.props.omitExtraData === true && this.props.liveOmit === true) {
       const newState = this.getStateFromProps(this.props, formData);
 
       const fieldNames = this.getFieldNames(

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -188,6 +188,9 @@ export default class Form extends Component {
       );
 
       newFormData = this.getUsedFormData(formData, fieldNames);
+      state = {
+        formData: newFormData,
+      };
     }
 
     if (mustValidate) {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -175,7 +175,11 @@ export default class Form extends Component {
     let state = { formData };
     let newFormData = formData;
 
-    if (this.props.omitExtraData === true && this.props.liveValidate) {
+    if (
+      this.props.omitExtraData === true &&
+      (this.props.liveValidate || this.props.liveOmit) &&
+      this.props.liveOmit !== false
+    ) {
       const newState = this.getStateFromProps(this.props, formData);
 
       const fieldNames = this.getFieldNames(

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1110,7 +1110,7 @@ describe("Form", () => {
       });
     });
 
-    it("should call getUsedFormData when the omitExtraData prop is true and liveValidate is true", () => {
+    it("should call getUsedFormData when the omitExtraData prop is true and liveOmit is true", () => {
       const schema = {
         type: "object",
         properties: {
@@ -1124,13 +1124,13 @@ describe("Form", () => {
       };
       const onChange = sandbox.spy();
       const omitExtraData = true;
-      const liveValidate = true;
+      const liveOmit = true;
       const { node, comp } = createFormComponent({
         schema,
         formData,
         onChange,
         omitExtraData,
-        liveValidate,
+        liveOmit,
       });
 
       sandbox.stub(comp, "getUsedFormData").returns({


### PR DESCRIPTION
### Reasons for making this change

Add a `liveOmit` option. I have a use case in which I want omitExtraData to happen during onChange, but I do not want liveValidate.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
