### PR TITLE
Fix expected value of input in test for NumberField

### DIFF
--- a/test/NumberField_test.js
+++ b/test/NumberField_test.js
@@ -207,7 +207,7 @@ describe("NumberField", () => {
       });
 
       expect(comp.state.formData).eql(0);
-      expect($input.value).eql("0");
+      expect($input.value).eql(".00");
     });
 
     it("should update input values correctly when formData prop changes", () => {


### PR DESCRIPTION
### Reasons for making this change

Related to #1355.

".00" is the expected input value. The `formData` remains `0`.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature