### PR TITLE
Allows for a custom tagName to be used in place of "form"

### DIFF
--- a/docs/form-customization.md
+++ b/docs/form-customization.md
@@ -722,3 +722,15 @@ It's possible to disable the whole form by setting the `disabled` prop. The `dis
 ```
 
 If you just want to disable some of the fields, see the [`ui:disabled`](#disabled-fields) parameter in the `uiSchema` directive. 
+
+
+### Changing the tag name
+
+
+It's possible to change the default `form` tag name to a different HTML tag, which can be helpful if you are nesting forms. However, native browser form behaviour, such as submitting when the `Enter` key is pressed, may no longer work.
+
+```jsx
+<Form
+  tagName="div"
+/>
+```

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -285,6 +285,7 @@ export default class Form extends Component {
       id,
       idPrefix,
       className,
+      tagName,
       name,
       method,
       target,
@@ -300,9 +301,10 @@ export default class Form extends Component {
     const { schema, uiSchema, formData, errorSchema, idSchema } = this.state;
     const registry = this.getRegistry();
     const _SchemaField = registry.fields.SchemaField;
+    const FormTag = tagName ? tagName : "form";
 
     return (
-      <form
+      <FormTag
         className={className ? className : "rjsf"}
         id={id}
         name={name}
@@ -342,7 +344,7 @@ export default class Form extends Component {
             </button>
           </div>
         )}
-      </form>
+      </FormTag>
     );
   }
 }
@@ -366,6 +368,7 @@ if (process.env.NODE_ENV !== "production") {
     onSubmit: PropTypes.func,
     id: PropTypes.string,
     className: PropTypes.string,
+    tagName: PropTypes.string,
     name: PropTypes.string,
     method: PropTypes.string,
     target: PropTypes.string,

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -2406,4 +2406,12 @@ describe("Form", () => {
       });
     });
   });
+
+  describe("Changing the tagName", () => {
+    it("should render the component using the custom tag name", () => {
+      const tagName = "SPAN";
+      const { node } = createFormComponent({ schema: {}, tagName });
+      expect(node.tagName).eql(tagName);
+    });
+  });
 });


### PR DESCRIPTION
### Reasons for making this change

Sometimes we need a way to nest the RJSF components so that we can utilise the rendering capabilities within our components. For example, when rendering a custom `Array<Object>` component, the child properties can be rendered in a child form.  However doing this will produce invalid html, a nasty error in the console, and possibly cause unforeseen problems across browsers.


### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
