### PR TITLE
Adding support for $ref pointers to additionalProperties.

### DIFF
--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -168,13 +168,32 @@ class ObjectField extends Component {
   }
 
   handleAddClick = schema => () => {
-    const type = schema.additionalProperties.type;
+    let type = schema.additionalProperties.type;
     const newFormData = { ...this.props.formData };
+
+    if (
+      type === undefined &&
+      schema.additionalProperties.hasOwnProperty("$ref")
+    ) {
+      const refSchema = retrieveSchema(
+        schema.additionalProperties,
+        this.getDefinitions(),
+        this.props.formData
+      );
+      type = refSchema.type;
+    }
+
     newFormData[
       this.getAvailableKey("newKey", newFormData)
     ] = this.getDefaultValue(type);
+
     this.props.onChange(newFormData);
   };
+
+  getDefinitions() {
+    const { registry = getDefaultRegistry() } = this.props;
+    return registry.definitions;
+  }
 
   render() {
     const {

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -171,16 +171,14 @@ class ObjectField extends Component {
     let type = schema.additionalProperties.type;
     const newFormData = { ...this.props.formData };
 
-    if (
-      type === undefined &&
-      schema.additionalProperties.hasOwnProperty("$ref")
-    ) {
+    if (schema.additionalProperties.hasOwnProperty("$ref")) {
       const { registry = getDefaultRegistry() } = this.props;
       const refSchema = retrieveSchema(
-        schema.additionalProperties,
+        { $ref: schema.additionalProperties["$ref"] },
         registry.definitions,
         this.props.formData
       );
+
       type = refSchema.type;
     }
 

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -175,9 +175,10 @@ class ObjectField extends Component {
       type === undefined &&
       schema.additionalProperties.hasOwnProperty("$ref")
     ) {
+      const { registry = getDefaultRegistry() } = this.props;
       const refSchema = retrieveSchema(
         schema.additionalProperties,
-        this.getDefinitions(),
+        registry.definitions,
         this.props.formData
       );
       type = refSchema.type;
@@ -189,11 +190,6 @@ class ObjectField extends Component {
 
     this.props.onChange(newFormData);
   };
-
-  getDefinitions() {
-    const { registry = getDefaultRegistry() } = this.props;
-    return registry.definitions;
-  }
 
   render() {
     const {

--- a/src/utils.js
+++ b/src/utils.js
@@ -537,6 +537,7 @@ export function stubExistingAdditionalProperties(
     ...schema,
     properties: { ...schema.properties },
   };
+
   Object.keys(formData).forEach(key => {
     if (schema.properties.hasOwnProperty(key)) {
       // No need to stub, our schema already has the property
@@ -544,14 +545,14 @@ export function stubExistingAdditionalProperties(
     }
 
     let additionalProperties;
-    if (schema.additionalProperties.hasOwnProperty("type")) {
-      additionalProperties = { ...schema.additionalProperties };
-    } else if (schema.additionalProperties.hasOwnProperty("$ref")) {
+    if (schema.additionalProperties.hasOwnProperty("$ref")) {
       additionalProperties = retrieveSchema(
-        schema.additionalProperties,
+        { $ref: schema.additionalProperties["$ref"] },
         definitions,
         formData
       );
+    } else if (schema.additionalProperties.hasOwnProperty("type")) {
+      additionalProperties = { ...schema.additionalProperties };
     } else {
       additionalProperties = { type: guessType(formData[key]) };
     }
@@ -561,6 +562,7 @@ export function stubExistingAdditionalProperties(
     // Set our additional property flag so we know it was dynamically added
     schema.properties[key][ADDITIONAL_PROPERTY_FLAG] = true;
   });
+
   return schema;
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -542,11 +542,20 @@ export function stubExistingAdditionalProperties(
       // No need to stub, our schema already has the property
       return;
     }
-    const additionalProperties = schema.additionalProperties.hasOwnProperty(
-      "type"
-    )
-      ? { ...schema.additionalProperties }
-      : { type: guessType(formData[key]) };
+
+    let additionalProperties;
+    if (schema.additionalProperties.hasOwnProperty("type")) {
+      additionalProperties = { ...schema.additionalProperties };
+    } else if (schema.additionalProperties.hasOwnProperty("$ref")) {
+      additionalProperties = retrieveSchema(
+        schema.additionalProperties,
+        definitions,
+        formData
+      );
+    } else {
+      additionalProperties = { type: guessType(formData[key]) };
+    }
+
     // The type of our new key should match the additionalProperties value;
     schema.properties[key] = additionalProperties;
     // Set our additional property flag so we know it was dynamically added

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -516,6 +516,24 @@ describe("Form", () => {
       expect(node.querySelector("input[type=text]").value).eql("hello");
     });
 
+    it("should propagate referenced definition defaults in objects with additionalProperties", () => {
+      const schema = {
+        definitions: {
+          testdef: { type: "string" },
+        },
+        type: "object",
+        additionalProperties: {
+          $ref: "#/definitions/testdef",
+        },
+      };
+
+      const { node } = createFormComponent({ schema });
+
+      Simulate.click(node.querySelector(".btn-add"));
+
+      expect(node.querySelector("input[type=text]").value).eql("newKey");
+    });
+
     it("should recursively handle referenced definitions", () => {
       const schema = {
         $ref: "#/definitions/node",

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -534,6 +534,27 @@ describe("Form", () => {
       expect(node.querySelector("input[type=text]").value).eql("newKey");
     });
 
+    it("should propagate referenced definition defaults in objects with additionalProperties that have a type present", () => {
+      // Though `additionalProperties` has a `type` present here, it also has a `$ref` so that
+      // referenced schema should override it.
+      const schema = {
+        definitions: {
+          testdef: { type: "number" },
+        },
+        type: "object",
+        additionalProperties: {
+          type: "string",
+          $ref: "#/definitions/testdef",
+        },
+      };
+
+      const { node } = createFormComponent({ schema });
+
+      Simulate.click(node.querySelector(".btn-add"));
+
+      expect(node.querySelector("input[type=number]").value).eql("0");
+    });
+
     it("should recursively handle referenced definitions", () => {
       const schema = {
         $ref: "#/definitions/node",

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import React from "react";
 
 import {
+  ADDITIONAL_PROPERTY_FLAG,
   asNumber,
   orderProperties,
   dataURItoBlob,
@@ -1069,6 +1070,38 @@ describe("utils", () => {
       const definitions = { "a~complex/name": address };
 
       expect(retrieveSchema(schema, definitions)).eql(address);
+    });
+
+    it("should 'resolve' and stub out a schema which contains an `additionalProperties` with a definition", () => {
+      const schema = {
+        type: "object",
+        additionalProperties: {
+          $ref: "#/definitions/components/schemas/address",
+        },
+      };
+
+      const address = {
+        type: "object",
+        properties: {
+          street_address: { type: "string" },
+          city: { type: "string" },
+          state: { type: "string" },
+        },
+        required: ["street_address", "city", "state"],
+      };
+
+      const definitions = { components: { schemas: { address } } };
+      const formData = { newKey: {} };
+
+      expect(retrieveSchema(schema, definitions, formData)).eql({
+        ...schema,
+        properties: {
+          newKey: {
+            ...address,
+            [ADDITIONAL_PROPERTY_FLAG]: true,
+          },
+        },
+      });
     });
 
     it("should priorize local definitions over foreign ones", () => {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1104,6 +1104,32 @@ describe("utils", () => {
       });
     });
 
+    it.only("should 'resolve' and stub out a schema which contains an `additionalProperties` with a type and definition", () => {
+      const schema = {
+        type: "string",
+        additionalProperties: {
+          $ref: "#/definitions/number",
+        },
+      };
+
+      const number = {
+        type: "number",
+      };
+
+      const definitions = { number };
+      const formData = { newKey: {} };
+
+      expect(retrieveSchema(schema, definitions, formData)).eql({
+        ...schema,
+        properties: {
+          newKey: {
+            ...number,
+            [ADDITIONAL_PROPERTY_FLAG]: true,
+          },
+        },
+      });
+    });
+
     it("should priorize local definitions over foreign ones", () => {
       const schema = {
         $ref: "#/definitions/address",


### PR DESCRIPTION
### Reasons for making this change

This adds support for `$ref` pointers on `additionalProperties` objects.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
