### PR TITLE
Fix omitExtraData bugs for nested empties and nonspecified objects

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -79,7 +79,6 @@ export default class Form extends Component {
       formData,
       props.idPrefix
     );
-    const pathSchema = toPathSchema(retrievedSchema, "", definitions, formData);
     return {
       schema,
       uiSchema,
@@ -89,7 +88,6 @@ export default class Form extends Component {
       errors,
       errorSchema,
       additionalMetaSchemas,
-      pathSchema,
     };
   }
 
@@ -180,12 +178,19 @@ export default class Form extends Component {
     let newFormData = formData;
 
     if (this.props.omitExtraData === true && this.props.liveOmit === true) {
-      const newState = this.getStateFromProps(this.props, formData);
-
-      const fieldNames = this.getFieldNames(
-        newState.pathSchema,
-        newState.formData
+      const retrievedSchema = retrieveSchema(
+        this.state.schema,
+        this.state.schema.definitions,
+        formData
       );
+      const pathSchema = toPathSchema(
+        retrievedSchema,
+        "",
+        this.state.schema.definitions,
+        formData
+      );
+
+      const fieldNames = this.getFieldNames(pathSchema, formData);
 
       newFormData = this.getUsedFormData(formData, fieldNames);
       state = {
@@ -231,11 +236,22 @@ export default class Form extends Component {
     event.persist();
     let newFormData = this.state.formData;
 
-    const { pathSchema } = this.state;
-
     if (this.props.omitExtraData === true) {
-      const fieldNames = this.getFieldNames(pathSchema, this.state.formData);
-      newFormData = this.getUsedFormData(this.state.formData, fieldNames);
+      const retrievedSchema = retrieveSchema(
+        this.state.schema,
+        this.state.schema.definitions,
+        newFormData
+      );
+      const pathSchema = toPathSchema(
+        retrievedSchema,
+        "",
+        this.state.schema.definitions,
+        newFormData
+      );
+
+      const fieldNames = this.getFieldNames(pathSchema, newFormData);
+
+      newFormData = this.getUsedFormData(newFormData, fieldNames);
     }
 
     if (!this.props.noValidate) {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -144,17 +144,14 @@ export default class Form extends Component {
   };
 
   getFieldNames = (pathSchema, formData) => {
-    const getAllPaths = (_obj, acc = [], paths = []) => {
+    const getAllPaths = (_obj, acc = [], paths = [""]) => {
       Object.keys(_obj).forEach(key => {
         if (typeof _obj[key] === "object") {
-          if (!paths.length) {
-            getAllPaths(_obj[key], acc, [key]);
-          } else {
-            let newPaths = paths.map(path => `${path}.${key}`);
-            getAllPaths(_obj[key], acc, newPaths);
-          }
-        } else if (key === "$name") {
+          let newPaths = paths.map(path => `${path}${key}.`);
+          getAllPaths(_obj[key], acc, newPaths);
+        } else if (key === "$name" && _obj[key] !== "") {
           paths.forEach(path => {
+            path = path.replace(/\.$/, "");
             const formValue = _get(formData, path);
             if (typeof formValue !== "object" || _isEmpty(formValue)) {
               acc.push(path);

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import _pick from "lodash/pick";
 import _get from "lodash/get";
+import _isEmpty from "lodash/isEmpty";
 
 import { default as DefaultErrorList } from "./ErrorList";
 import {
@@ -149,17 +150,13 @@ export default class Form extends Component {
           if (!paths.length) {
             getAllPaths(_obj[key], acc, [key]);
           } else {
-            let newPaths = [];
-            paths.forEach(path => {
-              newPaths.push(path);
-            });
-            newPaths = newPaths.map(path => `${path}.${key}`);
+            let newPaths = paths.map(path => `${path}.${key}`);
             getAllPaths(_obj[key], acc, newPaths);
           }
         } else if (key === "$name") {
           paths.forEach(path => {
             const formValue = _get(formData, path);
-            if (typeof formValue !== "object") {
+            if (typeof formValue !== "object" || _isEmpty(formValue)) {
               acc.push(path);
             }
           });

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -150,11 +150,11 @@ export default class Form extends Component {
     const getAllPaths = (_obj, acc = [], paths = [""]) => {
       Object.keys(_obj).forEach(key => {
         if (typeof _obj[key] === "object") {
-          let newPaths = paths.map(path => `${path}${key}.`);
+          let newPaths = paths.map(path => `${path}.${key}`);
           getAllPaths(_obj[key], acc, newPaths);
         } else if (key === "$name" && _obj[key] !== "") {
           paths.forEach(path => {
-            path = path.replace(/\.$/, "");
+            path = path.replace(/^\./, "");
             const formValue = _get(formData, path);
             if (typeof formValue !== "object" || _isEmpty(formValue)) {
               acc.push(path);

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -156,6 +156,8 @@ export default class Form extends Component {
           paths.forEach(path => {
             path = path.replace(/^\./, "");
             const formValue = _get(formData, path);
+            // adds path to fieldNames if it points to a value
+            // or an empty object/array
             if (typeof formValue !== "object" || _isEmpty(formValue)) {
               acc.push(path);
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -880,7 +880,6 @@ export function toPathSchema(schema, name = "", definitions, formData = {}) {
     return toPathSchema(_schema, name, definitions, formData);
   }
   if (
-    schema.type === "array" &&
     schema.hasOwnProperty("items") &&
     Array.isArray(formData) &&
     formData.length > 0
@@ -893,7 +892,7 @@ export function toPathSchema(schema, name = "", definitions, formData = {}) {
         element
       );
     });
-  } else if (schema.type === "object" && schema.hasOwnProperty("properties")) {
+  } else if (schema.hasOwnProperty("properties")) {
     for (const property in schema.properties || {}) {
       pathSchema[property] = toPathSchema(
         schema.properties[property],

--- a/src/utils.js
+++ b/src/utils.js
@@ -873,7 +873,7 @@ export function toIdSchema(
 
 export function toPathSchema(schema, name = "", definitions, formData = {}) {
   const pathSchema = {
-    $name: name.replace(/\.$/, ""),
+    $name: name.replace(/^\./, ""),
   };
   if ("$ref" in schema || "dependencies" in schema) {
     const _schema = retrieveSchema(schema, definitions, formData);
@@ -887,7 +887,7 @@ export function toPathSchema(schema, name = "", definitions, formData = {}) {
     formData.forEach((element, i) => {
       pathSchema[i] = toPathSchema(
         schema.items,
-        `${name}${i}.`,
+        `${name}.${i}`,
         definitions,
         element
       );
@@ -896,7 +896,7 @@ export function toPathSchema(schema, name = "", definitions, formData = {}) {
     for (const property in schema.properties) {
       pathSchema[property] = toPathSchema(
         schema.properties[property],
-        `${name}${property}.`,
+        `${name}.${property}`,
         definitions,
         (formData || {})[property]
       );

--- a/src/utils.js
+++ b/src/utils.js
@@ -893,7 +893,7 @@ export function toPathSchema(schema, name = "", definitions, formData = {}) {
       );
     });
   } else if (schema.hasOwnProperty("properties")) {
-    for (const property in schema.properties || {}) {
+    for (const property in schema.properties) {
       pathSchema[property] = toPathSchema(
         schema.properties[property],
         `${name}${property}.`,

--- a/src/utils.js
+++ b/src/utils.js
@@ -879,11 +879,7 @@ export function toPathSchema(schema, name = "", definitions, formData = {}) {
     const _schema = retrieveSchema(schema, definitions, formData);
     return toPathSchema(_schema, name, definitions, formData);
   }
-  if (
-    schema.hasOwnProperty("items") &&
-    Array.isArray(formData) &&
-    formData.length > 0
-  ) {
+  if (schema.hasOwnProperty("items") && Array.isArray(formData)) {
     formData.forEach((element, i) => {
       pathSchema[i] = toPathSchema(
         schema.items,
@@ -898,6 +894,8 @@ export function toPathSchema(schema, name = "", definitions, formData = {}) {
         schema.properties[property],
         `${name}.${property}`,
         definitions,
+        // It's possible that formData is not an object -- this can happen if an
+        // array item has just been added, but not populated with data yet
         (formData || {})[property]
       );
     }

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -12,9 +12,10 @@ import {
   createFormComponent,
   createSandbox,
   setProps,
+  describeRepeated,
 } from "./test_utils";
 
-describe("Form", () => {
+describeRepeated("Form common", createFormComponent => {
   let sandbox;
 
   beforeEach(() => {
@@ -743,25 +744,21 @@ describe("Form", () => {
       },
     };
 
-    it("should propagate deeply nested defaults to form state", done => {
+    it("should propagate deeply nested defaults to form state", () => {
       const { comp, node } = createFormComponent({ schema });
 
       Simulate.click(node.querySelector(".array-item-add button"));
       Simulate.submit(node);
 
-      // For some reason this may take some time to render, hence the safe wait.
-      setTimeout(() => {
-        expect(comp.state.formData).eql({
-          object: {
-            array: [
-              {
-                bool: true,
-              },
-            ],
-          },
-        });
-        done();
-      }, 250);
+      expect(comp.state.formData).eql({
+        object: {
+          array: [
+            {
+              bool: true,
+            },
+          ],
+        },
+      });
     });
   });
 
@@ -814,290 +811,6 @@ describe("Form", () => {
 
       sinon.assert.notCalled(onSubmit);
     });
-
-    it("should call getUsedFormData when the omitExtraData prop is true", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          foo: {
-            type: "string",
-          },
-        },
-      };
-      const formData = {
-        foo: "",
-      };
-      const onSubmit = sandbox.spy();
-      const onError = sandbox.spy();
-      const omitExtraData = true;
-      const { comp, node } = createFormComponent({
-        schema,
-        formData,
-        onSubmit,
-        onError,
-        omitExtraData,
-      });
-
-      sandbox.stub(comp, "getUsedFormData").returns({
-        foo: "",
-      });
-
-      Simulate.submit(node);
-
-      sinon.assert.calledOnce(comp.getUsedFormData);
-    });
-  });
-
-  describe("getUsedFormData", () => {
-    it("should just return the single input form value", () => {
-      const schema = {
-        title: "A single-field form",
-        type: "string",
-      };
-      const formData = "foo";
-      const onSubmit = sandbox.spy();
-      const { comp } = createFormComponent({
-        schema,
-        formData,
-        onSubmit,
-      });
-
-      const result = comp.getUsedFormData(formData, []);
-      expect(result).eql("foo");
-    });
-
-    it("should return the root level array", () => {
-      const schema = {
-        type: "array",
-        items: {
-          type: "string",
-        },
-      };
-      const formData = [];
-      const onSubmit = sandbox.spy();
-      const { comp } = createFormComponent({
-        schema,
-        formData,
-        onSubmit,
-      });
-
-      const result = comp.getUsedFormData(formData, []);
-      expect(result).eql([]);
-    });
-
-    it("should call getUsedFormData with data from fields in event", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          foo: { type: "string" },
-        },
-      };
-      const formData = {
-        foo: "bar",
-      };
-      const onSubmit = sandbox.spy();
-      const { comp } = createFormComponent({
-        schema,
-        formData,
-        onSubmit,
-      });
-
-      const result = comp.getUsedFormData(formData, ["foo"]);
-      expect(result).eql({ foo: "bar" });
-    });
-
-    it("unused form values should be omitted", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          foo: { type: "string" },
-          baz: { type: "string" },
-          list: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                title: { type: "string" },
-                details: { type: "string" },
-              },
-            },
-          },
-        },
-      };
-
-      const formData = {
-        foo: "bar",
-        baz: "buzz",
-        list: [
-          { title: "title0", details: "details0" },
-          { title: "title1", details: "details1" },
-        ],
-      };
-      const onSubmit = sandbox.spy();
-      const { comp } = createFormComponent({
-        schema,
-        formData,
-        onSubmit,
-      });
-
-      const result = comp.getUsedFormData(formData, [
-        "foo",
-        "list.0.title",
-        "list.1.details",
-      ]);
-      expect(result).eql({
-        foo: "bar",
-        list: [{ title: "title0" }, { details: "details1" }],
-      });
-    });
-  });
-
-  describe("getFieldNames()", () => {
-    it("should return an empty array for a single input form", () => {
-      const schema = {
-        type: "string",
-      };
-
-      const formData = "foo";
-
-      const onSubmit = sandbox.spy();
-      const { comp } = createFormComponent({
-        schema,
-        formData,
-        onSubmit,
-      });
-
-      const pathSchema = {
-        $name: "",
-      };
-
-      const fieldNames = comp.getFieldNames(pathSchema, formData);
-      expect(fieldNames).eql([]);
-    });
-
-    it("should get field names from pathSchema", () => {
-      const schema = {};
-
-      const formData = {
-        extra: {
-          foo: "bar",
-        },
-        level1: {
-          level2: "test",
-          anotherThing: {
-            anotherThingNested: "abc",
-            extra: "asdf",
-            anotherThingNested2: 0,
-          },
-        },
-        level1a: 1.23,
-      };
-
-      const onSubmit = sandbox.spy();
-      const { comp } = createFormComponent({
-        schema,
-        formData,
-        onSubmit,
-      });
-
-      const pathSchema = {
-        $name: "",
-        level1: {
-          $name: "level1",
-          level2: { $name: "level1.level2" },
-          anotherThing: {
-            $name: "level1.anotherThing",
-            anotherThingNested: {
-              $name: "level1.anotherThing.anotherThingNested",
-            },
-            anotherThingNested2: {
-              $name: "level1.anotherThing.anotherThingNested2",
-            },
-          },
-        },
-        level1a: {
-          $name: "level1a",
-        },
-      };
-
-      const fieldNames = comp.getFieldNames(pathSchema, formData);
-      expect(fieldNames.sort()).eql(
-        [
-          "level1a",
-          "level1.level2",
-          "level1.anotherThing.anotherThingNested",
-          "level1.anotherThing.anotherThingNested2",
-        ].sort()
-      );
-    });
-
-    it("should get field names from pathSchema with array", () => {
-      const schema = {};
-
-      const formData = {
-        address_list: [
-          {
-            street_address: "21, Jump Street",
-            city: "Babel",
-            state: "Neverland",
-          },
-          {
-            street_address: "1234 Schema Rd.",
-            city: "New York",
-            state: "Arizona",
-          },
-        ],
-      };
-
-      const onSubmit = sandbox.spy();
-      const { comp } = createFormComponent({
-        schema,
-        formData,
-        onSubmit,
-      });
-
-      const pathSchema = {
-        $name: "",
-        address_list: {
-          "0": {
-            $name: "address_list.0",
-            city: {
-              $name: "address_list.0.city",
-            },
-            state: {
-              $name: "address_list.0.state",
-            },
-            street_address: {
-              $name: "address_list.0.street_address",
-            },
-          },
-          "1": {
-            $name: "address_list.1",
-            city: {
-              $name: "address_list.1.city",
-            },
-            state: {
-              $name: "address_list.1.state",
-            },
-            street_address: {
-              $name: "address_list.1.street_address",
-            },
-          },
-        },
-      };
-
-      const fieldNames = comp.getFieldNames(pathSchema, formData);
-      expect(fieldNames.sort()).eql(
-        [
-          "address_list.0.city",
-          "address_list.0.state",
-          "address_list.0.street_address",
-          "address_list.1.city",
-          "address_list.1.state",
-          "address_list.1.street_address",
-        ].sort()
-      );
-    });
   });
 
   describe("Change handler", () => {
@@ -1129,74 +842,6 @@ describe("Form", () => {
           foo: "new",
         },
       });
-    });
-
-    it("should call getUsedFormData when the omitExtraData prop is true and liveOmit is true", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          foo: {
-            type: "string",
-          },
-        },
-      };
-      const formData = {
-        foo: "bar",
-      };
-      const onChange = sandbox.spy();
-      const omitExtraData = true;
-      const liveOmit = true;
-      const { node, comp } = createFormComponent({
-        schema,
-        formData,
-        onChange,
-        omitExtraData,
-        liveOmit,
-      });
-
-      sandbox.stub(comp, "getUsedFormData").returns({
-        foo: "",
-      });
-
-      Simulate.change(node.querySelector("[type=text]"), {
-        target: { value: "new" },
-      });
-
-      sinon.assert.calledOnce(comp.getUsedFormData);
-    });
-
-    it("should not call getUsedFormData when the omitExtraData prop is true and liveValidate is false", () => {
-      const schema = {
-        type: "object",
-        properties: {
-          foo: {
-            type: "string",
-          },
-        },
-      };
-      const formData = {
-        foo: "bar",
-      };
-      const onChange = sandbox.spy();
-      const omitExtraData = true;
-      const liveValidate = false;
-      const { node, comp } = createFormComponent({
-        schema,
-        formData,
-        onChange,
-        omitExtraData,
-        liveValidate,
-      });
-
-      sandbox.stub(comp, "getUsedFormData").returns({
-        foo: "",
-      });
-
-      Simulate.change(node.querySelector("[type=text]"), {
-        target: { value: "new" },
-      });
-
-      sinon.assert.notCalled(comp.getUsedFormData);
     });
   });
   describe("Blur handler", () => {
@@ -1465,6 +1110,128 @@ describe("Form", () => {
         comp.componentWillReceiveProps({ formData: ["yo"] });
 
         expect(comp.state.formData).eql(["yo"]);
+      });
+    });
+  });
+
+  describe("Internal formData updates", () => {
+    it("root", () => {
+      const formProps = {
+        schema: { type: "string" },
+        liveValidate: true,
+      };
+      const { comp, node } = createFormComponent(formProps);
+
+      Simulate.change(node.querySelector("input[type=text]"), {
+        target: { value: "yo" },
+      });
+
+      expect(comp.state.formData).eql("yo");
+    });
+    it("object", () => {
+      const { comp, node } = createFormComponent({
+        schema: {
+          type: "object",
+          properties: {
+            foo: {
+              type: "string",
+            },
+          },
+        },
+      });
+
+      Simulate.change(node.querySelector("input[type=text]"), {
+        target: { value: "yo" },
+      });
+
+      expect(comp.state.formData).eql({ foo: "yo" });
+    });
+    it("array of strings", () => {
+      const schema = {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      };
+      const { comp, node } = createFormComponent({ schema });
+
+      Simulate.click(node.querySelector(".array-item-add button"));
+
+      Simulate.change(node.querySelector("input[type=text]"), {
+        target: { value: "yo" },
+      });
+
+      expect(comp.state.formData).eql(["yo"]);
+    });
+    it("array of objects", () => {
+      const schema = {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+          },
+        },
+      };
+      const { comp, node } = createFormComponent({ schema });
+
+      Simulate.click(node.querySelector(".array-item-add button"));
+
+      Simulate.change(node.querySelector("input[type=text]"), {
+        target: { value: "yo" },
+      });
+
+      expect(comp.state.formData).eql([{ name: "yo" }]);
+    });
+    it("dependency with array of objects", () => {
+      const schema = {
+        definitions: {},
+        type: "object",
+        properties: {
+          show: {
+            type: "boolean",
+          },
+        },
+        dependencies: {
+          show: {
+            oneOf: [
+              {
+                properties: {
+                  show: {
+                    const: true,
+                  },
+                  participants: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        name: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      };
+      const { comp, node } = createFormComponent({ schema });
+
+      Simulate.change(node.querySelector("[type=checkbox]"), {
+        target: { checked: true },
+      });
+
+      Simulate.click(node.querySelector(".array-item-add button"));
+
+      Simulate.change(node.querySelector("input[type=text]"), {
+        target: { value: "yo" },
+      });
+
+      expect(comp.state.formData).eql({
+        show: true,
+        participants: [{ name: "yo" }],
       });
     });
   });
@@ -2097,16 +1864,15 @@ describe("Form", () => {
   });
 
   describe("Schema and formData updates", () => {
-    // https://github.com/mozilla-services/react-jsonschema-form/issues/231
-    const schema = {
-      type: "object",
-      properties: {
-        foo: { type: "string" },
-        bar: { type: "string" },
-      },
-    };
-
     it("should replace state when formData have keys removed", () => {
+      // https://github.com/mozilla-services/react-jsonschema-form/issues/231
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+          bar: { type: "string" },
+        },
+      };
       const formData = { foo: "foo", bar: "bar" };
       const { comp, node } = createFormComponent({ schema, formData });
       comp.componentWillReceiveProps({
@@ -2124,27 +1890,6 @@ describe("Form", () => {
       });
 
       expect(comp.state.formData).eql({ bar: "baz" });
-    });
-
-    it("should replace state when formData keys have changed", () => {
-      const formData = { foo: "foo", bar: "bar" };
-      const { comp, node } = createFormComponent({ schema, formData });
-      comp.componentWillReceiveProps({
-        schema: {
-          type: "object",
-          properties: {
-            foo: { type: "string" },
-            baz: { type: "string" },
-          },
-        },
-        formData: { foo: "foo", baz: "bar" },
-      });
-
-      Simulate.change(node.querySelector("#root_baz"), {
-        target: { value: "baz" },
-      });
-
-      expect(comp.state.formData).eql({ foo: "foo", baz: "baz" });
     });
   });
 
@@ -2510,6 +2255,435 @@ describe("Form", () => {
         target: { value: "Chuck" },
       });
       expect(node.querySelector("#root_lastName").value).eql("Norris");
+    });
+  });
+});
+
+describe("Form omitExtraData and liveOmit", () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should call getUsedFormData when the omitExtraData prop is true and liveOmit is true", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {
+          type: "string",
+        },
+      },
+    };
+    const formData = {
+      foo: "bar",
+    };
+    const onChange = sandbox.spy();
+    const omitExtraData = true;
+    const liveOmit = true;
+    const { node, comp } = createFormComponent({
+      schema,
+      formData,
+      onChange,
+      omitExtraData,
+      liveOmit,
+    });
+
+    sandbox.stub(comp, "getUsedFormData").returns({
+      foo: "",
+    });
+
+    Simulate.change(node.querySelector("[type=text]"), {
+      target: { value: "new" },
+    });
+
+    sinon.assert.calledOnce(comp.getUsedFormData);
+  });
+
+  it("should not call getUsedFormData when the omitExtraData prop is true and liveOmit is unspecified", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {
+          type: "string",
+        },
+      },
+    };
+    const formData = {
+      foo: "bar",
+    };
+    const onChange = sandbox.spy();
+    const omitExtraData = true;
+    const { node, comp } = createFormComponent({
+      schema,
+      formData,
+      onChange,
+      omitExtraData,
+    });
+
+    sandbox.stub(comp, "getUsedFormData").returns({
+      foo: "",
+    });
+
+    Simulate.change(node.querySelector("[type=text]"), {
+      target: { value: "new" },
+    });
+
+    sinon.assert.notCalled(comp.getUsedFormData);
+  });
+
+  describe("getUsedFormData", () => {
+    it("should call getUsedFormData when the omitExtraData prop is true", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string",
+          },
+        },
+      };
+      const formData = {
+        foo: "",
+      };
+      const onSubmit = sandbox.spy();
+      const onError = sandbox.spy();
+      const omitExtraData = true;
+      const { comp, node } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+        onError,
+        omitExtraData,
+      });
+
+      sandbox.stub(comp, "getUsedFormData").returns({
+        foo: "",
+      });
+
+      Simulate.submit(node);
+
+      sinon.assert.calledOnce(comp.getUsedFormData);
+    });
+    it("should just return the single input form value", () => {
+      const schema = {
+        title: "A single-field form",
+        type: "string",
+      };
+      const formData = "foo";
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const result = comp.getUsedFormData(formData, []);
+      expect(result).eql("foo");
+    });
+
+    it("should return the root level array", () => {
+      const schema = {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      };
+      const formData = [];
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const result = comp.getUsedFormData(formData, []);
+      expect(result).eql([]);
+    });
+
+    it("should call getUsedFormData with data from fields in event", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+        },
+      };
+      const formData = {
+        foo: "bar",
+      };
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const result = comp.getUsedFormData(formData, ["foo"]);
+      expect(result).eql({ foo: "bar" });
+    });
+
+    it("unused form values should be omitted", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+          baz: { type: "string" },
+          list: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                title: { type: "string" },
+                details: { type: "string" },
+              },
+            },
+          },
+        },
+      };
+
+      const formData = {
+        foo: "bar",
+        baz: "buzz",
+        list: [
+          { title: "title0", details: "details0" },
+          { title: "title1", details: "details1" },
+        ],
+      };
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const result = comp.getUsedFormData(formData, [
+        "foo",
+        "list.0.title",
+        "list.1.details",
+      ]);
+      expect(result).eql({
+        foo: "bar",
+        list: [{ title: "title0" }, { details: "details1" }],
+      });
+    });
+  });
+
+  describe("getFieldNames()", () => {
+    it("should return an empty array for a single input form", () => {
+      const schema = {
+        type: "string",
+      };
+
+      const formData = "foo";
+
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const pathSchema = {
+        $name: "",
+      };
+
+      const fieldNames = comp.getFieldNames(pathSchema, formData);
+      expect(fieldNames).eql([]);
+    });
+
+    it("should get field names from pathSchema", () => {
+      const schema = {};
+
+      const formData = {
+        extra: {
+          foo: "bar",
+        },
+        level1: {
+          level2: "test",
+          anotherThing: {
+            anotherThingNested: "abc",
+            extra: "asdf",
+            anotherThingNested2: 0,
+          },
+        },
+        level1a: 1.23,
+      };
+
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const pathSchema = {
+        $name: "",
+        level1: {
+          $name: "level1",
+          level2: { $name: "level1.level2" },
+          anotherThing: {
+            $name: "level1.anotherThing",
+            anotherThingNested: {
+              $name: "level1.anotherThing.anotherThingNested",
+            },
+            anotherThingNested2: {
+              $name: "level1.anotherThing.anotherThingNested2",
+            },
+          },
+        },
+        level1a: {
+          $name: "level1a",
+        },
+      };
+
+      const fieldNames = comp.getFieldNames(pathSchema, formData);
+      expect(fieldNames.sort()).eql(
+        [
+          "level1a",
+          "level1.level2",
+          "level1.anotherThing.anotherThingNested",
+          "level1.anotherThing.anotherThingNested2",
+        ].sort()
+      );
+    });
+
+    it("should get field names from pathSchema with array", () => {
+      const schema = {};
+
+      const formData = {
+        address_list: [
+          {
+            street_address: "21, Jump Street",
+            city: "Babel",
+            state: "Neverland",
+          },
+          {
+            street_address: "1234 Schema Rd.",
+            city: "New York",
+            state: "Arizona",
+          },
+        ],
+      };
+
+      const onSubmit = sandbox.spy();
+      const { comp } = createFormComponent({
+        schema,
+        formData,
+        onSubmit,
+      });
+
+      const pathSchema = {
+        $name: "",
+        address_list: {
+          "0": {
+            $name: "address_list.0",
+            city: {
+              $name: "address_list.0.city",
+            },
+            state: {
+              $name: "address_list.0.state",
+            },
+            street_address: {
+              $name: "address_list.0.street_address",
+            },
+          },
+          "1": {
+            $name: "address_list.1",
+            city: {
+              $name: "address_list.1.city",
+            },
+            state: {
+              $name: "address_list.1.state",
+            },
+            street_address: {
+              $name: "address_list.1.street_address",
+            },
+          },
+        },
+      };
+
+      const fieldNames = comp.getFieldNames(pathSchema, formData);
+      expect(fieldNames.sort()).eql(
+        [
+          "address_list.0.city",
+          "address_list.0.state",
+          "address_list.0.street_address",
+          "address_list.1.city",
+          "address_list.1.state",
+          "address_list.1.street_address",
+        ].sort()
+      );
+    });
+  });
+
+  describe("Schema and formData updates", () => {
+    // https://github.com/mozilla-services/react-jsonschema-form/issues/231
+    const schema = {
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+        bar: { type: "string" },
+      },
+    };
+
+    for (let omitExtraData of [true, false]) {
+      it(
+        "should replace state when formData keys have changed with omitExtraData=" +
+          omitExtraData,
+        () => {
+          const formData = { foo: "foo", bar: "bar" };
+          const { comp, node } = createFormComponent({
+            schema,
+            formData,
+            omitExtraData,
+          });
+          comp.componentWillReceiveProps({
+            schema: {
+              type: "object",
+              properties: {
+                foo: { type: "string" },
+                baz: { type: "string" },
+              },
+            },
+            formData: { foo: "foo", baz: "bar" },
+          });
+
+          Simulate.change(node.querySelector("#root_baz"), {
+            target: { value: "baz" },
+          });
+
+          expect(comp.state.formData).eql({ foo: "foo", baz: "baz" });
+        }
+      );
+    }
+
+    it("should replace state and omit extra data when formData keys have changed, with liveOmit=true", () => {
+      const formData = { foo: "foo", bar: "bar" };
+      const { comp, node } = createFormComponent({
+        schema,
+        formData,
+        omitExtraData: true,
+        liveOmit: true,
+      });
+      comp.componentWillReceiveProps({
+        schema: {
+          type: "object",
+          properties: {
+            foo: { type: "string" },
+            baz: { type: "string" },
+          },
+        },
+        formData: { foo: "foo", baz: "bar" },
+      });
+
+      Simulate.change(node.querySelector("#root_baz"), {
+        target: { value: "baz" },
+      });
+
+      expect(comp.state.formData).eql({ foo: "foo" });
     });
   });
 });

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -36,8 +36,8 @@ export function setProps(comp, newProps) {
 export function describeRepeated(title, fn) {
   const formExtraPropsList = [
     { omitExtraData: false },
-    // { omitExtraData: true },
-    // { omitExtraData: true, liveOmit: true },
+    { omitExtraData: true },
+    { omitExtraData: true, liveOmit: true },
   ];
   for (let formExtraProps of formExtraPropsList) {
     const createFormComponentFn = props =>

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -30,3 +30,20 @@ export function setProps(comp, newProps) {
   const node = findDOMNode(comp);
   render(React.createElement(comp.constructor, newProps), node.parentNode);
 }
+
+/* Run a group of tests with different combinations of omitExtraData and liveOmit as form props.
+ */
+export function describeRepeated(title, fn) {
+  const formExtraPropsList = [
+    { omitExtraData: false },
+    // { omitExtraData: true },
+    // { omitExtraData: true, liveOmit: true },
+  ];
+  for (let formExtraProps of formExtraPropsList) {
+    const createFormComponentFn = props =>
+      createFormComponent({ ...props, ...formExtraProps });
+    describe(title + " " + JSON.stringify(formExtraProps), () =>
+      fn(createFormComponentFn)
+    );
+  }
+}

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -2009,6 +2009,7 @@ describe("utils", () => {
       expect(toPathSchema(schema, "", schema.definitions, formData)).eql({
         $name: "",
         list: {
+          $name: "list",
           "0": {
             $name: "list.0",
             a: {
@@ -2145,6 +2146,7 @@ describe("utils", () => {
       expect(toPathSchema(schema, "", schema.definitions, formData)).eql({
         $name: "",
         address_list: {
+          $name: "address_list",
           "0": {
             $name: "address_list.0",
             city: {
@@ -2362,6 +2364,7 @@ describe("utils", () => {
       expect(toPathSchema(schema, "", schema.definitions, formData)).eql({
         $name: "",
         defaultsAndMinItems: {
+          $name: "defaultsAndMinItems",
           "0": {
             $name: "defaultsAndMinItems.0",
           },
@@ -2379,6 +2382,7 @@ describe("utils", () => {
           },
         },
         fixedItemsList: {
+          $name: "fixedItemsList",
           "0": {
             $name: "fixedItemsList.0",
           },
@@ -2390,6 +2394,7 @@ describe("utils", () => {
           },
         },
         fixedNoToolbar: {
+          $name: "fixedNoToolbar",
           "0": {
             $name: "fixedNoToolbar.0",
           },
@@ -2404,6 +2409,7 @@ describe("utils", () => {
           },
         },
         listOfObjects: {
+          $name: "listOfObjects",
           "0": {
             $name: "listOfObjects.0",
             id: {
@@ -2433,6 +2439,7 @@ describe("utils", () => {
           },
         },
         listOfStrings: {
+          $name: "listOfStrings",
           "0": {
             $name: "listOfStrings.0",
           },
@@ -2441,6 +2448,7 @@ describe("utils", () => {
           },
         },
         minItemsList: {
+          $name: "minItemsList",
           "0": {
             $name: "minItemsList.0",
             name: {
@@ -2461,6 +2469,7 @@ describe("utils", () => {
           },
         },
         multipleChoicesList: {
+          $name: "multipleChoicesList",
           "0": {
             $name: "multipleChoicesList.0",
           },
@@ -2469,7 +2478,9 @@ describe("utils", () => {
           },
         },
         nestedList: {
+          $name: "nestedList",
           "0": {
+            $name: "nestedList.0",
             "0": {
               $name: "nestedList.0.0",
             },
@@ -2478,12 +2489,14 @@ describe("utils", () => {
             },
           },
           "1": {
+            $name: "nestedList.1",
             "0": {
               $name: "nestedList.1.0",
             },
           },
         },
         noToolbar: {
+          $name: "noToolbar",
           "0": {
             $name: "noToolbar.0",
           },
@@ -2492,6 +2505,7 @@ describe("utils", () => {
           },
         },
         unorderable: {
+          $name: "unorderable",
           "0": {
             $name: "unorderable.0",
           },
@@ -2500,6 +2514,7 @@ describe("utils", () => {
           },
         },
         unremovable: {
+          $name: "unremovable",
           "0": {
             $name: "unremovable.0",
           },


### PR DESCRIPTION
### Reasons for making this change

Fixes #1388 and fixes #1396. Alternative to #1418.

Modifies behavior of `toPathSchema` in `utils.js` (afaik the function is only used in omitting the extra data, let me know if this breaks anything else) to create `$name` key for arrays as well to be consistent with behavior for objects. Modifies behavior of `getFieldNames` in `Form.js` to also add a path to the array of paths if that path points to something empty. Refactors the surrounding code to be more concise and, hopefully, readable. Adds tests for `omitExtraData` and `liveOmit`.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
