### PR TITLE
Replace react-addons-test-utils with react-dom/test-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10694,12 +10694,6 @@
         "prop-types": "^15.5.10"
       }
     },
-    "react-addons-test-utils": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz",
-      "integrity": "sha1-wStu/cIkfBDae4dw0YUICnsEcVY=",
-      "dev": true
-    },
     "react-codemirror2": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "nyc": "^13.2.0",
     "prettier": "^1.15.1",
     "react": "^15.5.0",
-    "react-addons-test-utils": "^15.3.2",
     "react-codemirror2": "^4.1.0",
     "react-dom": "^15.3.2",
     "react-transform-catch-errors": "^1.0.0",

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
+import { Simulate } from "react-dom/test-utils";
 
 import { createFormComponent, createSandbox } from "./test_utils";
 

--- a/test/BooleanField_test.js
+++ b/test/BooleanField_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
+import { Simulate } from "react-dom/test-utils";
 import sinon from "sinon";
 
 import { createFormComponent, createSandbox } from "./test_utils";

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import sinon from "sinon";
 import React from "react";
-import { renderIntoDocument, Simulate } from "react-addons-test-utils";
+import { renderIntoDocument, Simulate } from "react-dom/test-utils";
 import { findDOMNode } from "react-dom";
 
 import Form from "../src";

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
+import { Simulate } from "react-dom/test-utils";
 import sinon from "sinon";
 
 import { createFormComponent, createSandbox, setProps } from "./test_utils";

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
+import { Simulate } from "react-dom/test-utils";
 
 import { createFormComponent, createSandbox } from "./test_utils";
 import validateFormData from "../src/validate";

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
+import { Simulate } from "react-dom/test-utils";
 
 import SchemaField from "../src/components/fields/SchemaField";
 import TitleField from "../src/components/fields/TitleField";

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
+import { Simulate } from "react-dom/test-utils";
 
 import { parseDateString, toDateString } from "../src/utils";
 import { utcToLocal } from "../src/components/widgets/DateTimeWidget";

--- a/test/anyOf_test.js
+++ b/test/anyOf_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
+import { Simulate } from "react-dom/test-utils";
 
 import { createFormComponent, createSandbox, setProps } from "./test_utils";
 

--- a/test/oneOf_test.js
+++ b/test/oneOf_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { expect } from "chai";
-import { Simulate } from "react-addons-test-utils";
+import { Simulate } from "react-dom/test-utils";
 
 import { createFormComponent, createSandbox, setProps } from "./test_utils";
 

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -1,6 +1,6 @@
 import sinon from "sinon";
 import React from "react";
-import { scryRenderedComponentsWithType } from "react-addons-test-utils";
+import { scryRenderedComponentsWithType } from "react-dom/test-utils";
 import { getDefaultRegistry } from "../src/utils";
 import SchemaField from "../src/components/fields/SchemaField";
 import {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import sinon from "sinon";
-import { renderIntoDocument } from "react-addons-test-utils";
+import { renderIntoDocument } from "react-dom/test-utils";
 import { findDOMNode, render } from "react-dom";
 
 import Form from "../src";

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import React from "react";
-import { Simulate } from "react-addons-test-utils";
+import { Simulate } from "react-dom/test-utils";
 import SelectWidget from "../src/components/widgets/SelectWidget";
 import RadioWidget from "../src/components/widgets/RadioWidget";
 import { createFormComponent, createSandbox } from "./test_utils";

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { expect } from "chai";
 import sinon from "sinon";
-import { Simulate } from "react-addons-test-utils";
+import { Simulate } from "react-dom/test-utils";
 
 import validateFormData, { isValid, toErrorList } from "../src/validate";
 import { createFormComponent } from "./test_utils";


### PR DESCRIPTION
This is because react-addons-test-utils is deprecated and included within react-dom. We get this warning each time we run tests:

```
Warning: ReactTestUtils has been moved to react-dom/test-utils. Update references to remove this warning.
```