### PR TITLE
Add extraErrors prop (allows async validation)

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -310,12 +310,19 @@ class App extends Component {
   constructor(props) {
     super(props);
     // initialize state with Simple data sample
-    const { schema, uiSchema, formData, validate } = samples.Simple;
+    const {
+      schema,
+      uiSchema,
+      formData,
+      validate,
+      extraErrors,
+    } = samples.Simple;
     this.state = {
       form: false,
       schema,
       uiSchema,
       formData,
+      extraErrors,
       validate,
       editor: "default",
       theme: "default",

--- a/playground/app.js
+++ b/playground/app.js
@@ -377,6 +377,9 @@ class App extends Component {
 
   onFormDataEdited = formData => this.setState({ formData, shareURL: null });
 
+  onExtraErrorsEdited = extraErrors =>
+    this.setState({ extraErrors, shareURL: null });
+
   onThemeSelected = (theme, { stylesheet, editor }) => {
     this.setState({ theme, editor: editor ? editor : "default" });
     setImmediate(() => {
@@ -415,6 +418,7 @@ class App extends Component {
       ArrayFieldTemplate,
       ObjectFieldTemplate,
       transformErrors,
+      extraErrors,
     } = this.state;
 
     return (
@@ -439,12 +443,24 @@ class App extends Component {
           </div>
         </div>
         <div className="col-sm-7">
-          <Editor
-            title="JSONSchema"
-            theme={editor}
-            code={toJson(schema)}
-            onChange={this.onSchemaEdited}
-          />
+          <div className="row">
+            <div className="col-sm-6">
+              <Editor
+                title="JSONSchema"
+                theme={editor}
+                code={toJson(schema)}
+                onChange={this.onSchemaEdited}
+              />
+            </div>
+            <div className="col-sm-6">
+              <Editor
+                title="extraErrors"
+                theme={editor}
+                code={toJson(extraErrors)}
+                onChange={this.onExtraErrorsEdited}
+              />
+            </div>
+          </div>
           <div className="row">
             <div className="col-sm-6">
               <Editor
@@ -476,6 +492,7 @@ class App extends Component {
               schema={schema}
               uiSchema={uiSchema}
               formData={formData}
+              extraErrors={extraErrors}
               onChange={this.onFormDataChange}
               onSubmit={({ formData }, e) => {
                 console.log("submitted formData", formData);

--- a/playground/samples/alternatives.js
+++ b/playground/samples/alternatives.js
@@ -86,4 +86,5 @@ module.exports = {
     colorPalette: ["#ff0000"],
     blendMode: "screen",
   },
+  extraErrors: [],
 };

--- a/playground/samples/anyOf.js
+++ b/playground/samples/anyOf.js
@@ -56,4 +56,5 @@ module.exports = {
     ],
   },
   formData: {},
+  extraErrors: [],
 };

--- a/playground/samples/arrays.js
+++ b/playground/samples/arrays.js
@@ -174,4 +174,5 @@ module.exports = {
     noToolbar: ["one", "two"],
     fixedNoToolbar: [42, true, "additional item one", "additional item two"],
   },
+  extraErrors: [],
 };

--- a/playground/samples/custom.js
+++ b/playground/samples/custom.js
@@ -19,4 +19,5 @@ module.exports = {
     lat: 0,
     lon: 0,
   },
+  extraErrors: [],
 };

--- a/playground/samples/customArray.js
+++ b/playground/samples/customArray.js
@@ -55,4 +55,5 @@ export default {
   },
   formData: ["react", "jsonschema", "form"],
   ArrayFieldTemplate,
+  extraErrors: [],
 };

--- a/playground/samples/customObject.js
+++ b/playground/samples/customObject.js
@@ -62,4 +62,5 @@ export default {
     password: "noneed",
   },
   ObjectFieldTemplate,
+  extraErrors: [],
 };

--- a/playground/samples/date.js
+++ b/playground/samples/date.js
@@ -53,4 +53,5 @@ module.exports = {
     },
   },
   formData: {},
+  extraErrors: [],
 };

--- a/playground/samples/errors.js
+++ b/playground/samples/errors.js
@@ -39,4 +39,5 @@ module.exports = {
     skills: ["karate", "budo", "aikido"],
     multipleChoicesList: ["foo", "bar", "fuzz"],
   },
+  extraErrors: [],
 };

--- a/playground/samples/extraErrors.js
+++ b/playground/samples/extraErrors.js
@@ -29,6 +29,7 @@ module.exports = {
     {
       property: ".firstName",
       message: "An extra error, could be added asynchronously.",
+      stack: ".firstName has an extra error, could be added asynchronously.",
     },
   ],
 };

--- a/playground/samples/extraErrors.js
+++ b/playground/samples/extraErrors.js
@@ -1,12 +1,9 @@
 module.exports = {
   schema: {
-    title: "A customizable registration form",
-    description: "A simple form with additional properties example.",
+    title: "Extra error example",
+    description: "A form with an extra error on the firstName property.",
     type: "object",
     required: ["firstName", "lastName"],
-    additionalProperties: {
-      type: "string",
-    },
     properties: {
       firstName: {
         type: "string",
@@ -27,7 +24,11 @@ module.exports = {
   formData: {
     firstName: "Chuck",
     lastName: "Norris",
-    assKickCount: "infinity",
   },
-  extraErrors: [],
+  extraErrors: [
+    {
+      property: ".firstName",
+      message: "An extra error, could be added asynchronously.",
+    },
+  ],
 };

--- a/playground/samples/files.js
+++ b/playground/samples/files.js
@@ -29,4 +29,5 @@ module.exports = {
     },
   },
   formData: {},
+  extraErrors: [],
 };

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -22,6 +22,7 @@ import schemaDependencies from "./schemaDependencies";
 import additionalProperties from "./additionalProperties";
 import nullable from "./nullable";
 import nullField from "./null";
+import extraErrors from "./extraErrors";
 
 export const samples = {
   Simple: simple,
@@ -48,4 +49,5 @@ export const samples = {
   "One Of": oneOf,
   "Null fields": nullField,
   Nullable: nullable,
+  "Extra errors": extraErrors,
 };

--- a/playground/samples/large.js
+++ b/playground/samples/large.js
@@ -36,4 +36,5 @@ module.exports = {
     },
   },
   formData: {},
+  extraErrors: [],
 };

--- a/playground/samples/nested.js
+++ b/playground/samples/nested.js
@@ -61,4 +61,5 @@ module.exports = {
       },
     ],
   },
+  extraErrors: [],
 };

--- a/playground/samples/null.js
+++ b/playground/samples/null.js
@@ -25,4 +25,5 @@ module.exports = {
     },
   },
   formData: {},
+  extraErrors: [],
 };

--- a/playground/samples/nullable.js
+++ b/playground/samples/nullable.js
@@ -70,4 +70,5 @@ module.exports = {
     bio: null,
     password: "noneed",
   },
+  extraErrors: [],
 };

--- a/playground/samples/numbers.js
+++ b/playground/samples/numbers.js
@@ -60,4 +60,5 @@ module.exports = {
     integerRange: 42,
     integerRangeSteps: 80,
   },
+  extraErrors: [],
 };

--- a/playground/samples/oneOf.js
+++ b/playground/samples/oneOf.js
@@ -21,4 +21,5 @@ module.exports = {
     ],
   },
   formData: {},
+  extraErrors: [],
 };

--- a/playground/samples/ordering.js
+++ b/playground/samples/ordering.js
@@ -45,4 +45,5 @@ module.exports = {
     bio: "Roundhouse kicking asses since 1940",
     password: "noneed",
   },
+  extraErrors: [],
 };

--- a/playground/samples/propertyDependencies.js
+++ b/playground/samples/propertyDependencies.js
@@ -81,4 +81,5 @@ module.exports = {
       name: "Jill",
     },
   },
+  extraErrors: [],
 };

--- a/playground/samples/references.js
+++ b/playground/samples/references.js
@@ -58,4 +58,5 @@ module.exports = {
       children: [{ name: "leaf" }],
     },
   },
+  extraErrors: [],
 };

--- a/playground/samples/schemaDependencies.js
+++ b/playground/samples/schemaDependencies.js
@@ -168,4 +168,5 @@ module.exports = {
       },
     ],
   },
+  extraErrors: [],
 };

--- a/playground/samples/simple.js
+++ b/playground/samples/simple.js
@@ -66,4 +66,5 @@ module.exports = {
     bio: "Roundhouse kicking asses since 1940",
     password: "noneed",
   },
+  extraErrors: [],
 };

--- a/playground/samples/single.js
+++ b/playground/samples/single.js
@@ -5,4 +5,5 @@ module.exports = {
   },
   formData: "initial value",
   uiSchema: {},
+  extraErrors: [],
 };

--- a/playground/samples/validation.js
+++ b/playground/samples/validation.js
@@ -47,4 +47,5 @@ export default {
   formData: {},
   validate,
   transformErrors,
+  extraErrors: [],
 };

--- a/playground/samples/widgets.js
+++ b/playground/samples/widgets.js
@@ -177,4 +177,5 @@ export default {
     },
     secret: "I'm a hidden string.",
   },
+  extraErrors: [],
 };

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -64,7 +64,7 @@ export default class Form extends Component {
     const uiSchema = "uiSchema" in props ? props.uiSchema : this.props.uiSchema;
     const edit = typeof inputFormData !== "undefined";
     const extraErrorsChange =
-      !prevProps || props.extraErrors !== prevProps.extraErrors;
+      !prevProps || (props.extraErrors !== prevProps.extraErrors);
     const liveValidate = props.liveValidate || this.props.liveValidate;
     const mustValidate =
       edit && !props.noValidate && (liveValidate || extraErrorsChange);

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -43,7 +43,11 @@ export default class Form extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const nextState = this.getStateFromProps(nextProps, nextProps.formData);
+    const nextState = this.getStateFromProps(
+      nextProps,
+      nextProps.formData,
+      this.props
+    );
     if (
       !deepEquals(nextState.formData, nextProps.formData) &&
       !deepEquals(nextState.formData, this.state.formData) &&
@@ -60,7 +64,7 @@ export default class Form extends Component {
     const uiSchema = "uiSchema" in props ? props.uiSchema : this.props.uiSchema;
     const edit = typeof inputFormData !== "undefined";
     const extraErrorsChange =
-      prevProps && props.extraErrors && prevProps.extraErrors;
+      !!prevProps && props.extraErrors !== prevProps.extraErrors;
     const liveValidate = props.liveValidate || this.props.liveValidate;
     const mustValidate =
       edit && !props.noValidate && (liveValidate || extraErrorsChange);
@@ -70,7 +74,13 @@ export default class Form extends Component {
     const customFormats = props.customFormats;
     const additionalMetaSchemas = props.additionalMetaSchemas;
     const { errors, errorSchema } = mustValidate
-      ? this.validate(formData, schema, additionalMetaSchemas, customFormats)
+      ? this.validate(
+          formData,
+          schema,
+          additionalMetaSchemas,
+          customFormats,
+          props.extraErrors
+        )
       : {
           errors: state.errors || [],
           errorSchema: state.errorSchema || {},
@@ -104,9 +114,10 @@ export default class Form extends Component {
     formData,
     schema = this.props.schema,
     additionalMetaSchemas = this.props.additionalMetaSchemas,
-    customFormats = this.props.customFormats
+    customFormats = this.props.customFormats,
+    extraErrors = this.props.extraErrors
   ) {
-    const { validate, transformErrors, extraErrors } = this.props;
+    const { validate, transformErrors } = this.props;
     const { definitions } = this.getRegistry();
     const resolvedSchema = retrieveSchema(schema, definitions, formData);
     return validateFormData(

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -64,7 +64,7 @@ export default class Form extends Component {
     const uiSchema = "uiSchema" in props ? props.uiSchema : this.props.uiSchema;
     const edit = typeof inputFormData !== "undefined";
     const extraErrorsChange =
-      !!prevProps && props.extraErrors !== prevProps.extraErrors;
+      !prevProps || props.extraErrors !== prevProps.extraErrors;
     const liveValidate = props.liveValidate || this.props.liveValidate;
     const mustValidate =
       edit && !props.noValidate && (liveValidate || extraErrorsChange);

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -59,7 +59,8 @@ export default class Form extends Component {
     const schema = "schema" in props ? props.schema : this.props.schema;
     const uiSchema = "uiSchema" in props ? props.uiSchema : this.props.uiSchema;
     const edit = typeof inputFormData !== "undefined";
-    const extraErrorsChange = props.extraErrors && prevProps.extraErrors;
+    const extraErrorsChange =
+      prevProps && props.extraErrors && prevProps.extraErrors;
     const liveValidate = props.liveValidate || this.props.liveValidate;
     const mustValidate =
       edit && !props.noValidate && (liveValidate || extraErrorsChange);

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -64,7 +64,7 @@ export default class Form extends Component {
     const uiSchema = "uiSchema" in props ? props.uiSchema : this.props.uiSchema;
     const edit = typeof inputFormData !== "undefined";
     const extraErrorsChange =
-      !prevProps || (props.extraErrors !== prevProps.extraErrors);
+      !prevProps || props.extraErrors !== prevProps.extraErrors;
     const liveValidate = props.liveValidate || this.props.liveValidate;
     const mustValidate =
       edit && !props.noValidate && (liveValidate || extraErrorsChange);
@@ -255,9 +255,14 @@ export default class Form extends Component {
       newFormData = this.getUsedFormData(this.state.formData, fieldNames);
     }
 
+    let errors = [];
+    let errorSchema = {};
     if (!this.props.noValidate) {
-      const { errors, errorSchema } = this.validate(newFormData);
-      if (Object.keys(errors).length > 0) {
+      const validationResult = this.validate(newFormData);
+      errors = validationResult.errors;
+      errorSchema = validationResult.errorSchema;
+      let canSubmit = validationResult.canSubmit;
+      if (!canSubmit) {
         setState(this, { errors, errorSchema }, () => {
           if (this.props.onError) {
             this.props.onError(errors);
@@ -269,17 +274,14 @@ export default class Form extends Component {
       }
     }
 
-    this.setState(
-      { formData: newFormData, errors: [], errorSchema: {} },
-      () => {
-        if (this.props.onSubmit) {
-          this.props.onSubmit(
-            { ...this.state, formData: newFormData, status: "submitted" },
-            event
-          );
-        }
+    this.setState({ formData: newFormData, errors, errorSchema }, () => {
+      if (this.props.onSubmit) {
+        this.props.onSubmit(
+          { ...this.state, formData: newFormData, status: "submitted" },
+          event
+        );
       }
-    );
+    });
   };
 
   getRegistry() {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -27,6 +27,7 @@ export default class Form extends Component {
     noHtml5Validate: false,
     ErrorList: DefaultErrorList,
     omitExtraData: false,
+    extraErrors: [],
   };
 
   constructor(props) {
@@ -53,13 +54,15 @@ export default class Form extends Component {
     this.setState(nextState);
   }
 
-  getStateFromProps(props, inputFormData) {
+  getStateFromProps(props, inputFormData, prevProps) {
     const state = this.state || {};
     const schema = "schema" in props ? props.schema : this.props.schema;
     const uiSchema = "uiSchema" in props ? props.uiSchema : this.props.uiSchema;
     const edit = typeof inputFormData !== "undefined";
+    const extraErrorsChange = props.extraErrors && prevProps.extraErrors;
     const liveValidate = props.liveValidate || this.props.liveValidate;
-    const mustValidate = edit && !props.noValidate && liveValidate;
+    const mustValidate =
+      edit && !props.noValidate && (liveValidate || extraErrorsChange);
     const { definitions } = schema;
     const formData = getDefaultFormState(schema, inputFormData, definitions);
     const retrievedSchema = retrieveSchema(schema, definitions, formData);
@@ -102,7 +105,7 @@ export default class Form extends Component {
     additionalMetaSchemas = this.props.additionalMetaSchemas,
     customFormats = this.props.customFormats
   ) {
-    const { validate, transformErrors } = this.props;
+    const { validate, transformErrors, extraErrors } = this.props;
     const { definitions } = this.getRegistry();
     const resolvedSchema = retrieveSchema(schema, definitions, formData);
     return validateFormData(
@@ -111,7 +114,8 @@ export default class Form extends Component {
       validate,
       transformErrors,
       additionalMetaSchemas,
-      customFormats
+      customFormats,
+      extraErrors
     );
   }
 
@@ -363,6 +367,7 @@ if (process.env.NODE_ENV !== "production") {
     schema: PropTypes.object.isRequired,
     uiSchema: PropTypes.object,
     formData: PropTypes.any,
+    extraErrors: PropTypes.array,
     widgets: PropTypes.objectOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object])
     ),

--- a/src/validate.js
+++ b/src/validate.js
@@ -170,7 +170,8 @@ export default function validateFormData(
   customValidate,
   transformErrors,
   additionalMetaSchemas = [],
-  customFormats = {}
+  customFormats = {},
+  extraErrors = []
 ) {
   // Include form data with undefined values, which is required for validation.
   const { definitions } = schema;
@@ -210,9 +211,11 @@ export default function validateFormData(
   }
 
   let errors = transformAjvErrors(ajv.errors);
-  // Clear errors to prevent persistent errors, see #1104
 
+  // Clear errors to prevent persistent errors, see #1104
   ajv.errors = null;
+
+  errors = errors.concat(extraErrors);
 
   const noProperMetaSchema =
     validationError &&

--- a/src/validate.js
+++ b/src/validate.js
@@ -210,6 +210,9 @@ export default function validateFormData(
     validationError = err;
   }
 
+  // No ajv errors found, only async errors possible now
+  let canSubmit = !ajv.errors;
+
   let errors = transformAjvErrors(ajv.errors);
 
   // Clear errors to prevent persistent errors, see #1104
@@ -249,7 +252,7 @@ export default function validateFormData(
   }
 
   if (typeof customValidate !== "function") {
-    return { errors, errorSchema };
+    return { errors, errorSchema, canSubmit };
   }
 
   const errorHandler = customValidate(formData, createErrorHandler(formData));
@@ -263,6 +266,7 @@ export default function validateFormData(
   return {
     errors: newErrors,
     errorSchema: newErrorSchema,
+    canSubmit,
   };
 }
 

--- a/test/extraErrors_test.js
+++ b/test/extraErrors_test.js
@@ -1,0 +1,21 @@
+import { createSandbox } from "./test_utils";
+
+describe("extraErrors", () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should not render extra errors if the prop is not present", () => {
+    // TODO
+  });
+
+  it("should errors if the prop is present", () => {
+    // TODO
+  });
+});


### PR DESCRIPTION
### Reasons for making this change

This is another attempt at adding async validation. The method used is similar to PR #874.
I have already outlined my idea in issue #1381.

Basically, what this PR does is add an extraErrors prop to the Form component. Errors in this prop are added to the other validation errors. This makes async validation possible because the surrounding component can perform async validation either on submit or on validation.

I have attempted to write tests but failed miserably, any help would be appreciated.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
