### PR TITLE
Key changes on additionalProperties items no longer suffer data loss.

### DIFF
--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -70,6 +70,7 @@ class ObjectField extends Component {
   };
 
   state = {
+    wasPropertyKeyModified: false,
     additionalProperties: {},
   };
 
@@ -128,6 +129,7 @@ class ObjectField extends Component {
       if (oldValue === value) {
         return;
       }
+
       value = this.getAvailableKey(value, this.props.formData);
       const newFormData = { ...this.props.formData };
       const newKeys = { [oldValue]: value };
@@ -136,6 +138,9 @@ class ObjectField extends Component {
         return { [newKey]: newFormData[key] };
       });
       const renamedObj = Object.assign({}, ...keyValues);
+
+      this.setState({ wasPropertyKeyModified: true });
+
       this.props.onChange(
         renamedObj,
         errorSchema &&
@@ -191,10 +196,19 @@ class ObjectField extends Component {
       onFocus,
       registry = getDefaultRegistry(),
     } = this.props;
+
     const { definitions, fields, formContext } = registry;
     const { SchemaField, TitleField, DescriptionField } = fields;
     const schema = retrieveSchema(this.props.schema, definitions, formData);
-    const title = schema.title === undefined ? name : schema.title;
+
+    // If this schema has a title defined, but the user has set a new key/label, retain their input.
+    let title;
+    if (this.state.wasPropertyKeyModified) {
+      title = name;
+    } else {
+      title = schema.title === undefined ? name : schema.title;
+    }
+
     const description = uiSchema["ui:description"] || schema.description;
     let orderedProperties;
     try {
@@ -242,6 +256,7 @@ class ObjectField extends Component {
               idSchema={idSchema[name]}
               idPrefix={idPrefix}
               formData={(formData || {})[name]}
+              wasPropertyKeyModified={this.state.wasPropertyKeyModified}
               onKeyChange={this.onKeyChange(name)}
               onChange={this.onPropertyChange(
                 name,

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -235,6 +235,7 @@ function SchemaFieldRender(props) {
     onDropPropertyClick,
     required,
     registry = getDefaultRegistry(),
+    wasPropertyKeyModified = false,
   } = props;
   const { definitions, fields, formContext } = registry;
   const FieldTemplate =
@@ -296,8 +297,15 @@ function SchemaFieldRender(props) {
 
   const { type } = schema;
   const id = idSchema.$id;
-  const label =
-    uiSchema["ui:title"] || props.schema.title || schema.title || name;
+
+  // If this schema has a title defined, but the user has set a new key/label, retain their input.
+  let label;
+  if (wasPropertyKeyModified) {
+    label = name;
+  } else {
+    label = uiSchema["ui:title"] || props.schema.title || schema.title || name;
+  }
+
   const description =
     uiSchema["ui:description"] ||
     props.schema.description ||

--- a/test/ObjectField_test.js
+++ b/test/ObjectField_test.js
@@ -552,6 +552,26 @@ describe("ObjectField", () => {
       expect(comp.state.formData.newFirst).eql(1);
     });
 
+    it("should retain user-input data if key-value pair has a title present in the schema", () => {
+      const { comp, node } = createFormComponent({
+        schema: {
+          type: "object",
+          additionalProperties: {
+            title: "Custom title",
+            type: "string",
+          },
+        },
+        formData: { "Custom title": 1 },
+      });
+
+      const textNode = node.querySelector("#root_Custom\\ title-key");
+      Simulate.blur(textNode, {
+        target: { value: "Renamed custom title" },
+      });
+
+      expect(comp.state.formData["Renamed custom title"]).eql(1);
+    });
+
     it("should keep order of renamed key-value pairs while renaming key", () => {
       const { comp, node } = createFormComponent({
         schema,


### PR DESCRIPTION
### Reasons for making this change

If there is an `additionalProperties` object present that has a `title` contained within it, the input form data for that title is overridden whenever you click out of the input, resulting in user-entered data being lost.

This resolves https://github.com/mozilla-services/react-jsonschema-form/issues/1382, and here is a local dev playground link to see the fix in action:

http://localhost:8080/#eyJmb3JtRGF0YSI6e30sInNjaGVtYSI6eyJ0aXRsZSI6IkEgY3VzdG9taXphYmxlIHJlZ2lzdHJhdGlvbiBmb3JtIiwiZGVzY3JpcHRpb24iOiJBIHNpbXBsZSBmb3JtIHdpdGggYWRkaXRpb25hbCBwcm9wZXJ0aWVzIGV4YW1wbGUuIiwidHlwZSI6Im9iamVjdCIsImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7InR5cGUiOiJvYmplY3QiLCJwcm9wZXJ0aWVzIjp7ImNvZGUiOnsidHlwZSI6ImludGVnZXIifSwidGV4dCI6eyJ0eXBlIjoic3RyaW5nIn19LCJ0aXRsZSI6IlRoaXMgaXMgYSBjdXN0b20gdGl0bGUifX0sInVpU2NoZW1hIjp7fX0=

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
