### PR TITLE
Allow "0." to be typed in to a text widget

### DIFF
--- a/src/components/fields/NumberField.js
+++ b/src/components/fields/NumberField.js
@@ -69,7 +69,7 @@ class NumberField extends React.Component {
 
     let value = formData;
 
-    if (typeof lastValue === "string" && value) {
+    if (typeof lastValue === "string" && typeof value === "number") {
       // Construct a regular expression that checks for a string that consists
       // of the formData value suffixed with zero or one '.' characters and zero
       // or more '0' characters

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -207,7 +207,7 @@ describe("NumberField", () => {
       });
 
       expect(comp.state.formData).eql(0);
-      expect($input.value).eql("0");
+      expect($input.value).eql(".00");
     });
 
     it("should update input values correctly when formData prop changes", () => {

--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -16,286 +16,38 @@ describe("NumberField", () => {
     sandbox.restore();
   });
 
-  describe("TextWidget", () => {
-    it("should render a number input", () => {
+  describe("Number widget", () => {
+    it("should use step to represent the multipleOf keyword", () => {
       const { node } = createFormComponent({
         schema: {
           type: "number",
+          multipleOf: 5,
         },
       });
 
-      expect(
-        node.querySelectorAll(".field input[type=number]")
-      ).to.have.length.of(1);
+      expect(node.querySelector("input").step).to.eql("5");
     });
 
-    it("should render a string field with a label", () => {
+    it("should use min to represent the minimum keyword", () => {
       const { node } = createFormComponent({
         schema: {
           type: "number",
-          title: "foo",
+          minimum: 0,
         },
       });
 
-      expect(node.querySelector(".field label").textContent).eql("foo");
+      expect(node.querySelector("input").min).to.eql("0");
     });
 
-    it("should render a string field with a description", () => {
+    it("should use max to represent the maximum keyword", () => {
       const { node } = createFormComponent({
         schema: {
           type: "number",
-          description: "bar",
+          maximum: 100,
         },
       });
 
-      expect(node.querySelector(".field-description").textContent).eql("bar");
-    });
-
-    it("should default state value to undefined", () => {
-      const { comp } = createFormComponent({
-        schema: { type: "number" },
-      });
-
-      expect(comp.state.formData).eql(undefined);
-    });
-
-    it("should assign a default value", () => {
-      const { node } = createFormComponent({
-        schema: {
-          type: "number",
-          default: 2,
-        },
-      });
-
-      expect(node.querySelector(".field input").value).eql("2");
-    });
-
-    it("should handle a change event", () => {
-      const { comp, node } = createFormComponent({
-        schema: {
-          type: "number",
-        },
-      });
-
-      Simulate.change(node.querySelector("input"), {
-        target: { value: "2" },
-      });
-
-      expect(comp.state.formData).eql(2);
-    });
-
-    it("should handle a blur event", () => {
-      const onBlur = sandbox.spy();
-      const { node } = createFormComponent({
-        schema: {
-          type: "number",
-        },
-        onBlur,
-      });
-
-      const input = node.querySelector("input");
-      Simulate.blur(input, {
-        target: { value: "2" },
-      });
-
-      expect(onBlur.calledWith(input.id, 2));
-    });
-
-    it("should handle a focus event", () => {
-      const onFocus = sandbox.spy();
-      const { node } = createFormComponent({
-        schema: {
-          type: "number",
-        },
-        onFocus,
-      });
-
-      const input = node.querySelector("input");
-      Simulate.focus(input, {
-        target: { value: "2" },
-      });
-
-      expect(onFocus.calledWith(input.id, 2));
-    });
-
-    it("should fill field with data", () => {
-      const { node } = createFormComponent({
-        schema: {
-          type: "number",
-        },
-        formData: 2,
-      });
-
-      expect(node.querySelector(".field input").value).eql("2");
-    });
-
-    describe("when inputting a number that ends with a dot and/or zero it should normalize it, without changing the input value", () => {
-      const { comp, node } = createFormComponent({
-        schema: {
-          type: "number",
-        },
-      });
-
-      const $input = node.querySelector("input");
-
-      const tests = [
-        {
-          input: "2.",
-          output: 2,
-        },
-        {
-          input: "2.0",
-          output: 2,
-        },
-        {
-          input: "2.3",
-          output: 2.3,
-        },
-        {
-          input: "2.30",
-          output: 2.3,
-        },
-        {
-          input: "2.300",
-          output: 2.3,
-        },
-        {
-          input: "2.3001",
-          output: 2.3001,
-        },
-        {
-          input: "2.03",
-          output: 2.03,
-        },
-        {
-          input: "2.003",
-          output: 2.003,
-        },
-        {
-          input: "2.00300",
-          output: 2.003,
-        },
-        {
-          input: "200300",
-          output: 200300,
-        },
-      ];
-
-      tests.forEach(test => {
-        it(`should work with an input value of ${test.input}`, () => {
-          Simulate.change($input, {
-            target: { value: test.input },
-          });
-
-          expect(comp.state.formData).eql(test.output);
-          expect($input.value).eql(test.input);
-        });
-      });
-    });
-
-    it("should normalize values beginning with a decimal point", () => {
-      const { comp, node } = createFormComponent({
-        schema: {
-          type: "number",
-        },
-      });
-
-      const $input = node.querySelector("input");
-
-      Simulate.change($input, {
-        target: { value: ".00" },
-      });
-
-      expect(comp.state.formData).eql(0);
-      expect($input.value).eql(".00");
-    });
-
-    it("should update input values correctly when formData prop changes", () => {
-      const schema = {
-        type: "number",
-      };
-
-      const { comp, node } = createFormComponent({
-        schema,
-        formData: 2.03,
-      });
-
-      const $input = node.querySelector("input");
-
-      expect($input.value).eql("2.03");
-
-      setProps(comp, {
-        schema,
-        formData: 203,
-      });
-
-      expect($input.value).eql("203");
-    });
-
-    it("should render the widget with the expected id", () => {
-      const { node } = createFormComponent({
-        schema: {
-          type: "number",
-        },
-      });
-
-      expect(node.querySelector("input[type=number]").id).eql("root");
-    });
-
-    it("should render with trailing zeroes", () => {
-      const { node } = createFormComponent({
-        schema: {
-          type: "number",
-        },
-      });
-
-      Simulate.change(node.querySelector("input"), {
-        target: { value: "2." },
-      });
-      expect(node.querySelector(".field input").value).eql("2.");
-
-      Simulate.change(node.querySelector("input"), {
-        target: { value: "2.0" },
-      });
-      expect(node.querySelector(".field input").value).eql("2.0");
-
-      Simulate.change(node.querySelector("input"), {
-        target: { value: "2.00" },
-      });
-      expect(node.querySelector(".field input").value).eql("2.00");
-
-      Simulate.change(node.querySelector("input"), {
-        target: { value: "2.000" },
-      });
-      expect(node.querySelector(".field input").value).eql("2.000");
-    });
-
-    it("should allow a zero to be input", () => {
-      const { node } = createFormComponent({
-        schema: {
-          type: "number",
-        },
-      });
-
-      Simulate.change(node.querySelector("input"), {
-        target: { value: "0" },
-      });
-      expect(node.querySelector(".field input").value).eql("0");
-    });
-
-    it("should render customized StringField", () => {
-      const CustomStringField = () => <div id="custom" />;
-
-      const { node } = createFormComponent({
-        schema: {
-          type: "number",
-        },
-        fields: {
-          StringField: CustomStringField,
-        },
-      });
-
-      expect(node.querySelector("#custom")).to.exist;
+      expect(node.querySelector("input").max).to.eql("100");
     });
 
     it("should use step to represent the multipleOf keyword", () => {
@@ -330,6 +82,301 @@ describe("NumberField", () => {
 
       expect(node.querySelector("input").max).to.eql("100");
     });
+  });
+  describe("Number and text widget", () => {
+    let uiSchemas = [
+      {},
+      {
+        "ui:options": {
+          inputType: "text",
+        },
+      },
+    ];
+    for (let uiSchema of uiSchemas) {
+      it("should render a string field with a label", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "number",
+            title: "foo",
+          },
+          uiSchema,
+        });
+
+        expect(node.querySelector(".field label").textContent).eql("foo");
+      });
+
+      it("should render a string field with a description", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "number",
+            description: "bar",
+          },
+          uiSchema,
+        });
+
+        expect(node.querySelector(".field-description").textContent).eql("bar");
+      });
+
+      it("should default state value to undefined", () => {
+        const { comp } = createFormComponent({
+          schema: { type: "number" },
+          uiSchema,
+        });
+
+        expect(comp.state.formData).eql(undefined);
+      });
+
+      it("should assign a default value", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "number",
+            default: 2,
+          },
+          uiSchema,
+        });
+
+        expect(node.querySelector(".field input").value).eql("2");
+      });
+
+      it("should handle a change event", () => {
+        const { comp, node } = createFormComponent({
+          schema: {
+            type: "number",
+          },
+          uiSchema,
+        });
+
+        Simulate.change(node.querySelector("input"), {
+          target: { value: "2" },
+        });
+
+        expect(comp.state.formData).eql(2);
+      });
+
+      it("should handle a blur event", () => {
+        const onBlur = sandbox.spy();
+        const { node } = createFormComponent({
+          schema: {
+            type: "number",
+          },
+          uiSchema,
+          onBlur,
+        });
+
+        const input = node.querySelector("input");
+        Simulate.blur(input, {
+          target: { value: "2" },
+        });
+
+        expect(onBlur.calledWith(input.id, 2));
+      });
+
+      it("should handle a focus event", () => {
+        const onFocus = sandbox.spy();
+        const { node } = createFormComponent({
+          schema: {
+            type: "number",
+          },
+          uiSchema,
+          onFocus,
+        });
+
+        const input = node.querySelector("input");
+        Simulate.focus(input, {
+          target: { value: "2" },
+        });
+
+        expect(onFocus.calledWith(input.id, 2));
+      });
+
+      it("should fill field with data", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "number",
+          },
+          uiSchema,
+          formData: 2,
+        });
+
+        expect(node.querySelector(".field input").value).eql("2");
+      });
+
+      describe("when inputting a number that ends with a dot and/or zero it should normalize it, without changing the input value", () => {
+        const { comp, node } = createFormComponent({
+          schema: {
+            type: "number",
+          },
+          uiSchema,
+        });
+
+        const $input = node.querySelector("input");
+
+        const tests = [
+          {
+            input: "2.",
+            output: 2,
+          },
+          {
+            input: "2.0",
+            output: 2,
+          },
+          {
+            input: "2.3",
+            output: 2.3,
+          },
+          {
+            input: "2.30",
+            output: 2.3,
+          },
+          {
+            input: "2.300",
+            output: 2.3,
+          },
+          {
+            input: "2.3001",
+            output: 2.3001,
+          },
+          {
+            input: "2.03",
+            output: 2.03,
+          },
+          {
+            input: "2.003",
+            output: 2.003,
+          },
+          {
+            input: "2.00300",
+            output: 2.003,
+          },
+          {
+            input: "200300",
+            output: 200300,
+          },
+        ];
+
+        tests.forEach(test => {
+          it(`should work with an input value of ${test.input}`, () => {
+            Simulate.change($input, {
+              target: { value: test.input },
+            });
+
+            expect(comp.state.formData).eql(test.output);
+            expect($input.value).eql(test.input);
+          });
+        });
+      });
+
+      it("should normalize values beginning with a decimal point", () => {
+        const { comp, node } = createFormComponent({
+          schema: {
+            type: "number",
+          },
+          uiSchema,
+        });
+
+        const $input = node.querySelector("input");
+
+        Simulate.change($input, {
+          target: { value: ".00" },
+        });
+
+        expect(comp.state.formData).eql(0);
+        expect($input.value).eql(".00");
+      });
+
+      it("should update input values correctly when formData prop changes", () => {
+        const schema = {
+          type: "number",
+        };
+
+        const { comp, node } = createFormComponent({
+          schema,
+          uiSchema,
+          formData: 2.03,
+        });
+
+        const $input = node.querySelector("input");
+
+        expect($input.value).eql("2.03");
+
+        setProps(comp, {
+          schema,
+          formData: 203,
+        });
+
+        expect($input.value).eql("203");
+      });
+
+      it("should render the widget with the expected id", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "number",
+          },
+          uiSchema,
+        });
+
+        expect(node.querySelector("input").id).eql("root");
+      });
+
+      it("should render with trailing zeroes", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "number",
+          },
+          uiSchema,
+        });
+
+        Simulate.change(node.querySelector("input"), {
+          target: { value: "2." },
+        });
+        expect(node.querySelector(".field input").value).eql("2.");
+
+        Simulate.change(node.querySelector("input"), {
+          target: { value: "2.0" },
+        });
+        expect(node.querySelector(".field input").value).eql("2.0");
+
+        Simulate.change(node.querySelector("input"), {
+          target: { value: "2.00" },
+        });
+        expect(node.querySelector(".field input").value).eql("2.00");
+
+        Simulate.change(node.querySelector("input"), {
+          target: { value: "2.000" },
+        });
+        expect(node.querySelector(".field input").value).eql("2.000");
+      });
+
+      it("should allow a zero to be input", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "number",
+          },
+          uiSchema,
+        });
+
+        Simulate.change(node.querySelector("input"), {
+          target: { value: "0" },
+        });
+        expect(node.querySelector(".field input").value).eql("0");
+      });
+
+      it("should render customized StringField", () => {
+        const CustomStringField = () => <div id="custom" />;
+
+        const { node } = createFormComponent({
+          schema: {
+            type: "number",
+          },
+          uiSchema,
+          fields: {
+            StringField: CustomStringField,
+          },
+        });
+
+        expect(node.querySelector("#custom")).to.exist;
+      });
+    }
   });
 
   describe("SelectWidget", () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes #1355.

Changed some of the number field tests to run both on the default uiSchema and the uiSchema with the input type set to "text".

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
