### PR TITLE
[Feat] Introduce a More Flexible Way to Trigger Form Submit Programmatically

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -163,6 +163,22 @@ render((
 yourForm.submit();
 ```
 
+Alternatively, if your form component is given an `id`, instead of getting a reference to the `Form` component, you can use the utility function `submitForm` to submit the form programmatically. Advantage of using this approach is that you now don't have to pass the form component reference around, if your implementation needs to trigger the form submit in another component (say, a modal) or as part of a data flow (say, a redux middleware after some AJAX finishes).
+
+```js
+import Form, { submitForm } from 'react-jsonschema-form';
+
+const onSubmit = ({formData}) => console.log("Data submitted: ",  formData);
+const formId = 'my-form';
+
+render((
+  <Form id={formId} schema={schema}
+        onSubmit={onSubmit} ref={(form) => {yourForm = form;}}/>
+), document.getElementById("app"));
+
+submitForm(formId);
+```
+
 ## Styling your forms
 
 This library renders form fields and widgets leveraging the [Bootstrap](http://getbootstrap.com/) semantics. That means your forms will be beautiful by default if you're loading its stylesheet in your page.

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -14,6 +14,8 @@ import {
   deepEquals,
   toPathSchema,
   isObject,
+  registerFormNode,
+  unregisterFormNode,
 } from "../utils";
 import validateFormData, { toErrorList } from "../validate";
 
@@ -327,6 +329,7 @@ export default class Form extends Component {
         onSubmit={this.onSubmit}
         ref={form => {
           this.formElement = form;
+          registerFormNode(this.props.id, form);
         }}>
         {this.renderErrors()}
         <_SchemaField
@@ -355,6 +358,10 @@ export default class Form extends Component {
         )}
       </FormTag>
     );
+  }
+
+  componentWillUnmount() {
+    unregisterFormNode(this.props.id);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import Form from "./components/Form";
 import withTheme from "./withTheme";
 
+export { submitForm } from "./utils";
 export { withTheme };
 export default Form;

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,6 +66,41 @@ export function getDefaultRegistry() {
   };
 }
 
+const currentFormInstances = {};
+
+export function registerFormNode(formId, formNode) {
+  if (typeof formId !== "undefined") {
+    currentFormInstances[formId] = formNode;
+  }
+}
+
+export function unregisterFormNode(formId) {
+  delete currentFormInstances[formId];
+}
+
+function getRegisteredFormNode(formId) {
+  const formNode = currentFormInstances[formId];
+
+  if (!formNode && process.env.NODE_ENV === "development") {
+    console.error(
+      `No registered form node found with given id (${formId}). Please check if the target form has proper id assigned.`
+    );
+  }
+
+  return formNode;
+}
+
+export function submitForm(formId) {
+  const formNode = getRegisteredFormNode(formId);
+
+  if (formNode) {
+    formNode.dispatchEvent(new window.Event("submit", { cancelable: true }));
+    return true;
+  } else {
+    return false;
+  }
+}
+
 export function getSchemaType(schema) {
   let { type } = schema;
 

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -6,7 +6,7 @@ import { findDOMNode } from "react-dom";
 import { Portal } from "react-portal";
 import { createRef } from "create-react-ref";
 
-import Form from "../src";
+import Form, { submitForm } from "../src";
 import {
   createComponent,
   createFormComponent,
@@ -2491,6 +2491,38 @@ describe("Form", () => {
         target: { value: "Chuck" },
       });
       expect(node.querySelector("#root_lastName").value).eql("Norris");
+    });
+  });
+
+  describe("Function `submitForm`", () => {
+    it("should do nothing if there's no form found with given id", () => {
+      const onFormSubmit = sandbox.spy();
+
+      createFormComponent({
+        schema: {},
+        onSubmit: onFormSubmit,
+      });
+
+      const isSubmitted = submitForm("non-exist-form-id");
+
+      expect(isSubmitted).to.be.false;
+      sinon.assert.notCalled(onFormSubmit);
+    });
+
+    it("should submit a form found with given id", () => {
+      const onFormSubmit = sandbox.spy();
+      const formId = "form-id";
+
+      createFormComponent({
+        id: formId,
+        schema: {},
+        onSubmit: onFormSubmit,
+      });
+
+      const isSubmitted = submitForm(formId);
+
+      expect(isSubmitted).to.be.true;
+      sinon.assert.calledOnce(onFormSubmit);
     });
   });
 });


### PR DESCRIPTION
+ This change adds a new utility function, `submitForm`, to trigger a form's submission.

### Reasons for making this change
This change is an enhancement to the existing programmatic form submission functionality. This change introduces a more flexible way to submit a form programmatically. This will make using the form and a submit trigger separately easier and more flexible (They don't necessarily have to be coded under a common parent component so that the form's ref can be passed to the trigger component).

Example of usage is documented here:
https://github.com/mozilla-services/react-jsonschema-form/pull/1415/files#diff-1a523bd9fa0dbf998008b37579210e12R168-R179

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
