### PR TITLE
Fix publicPath for netlify deploy previews

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -9,7 +9,7 @@ module.exports = {
   output: {
     path: path.join(__dirname, "build"),
     filename: "bundle.js",
-    publicPath: "/react-jsonschema-form/"
+    publicPath: process.env.SHOW_NETLIFY_BADGE ? "": "/react-jsonschema-form/"
   },
   plugins: [
     new MonacoWebpackPlugin({


### PR DESCRIPTION
### Reasons for making this change

This fixes the Monaco editor on netlify deploy previews.

Previously, publicPath on deploy previews was set to "/react-jsonschema-form/" which ended up making the right scripts not load properly and give errors like this:

![image](https://user-images.githubusercontent.com/1689183/63064162-d943ca00-beb4-11e9-9633-a921e65f6645.png)


### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
