### PR TITLE
#1353 - fix for unable to add items to nested list

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -223,10 +223,20 @@ class ArrayField extends Component {
     if (isFixedItems(schema) && allowAdditionalItems(schema)) {
       itemSchema = schema.additionalItems;
     }
-    this.props.onChange([
-      ...formData,
-      getDefaultFormState(itemSchema, undefined, definitions),
-    ]);
+    if (formData) {
+      this.props.onChange([
+        ...formData,
+        getDefaultFormState(
+          itemSchema,
+          itemSchema.type === "array" ? [] : undefined,
+          definitions
+        ),
+      ]);
+    } else {
+      this.props.onChange([
+        getDefaultFormState(itemSchema, undefined, definitions),
+      ]);
+    }
   };
 
   onDropIndexClick = index => {


### PR DESCRIPTION
### Reasons for making this change

Related issue: #1353 

A JS error is thrown when attempting to add an item to a new inner list of a nested list.

This blocks a user from adding items to a nested list.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
