### PR TITLE
Fix publicPath for playground

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -9,7 +9,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, "build"),
     filename: "bundle.js",
-    publicPath: "/static/"
+    publicPath: "/react-jsonschema-form/"
   },
   plugins: [
     new MonacoWebpackPlugin({


### PR DESCRIPTION
### Reasons for making this change

Fixes the publicPath for the playground to "react-jsonschema-form". This way, when the playground is hosted at https://mozilla-services.github.io/react-jsonschema-form, fetching other js files will work. This problem cropped up recently with adding in the Monaco editor, as it generates a few other js worker files.

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
