### PR TITLE
Added all default widgets to documentation

### DIFF
--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -527,6 +527,27 @@ render((
 ), document.getElementById("app"));
 ```
 
+The default widgets you can overwrite are:
+
+ - `AltDateTimeWidget`
+ - `AltDateWidget`
+ - `CheckboxesWidget`
+ - `CheckboxWidget`
+ - `ColorWidget`
+ - `DateTimeWidget`
+ - `DateWidget`
+ - `EmailWidget`
+ - `FileWidget`
+ - `HiddenWidget`
+ - `PasswordWidget`
+ - `RadioWidget`
+ - `RangeWidget`
+ - `SelectWidget`
+ - `TextareaWidget`
+ - `TextWidget`
+ - `UpDownWidget`
+ - `URLWidget`
+
 ### Custom titles
 
 You can provide your own implementation of the `TitleField` base React component for rendering any title. This is useful when you want to augment how titles are handled.


### PR DESCRIPTION
### Reasons for making this change

Added all the default widgets that can be overwritten in alphabetical order to documentation. Please review, and let me know if anything else is required for this issue. Fixes #1198

### Checklist

* [o] **I'm updating documentation**
  - [o] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
