### PR TITLE
Run lint-staged only on the checked-in files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "prettierOptions": "--jsx-bracket-same-line --trailing-comma es5 --semi --tab-width 2",
   "lint-staged": {
     "{playground,src,test}/**/*.js": [
-      "npm run lint",
-      "npm run cs-format",
+      "eslint --fix",
+      "prettier --jsx-bracket-same-line --trailing-comma es5 --use-tabs false --semi --tab-width 2 --write",
       "git add"
     ]
   },


### PR DESCRIPTION
### Reasons for making this change

Previously, lint-staged was running prettier and eslint on _all_ files changed, rather than just the checked-in files. This PR fixes that.