### PR TITLE
Fixed schema type not being deduced correctly in compute defaults #1334

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -184,7 +184,7 @@ function computeDefaults(
     defaults = schema.default;
   }
 
-  switch (schema.type) {
+  switch (getSchemaType(schema)) {
     // We need to recur for object schema inner default values.
     case "object":
       return Object.keys(schema.properties || {}).reduce((acc, key) => {

--- a/test/anyOf_test.js
+++ b/test/anyOf_test.js
@@ -85,6 +85,36 @@ describe("anyOf", () => {
     expect(comp.state.formData).eql({ foo: "defaultbar" });
   });
 
+  it("should assign a default value and set defaults on option change with 'type': 'object' missing", () => {
+    const { comp, node } = createFormComponent({
+      schema: {
+        type: "object",
+        anyOf: [
+          {
+            properties: {
+              foo: { type: "string", default: "defaultfoo" },
+            },
+          },
+          {
+            properties: {
+              foo: { type: "string", default: "defaultbar" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(comp.state.formData).eql({ foo: "defaultfoo" });
+
+    const $select = node.querySelector("select");
+
+    Simulate.change($select, {
+      target: { value: $select.options[1].value },
+    });
+
+    expect(comp.state.formData).eql({ foo: "defaultbar" });
+  });
+
   it("should render a custom widget", () => {
     const schema = {
       type: "object",

--- a/test/oneOf_test.js
+++ b/test/oneOf_test.js
@@ -85,6 +85,36 @@ describe("oneOf", () => {
     expect(comp.state.formData).eql({ foo: "defaultbar" });
   });
 
+  it("should assign a default value and set defaults on option change with 'type': 'object' missing", () => {
+    const { comp, node } = createFormComponent({
+      schema: {
+        type: "object",
+        oneOf: [
+          {
+            properties: {
+              foo: { type: "string", default: "defaultfoo" },
+            },
+          },
+          {
+            properties: {
+              foo: { type: "string", default: "defaultbar" },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(comp.state.formData).eql({ foo: "defaultfoo" });
+
+    const $select = node.querySelector("select");
+
+    Simulate.change($select, {
+      target: { value: $select.options[1].value },
+    });
+
+    expect(comp.state.formData).eql({ foo: "defaultbar" });
+  });
+
   it("should render a custom widget", () => {
     const schema = {
       type: "object",

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -359,6 +359,23 @@ describe("utils", () => {
         });
       });
 
+      it("should populate defaults for oneOf when 'type': 'object' is missing", () => {
+        const schema = {
+          type: "object",
+          oneOf: [
+            {
+              properties: { name: { type: "string", default: "a" } },
+            },
+            {
+              properties: { id: { type: "number", default: 13 } },
+            },
+          ],
+        };
+        expect(getDefaultFormState(schema, {})).eql({
+          name: "a",
+        });
+      });
+
       it("should populate nested default values for oneOf", () => {
         const schema = {
           type: "object",


### PR DESCRIPTION
# Reasons for making this change
As described in bug report #1334, the "default" values of schemas are not correctly applied to anyOf/oneOf properties.

This PR fixes that. 
anyOf/oneOf schema don't have 'type' properties sometimes, so we needed to use `getSchemaType(schema)` instead of `schema.type` in `computeDefaults`


### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed.
