### PR TITLE
fix: issue with false as formData on radio components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsonschema-form",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -273,7 +273,7 @@ export function getDefaultFormState(
     // Override schema defaults with form data.
     return mergeObjects(defaults, formData);
   }
-  if (formData === 0) {
+  if (formData === 0 || formData === false) {
     return formData;
   }
   return formData || defaults;

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -49,6 +49,17 @@ describe("utils", () => {
         ).to.eql(0);
       });
 
+      it("should keep existing form data that is equal to false", () => {
+        expect(
+          getDefaultFormState(
+            {
+              type: "boolean",
+            },
+            false
+          )
+        ).to.eql(false);
+      });
+
       const noneValues = [null, undefined, NaN];
       noneValues.forEach(noneValue => {
         it("should overwrite existing form data that is equal to a none value", () => {


### PR DESCRIPTION
### Reasons for making this change

Passing `formData` as `false` for `type="boolean"` caused `formData` to come back as `undefined` on a non-nested JSONSchema object. To see it break, change `formData` to `false` in this example: [playground](https://mozilla-services.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6dHJ1ZSwic2NoZW1hIjp7InRpdGxlIjoiQSBzaW5nbGUtZmllbGQgZm9ybSIsInR5cGUiOiJib29sZWFuIn0sInVpU2NoZW1hIjp7InVpOndpZGdldCI6InJhZGlvIn0sImxpdmVTZXR0aW5ncyI6eyJ2YWxpZGF0ZSI6dHJ1ZSwiZGlzYWJsZSI6ZmFsc2UsIm9taXRFeHRyYURhdGEiOmZhbHNlLCJsaXZlT21pdCI6ZmFsc2V9fQ==).

I didn't create an issue for this, but I still want to discuss if there was a point of not allowing `formData` to be `false`.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
