### PR TITLE
Fix omitData for top level array

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -139,7 +139,12 @@ export default class Form extends Component {
       return formData;
     }
 
-    return _pick(formData, fields);
+    let data = _pick(formData, fields);
+    if (typeof formData === "array") {
+      return Object.keys(data).map((k) => data[k]);
+    } else {
+      return data;
+    }
   };
 
   getFieldNames = (pathSchema, formData) => {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -142,9 +142,9 @@ export default class Form extends Component {
     let data = _pick(formData, fields);
     if (Array.isArray(formData)) {
       return Object.keys(data).map(key => data[key]);
-    } else {
-      return data;
     }
+
+    return data;
   };
 
   getFieldNames = (pathSchema, formData) => {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -140,8 +140,8 @@ export default class Form extends Component {
     }
 
     let data = _pick(formData, fields);
-    if (typeof formData === "array") {
-      return Object.keys(data).map((k) => data[k]);
+    if (Array.isArray(formData)) {
+      return Object.keys(data).map(key => data[key]);
     } else {
       return data;
     }

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -866,6 +866,25 @@ describe("Form", () => {
       expect(result).eql("foo");
     });
 
+    it("should return the root level array", () => {
+      const schema = {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      };
+      const formData = [];
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const result = comp.getUsedFormData(formData, []);
+      expect(result).eql([]);
+    });
+
     it("should call getUsedFormData with data from fields in event", () => {
       const schema = {
         type: "object",


### PR DESCRIPTION
### Reasons for making this change

Enabling omitData currently converts a top level array to an object. Now includes a check if the form's top level type is an array, and converts back to an array if necessary.

#1396

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
