### PR TITLE
Array items now have unique, stable keys (#1046)

### DIFF
--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -112,6 +112,7 @@ The following props are part of each element in `items`:
 - `hasRemove`: A boolean value stating whether the array item can be removed.
 - `hasToolbar`: A boolean value stating whether the array item has a toolbar.
 - `index`: A number stating the index the array item occurs in `items`.
+- `key`: A stable, unique key for the array item.
 - `onDropIndexClick: (index) => (event) => void`: Returns a function that removes the item at `index`.
 - `onReorderClick: (index, newIndex) => (event) => void`: Returns a function that swaps the items at `index` with `newIndex`.
 - `readonly`: A boolean value stating if the array item is read-only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8170,6 +8170,11 @@
       "dev": true,
       "optional": true
     },
+    "nanoid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.3.tgz",
+      "integrity": "sha512-NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10734,6 +10734,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-proxy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11268,6 +11268,14 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shortid": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
+      "integrity": "sha1-gNtqr8vD46RoULPIjTngUbhMjRg=",
+      "requires": {
+        "nanoid": "^2.0.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "lodash.pick": "^4.4.0",
     "lodash.topath": "^4.5.2",
     "prop-types": "^15.5.8",
-    "react-is": "^16.8.4"
+    "react-is": "^16.8.4",
+    "shortid": "^2.2.14"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lodash.topath": "^4.5.2",
     "prop-types": "^15.5.8",
     "react-is": "^16.8.4",
+    "react-lifecycles-compat": "^3.0.4",
     "shortid": "^2.2.14"
   },
   "devDependencies": {

--- a/playground/samples/customArray.js
+++ b/playground/samples/customArray.js
@@ -5,10 +5,7 @@ function ArrayFieldTemplate(props) {
     <div className={props.className}>
       {props.items &&
         props.items.map(element => (
-          <div
-            key={element.key}
-            id={`array-item-${element.key}`}
-            className={element.className}>
+          <div key={element.key} className={element.className}>
             <div>{element.children}</div>
             {element.hasMoveDown && (
               <button

--- a/playground/samples/customArray.js
+++ b/playground/samples/customArray.js
@@ -5,7 +5,10 @@ function ArrayFieldTemplate(props) {
     <div className={props.className}>
       {props.items &&
         props.items.map(element => (
-          <div key={element.index}>
+          <div
+            key={element.key}
+            id={`array-item-${element.key}`}
+            className={element.className}>
             <div>{element.children}</div>
             {element.hasMoveDown && (
               <button

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -46,10 +46,7 @@ function DefaultArrayItem(props) {
     fontWeight: "bold",
   };
   return (
-    <div
-      key={props.key}
-      id={`array-item-${props.key}`}
-      className={props.className}>
+    <div key={props.key} className={props.className}>
       <div className={props.hasToolbar ? "col-xs-9" : "col-xs-12"}>
         {props.children}
       </div>

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -1,6 +1,7 @@
 import AddButton from "../AddButton";
 import IconButton from "../IconButton";
 import React, { Component } from "react";
+import { polyfill } from "react-lifecycles-compat";
 import includes from "core-js/library/fn/array/includes";
 import * as types from "../../types";
 
@@ -217,9 +218,9 @@ class ArrayField extends Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  static getDerivedStateFromProps(nextProps, prevState) {
     const nextFormData = nextProps.formData;
-    const previousKeyedFormData = this.state.keyedFormData;
+    const previousKeyedFormData = prevState.keyedFormData;
     const newKeyedFormData =
       nextFormData.length === previousKeyedFormData.length
         ? previousKeyedFormData.map((previousKeyedFormDatum, index) => {
@@ -229,29 +230,10 @@ class ArrayField extends Component {
             };
           })
         : generateKeyedFormData(nextFormData);
-    this.setState({
-      keyedFormData: newKeyedFormData,
-    });
-  }
-
-  /*
-  // React 16.3 replaces componentWillReceiveProps with getDerivedStateFromProps
-  //
-  static getDerivedStateFromProps(nextProps, prevState) {
-    const nextFormData = nextProps.formData;
-    const previousKeyedFormData = prevState.keyedFormData;
-    const newKeyedFormData = (nextFormData.length === previousKeyedFormData.length) ?
-      previousKeyedFormData.map((previousKeyedFormDatum, index) => {
-        return {
-          key: previousKeyedFormDatum.key,
-          item: nextFormData[index]
-        };
-      }) : generateKeyedFormData(nextFormData);
     return {
-      keyedFormData: newKeyedFormData
+      keyedFormData: newKeyedFormData,
     };
   }
-  */
 
   get itemTitle() {
     const { schema } = this.props;
@@ -770,5 +752,7 @@ class ArrayField extends Component {
 if (process.env.NODE_ENV !== "production") {
   ArrayField.propTypes = types.fieldProps;
 }
+
+polyfill(ArrayField);
 
 export default ArrayField;

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -45,7 +45,10 @@ function DefaultArrayItem(props) {
     fontWeight: "bold",
   };
   return (
-    <div key={props.index} className={props.className}>
+    <div
+      key={props.key}
+      id={`array-item-${props.key}`}
+      className={props.className}>
       <div className={props.hasToolbar ? "col-xs-9" : "col-xs-12"}>
         {props.children}
       </div>
@@ -639,7 +642,8 @@ class ArrayField extends Component {
       disabled,
       idSchema,
       formData,
-      items: items.map((item, index) => {
+      items: this.state.keyedFormData.map((keyedItem, index) => {
+        const { key, item } = keyedItem;
         const additional = index >= itemSchemas.length;
         const itemSchema = additional
           ? retrieveSchema(schema.additionalItems, definitions, item)
@@ -660,6 +664,7 @@ class ArrayField extends Component {
         const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
 
         return this.renderArrayFieldItem({
+          key,
           index,
           canRemove: additional,
           canMoveUp: index >= itemSchemas.length + 1,

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -282,7 +282,7 @@ class ArrayField extends Component {
 
   onAddClick = event => {
     event.preventDefault();
-    const { schema, registry = getDefaultRegistry() } = this.props;
+    const { schema, registry = getDefaultRegistry(), onChange } = this.props;
     const { definitions } = registry;
     let itemSchema = schema.items;
     if (isFixedItems(schema) && allowAdditionalItems(schema)) {
@@ -301,10 +301,12 @@ class ArrayField extends Component {
       },
     ];
 
-    this.setState({
-      keyedFormData: newKeyedFormData,
-    });
-    this.props.onChange(keyedToPlainFormData(newKeyedFormData));
+    this.setState(
+      {
+        keyedFormData: newKeyedFormData,
+      },
+      () => onChange(keyedToPlainFormData(newKeyedFormData))
+    );
   };
 
   onDropIndexClick = index => {
@@ -329,10 +331,12 @@ class ArrayField extends Component {
         }
       }
       const newKeyedFormData = keyedFormData.filter((_, i) => i !== index);
-      this.setState({
-        keyedFormData: newKeyedFormData,
-      });
-      onChange(keyedToPlainFormData(newKeyedFormData), newErrorSchema);
+      this.setState(
+        {
+          keyedFormData: newKeyedFormData,
+        },
+        () => onChange(keyedToPlainFormData(newKeyedFormData), newErrorSchema)
+      );
     };
   };
 
@@ -370,10 +374,12 @@ class ArrayField extends Component {
         return _newKeyedFormData;
       }
       const newKeyedFormData = reOrderArray();
-      this.setState({
-        keyedFormData: newKeyedFormData,
-      });
-      onChange(keyedToPlainFormData(newKeyedFormData), newErrorSchema);
+      this.setState(
+        {
+          keyedFormData: newKeyedFormData,
+        },
+        () => onChange(keyedToPlainFormData(newKeyedFormData), newErrorSchema)
+      );
     };
   };
 

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -221,12 +221,15 @@ describe("ArrayField", () => {
     });
 
     it("should assign new keys/ids when clicking the add button", () => {
-      const { node } = createFormComponent({ schema });
+      const { node } = createFormComponent({
+        schema,
+        ArrayFieldTemplate: ExposedArrayKeyTemplate,
+      });
 
       Simulate.click(node.querySelector(".array-item-add button"));
 
-      expect(node.querySelector(".array-item").id.startsWith("array-item-")).to
-        .be.true;
+      expect(node.querySelector(".array-item").hasAttribute(ArrayKeyDataAttr))
+        .to.be.true;
     });
 
     it("should not provide an add button if length equals maxItems", () => {

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -5,6 +5,62 @@ import { Simulate } from "react-addons-test-utils";
 
 import { createFormComponent, createSandbox } from "./test_utils";
 
+const ArrayKeyDataAttr = "data-rjsf-itemkey";
+const ExposedArrayKeyTemplate = function(props) {
+  return (
+    <div className="array">
+      {props.items &&
+        props.items.map(element => (
+          <div
+            key={element.key}
+            className="array-item"
+            data-rjsf-itemkey={element.key}>
+            <div>{element.children}</div>
+            {(element.hasMoveUp || element.hasMoveDown) && (
+              <button
+                className="array-item-move-down"
+                onClick={element.onReorderClick(
+                  element.index,
+                  element.index + 1
+                )}>
+                Down
+              </button>
+            )}
+            {(element.hasMoveUp || element.hasMoveDown) && (
+              <button
+                className="array-item-move-up"
+                onClick={element.onReorderClick(
+                  element.index,
+                  element.index - 1
+                )}>
+                Up
+              </button>
+            )}
+            {element.hasRemove && (
+              <button
+                className="array-item-remove"
+                onClick={element.onDropIndexClick(element.index)}>
+                Remove
+              </button>
+            )}
+            <button onClick={element.onDropIndexClick(element.index)}>
+              Delete
+            </button>
+            <hr />
+          </div>
+        ))}
+
+      {props.canAdd && (
+        <div className="array-item-add">
+          <button onClick={props.onAddClick} type="button">
+            Add New
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
 describe("ArrayField", () => {
   let sandbox;
   const CustomComponent = props => {
@@ -195,23 +251,27 @@ describe("ArrayField", () => {
       const { node } = createFormComponent({
         schema: { maxItems: 2, ...schema },
         formData: ["foo"],
+        ArrayFieldTemplate: ExposedArrayKeyTemplate,
       });
 
       const startRows = node.querySelectorAll(".array-item");
-      const startRow1_id = startRows[0].id;
-      const startRow2_id = startRows[1] ? startRows[1].id : undefined;
+      const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
+      const startRow2_key = startRows[1]
+        ? startRows[1].getAttribute(ArrayKeyDataAttr)
+        : undefined;
 
       Simulate.click(node.querySelector(".array-item-add button"));
 
       const endRows = node.querySelectorAll(".array-item");
-      const endRow1_id = endRows[0].id;
-      const endRow2_id = endRows[1].id;
+      const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
+      const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
 
-      expect(startRow1_id).to.equal(endRow1_id);
-      expect(startRow2_id).to.not.equal(endRow2_id);
+      expect(startRow1_key).to.equal(endRow1_key);
+      expect(startRow2_key).to.not.equal(endRow2_key);
 
-      expect(startRow2_id).to.be.undefined;
-      expect(endRow2_id.startsWith("array-item-")).to.be.true;
+      expect(startRow2_key).to.be.undefined;
+      expect(endRows[0].hasAttribute(ArrayKeyDataAttr)).to.be.true;
+      expect(endRows[1].hasAttribute(ArrayKeyDataAttr)).to.be.true;
     });
 
     it("should not provide an add button if addable is expliclty false regardless maxItems value", () => {
@@ -317,46 +377,56 @@ describe("ArrayField", () => {
       const { node } = createFormComponent({
         schema,
         formData: ["foo", "bar", "baz"],
+        ArrayFieldTemplate: ExposedArrayKeyTemplate,
       });
       const moveDownBtns = node.querySelectorAll(".array-item-move-down");
       const startRows = node.querySelectorAll(".array-item");
-      const startRow1_id = startRows[0].id;
-      const startRow2_id = startRows[1].id;
-      const startRow3_id = startRows[2].id;
+      const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
+      const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
+      const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
 
       Simulate.click(moveDownBtns[0]);
 
       const endRows = node.querySelectorAll(".array-item");
-      const endRow1_id = endRows[0].id;
-      const endRow2_id = endRows[1].id;
-      const endRow3_id = endRows[2].id;
+      const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
+      const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
+      const endRow3_key = endRows[2].getAttribute(ArrayKeyDataAttr);
 
-      expect(startRow1_id).to.equal(endRow2_id);
-      expect(startRow2_id).to.equal(endRow1_id);
-      expect(startRow3_id).to.equal(endRow3_id);
+      expect(startRow1_key).to.equal(endRow2_key);
+      expect(startRow2_key).to.equal(endRow1_key);
+      expect(startRow3_key).to.equal(endRow3_key);
+
+      expect(endRows[0].hasAttribute(ArrayKeyDataAttr)).to.be.true;
+      expect(endRows[1].hasAttribute(ArrayKeyDataAttr)).to.be.true;
+      expect(endRows[2].hasAttribute(ArrayKeyDataAttr)).to.be.true;
     });
 
     it("should retain row keys/ids when moving up", () => {
       const { node } = createFormComponent({
         schema,
         formData: ["foo", "bar", "baz"],
+        ArrayFieldTemplate: ExposedArrayKeyTemplate,
       });
       const moveUpBtns = node.querySelectorAll(".array-item-move-up");
       const startRows = node.querySelectorAll(".array-item");
-      const startRow1_id = startRows[0].id;
-      const startRow2_id = startRows[1].id;
-      const startRow3_id = startRows[2].id;
+      const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
+      const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
+      const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
 
       Simulate.click(moveUpBtns[2]);
 
       const endRows = node.querySelectorAll(".array-item");
-      const endRow1_id = endRows[0].id;
-      const endRow2_id = endRows[1].id;
-      const endRow3_id = endRows[2].id;
+      const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
+      const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
+      const endRow3_key = endRows[2].getAttribute(ArrayKeyDataAttr);
 
-      expect(startRow1_id).to.equal(endRow1_id);
-      expect(startRow2_id).to.equal(endRow3_id);
-      expect(startRow3_id).to.equal(endRow2_id);
+      expect(startRow1_key).to.equal(endRow1_key);
+      expect(startRow2_key).to.equal(endRow3_key);
+      expect(startRow3_key).to.equal(endRow2_key);
+
+      expect(endRows[0].hasAttribute(ArrayKeyDataAttr)).to.be.true;
+      expect(endRows[1].hasAttribute(ArrayKeyDataAttr)).to.be.true;
+      expect(endRows[2].hasAttribute(ArrayKeyDataAttr)).to.be.true;
     });
 
     it("should move from first to last in the list", () => {
@@ -375,7 +445,7 @@ describe("ArrayField", () => {
         return (
           <div
             key={props.key}
-            id={`array-item-${props.key}`}
+            data-rjsf-itemkey={props.key}
             className={`array-item item-${props.index}`}>
             {props.children}
             {buttons}
@@ -398,9 +468,9 @@ describe("ArrayField", () => {
       });
 
       const startRows = node.querySelectorAll(".array-item");
-      const startRow1_id = startRows[0].id;
-      const startRow2_id = startRows[1].id;
-      const startRow3_id = startRows[2].id;
+      const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
+      const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
+      const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
 
       const button = node.querySelector(".item-0 .array-item-move-to-2");
       Simulate.click(button);
@@ -411,15 +481,17 @@ describe("ArrayField", () => {
       expect(inputs[2].value).eql("foo");
 
       const endRows = node.querySelectorAll(".array-item");
-      const endRow1_id = endRows[0].id;
-      const endRow2_id = endRows[1].id;
-      const endRow3_id = endRows[2].id;
+      const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
+      const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
+      const endRow3_key = endRows[2].getAttribute(ArrayKeyDataAttr);
 
-      expect(startRow1_id).to.equal(endRow3_id);
-      expect(startRow2_id).to.equal(endRow1_id);
-      expect(startRow3_id).to.equal(endRow2_id);
+      expect(startRow1_key).to.equal(endRow3_key);
+      expect(startRow2_key).to.equal(endRow1_key);
+      expect(startRow3_key).to.equal(endRow2_key);
 
-      expect(endRow2_id.startsWith("array-item-")).to.be.true;
+      expect(endRows[0].hasAttribute(ArrayKeyDataAttr)).to.be.true;
+      expect(endRows[1].hasAttribute(ArrayKeyDataAttr)).to.be.true;
+      expect(endRows[2].hasAttribute(ArrayKeyDataAttr)).to.be.true;
     });
 
     it("should disable move buttons on the ends of the list", () => {
@@ -467,18 +539,20 @@ describe("ArrayField", () => {
       const { node } = createFormComponent({
         schema,
         formData: ["foo", "bar"],
+        ArrayFieldTemplate: ExposedArrayKeyTemplate,
       });
 
       const startRows = node.querySelectorAll(".array-item");
-      const startRow2_id = startRows[1].id;
+      const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
 
       const dropBtns = node.querySelectorAll(".array-item-remove");
       Simulate.click(dropBtns[0]);
 
       const endRows = node.querySelectorAll(".array-item");
-      const endRow1_id = endRows[0].id;
+      const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
 
-      expect(startRow2_id).to.equal(endRow1_id);
+      expect(startRow2_key).to.equal(endRow1_key);
+      expect(endRows[0].hasAttribute(ArrayKeyDataAttr)).to.be.true;
     });
 
     it("should not show remove button if removable is false", () => {
@@ -1364,13 +1438,16 @@ describe("ArrayField", () => {
       const { comp, node } = createFormComponent({
         schema: schemaAdditional,
         formData: [1, 2, "foo"],
+        ArrayFieldTemplate: ExposedArrayKeyTemplate,
       });
 
       const startRows = node.querySelectorAll(".array-item");
-      const startRow1_id = startRows[0].id;
-      const startRow2_id = startRows[1].id;
-      const startRow3_id = startRows[2].id;
-      const startRow4_id = startRows[3] ? startRows[3].id : undefined;
+      const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
+      const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
+      const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
+      const startRow4_key = startRows[3]
+        ? startRows[3].getAttribute(ArrayKeyDataAttr)
+        : undefined;
 
       it("should add a field when clicking add button", () => {
         const addBtn = node.querySelector(".array-item-add button");
@@ -1383,18 +1460,21 @@ describe("ArrayField", () => {
 
       it("should retain existing row keys/ids when adding additional items", () => {
         const endRows = node.querySelectorAll(".array-item");
-        const endRow1_id = endRows[0].id;
-        const endRow2_id = endRows[1].id;
-        const endRow3_id = endRows[2].id;
-        const endRow4_id = endRows[3].id;
+        const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
+        const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
+        const endRow3_key = endRows[2].getAttribute(ArrayKeyDataAttr);
+        const endRow4_key = endRows[3].getAttribute(ArrayKeyDataAttr);
 
-        expect(startRow1_id).to.equal(endRow1_id);
-        expect(startRow2_id).to.equal(endRow2_id);
-        expect(startRow3_id).to.equal(endRow3_id);
+        expect(startRow1_key).to.equal(endRow1_key);
+        expect(startRow2_key).to.equal(endRow2_key);
+        expect(startRow3_key).to.equal(endRow3_key);
 
-        expect(startRow4_id).to.not.equal(endRow4_id);
-        expect(startRow4_id).to.be.undefined;
-        expect(endRow4_id.startsWith("array-item-")).to.be.true;
+        expect(startRow4_key).to.not.equal(endRow4_key);
+        expect(startRow4_key).to.be.undefined;
+        expect(endRows[0].hasAttribute(ArrayKeyDataAttr)).to.be.true;
+        expect(endRows[1].hasAttribute(ArrayKeyDataAttr)).to.be.true;
+        expect(endRows[2].hasAttribute(ArrayKeyDataAttr)).to.be.true;
+        expect(endRows[3].hasAttribute(ArrayKeyDataAttr)).to.be.true;
       });
 
       it("should change the state when changing input value", () => {


### PR DESCRIPTION
### Reasons for making this change

Array items did not have stable, unique keys and instead had to rely on the index of the item.
Fixes #1046
Fixes #1333

### Checklist

* [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [X] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
